### PR TITLE
Sync upstream session and manifest recovery fixes

### DIFF
--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -174,7 +174,8 @@ pub use usage::{
 pub use windows_shell::{bash_shell_path, set_shell_if_windows};
 pub use worker_boot::{
     Worker, WorkerEvent, WorkerEventKind, WorkerEventPayload, WorkerFailure, WorkerFailureKind,
-    WorkerPromptTarget, WorkerReadySnapshot, WorkerRegistry, WorkerStatus, WorkerTrustResolution,
+    WorkerPromptTarget, WorkerReadySnapshot, WorkerRegistry, WorkerStatus, WorkerTaskReceipt,
+    WorkerTrustResolution,
 };
 
 #[cfg(windows)]

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -13,6 +13,7 @@ const SESSION_VERSION: u32 = 1;
 const ROTATE_AFTER_BYTES: u64 = 256 * 1024;
 const MAX_ROTATED_FILES: usize = 3;
 static SESSION_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+static LAST_TIMESTAMP_MS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MessageRole {
@@ -998,10 +999,27 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
 }
 
 fn current_time_millis() -> u64 {
-    SystemTime::now()
+    let wall_clock = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+    let mut candidate = wall_clock;
+    loop {
+        let previous = LAST_TIMESTAMP_MS.load(Ordering::Relaxed);
+        if candidate <= previous {
+            candidate = previous.saturating_add(1);
+        }
+        match LAST_TIMESTAMP_MS.compare_exchange(
+            previous,
+            candidate,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => return candidate,
+            Err(actual) => candidate = actual.saturating_add(1),
+        }
+    }
 }
 
 fn generate_session_id() -> String {
@@ -1093,14 +1111,24 @@ fn cleanup_rotated_logs(path: &Path) -> Result<(), SessionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_rotated_logs, rotate_session_file_if_needed, ContentBlock, ConversationMessage,
-        MessageRole, Session, SessionFork,
+        cleanup_rotated_logs, current_time_millis, rotate_session_file_if_needed, ContentBlock,
+        ConversationMessage, MessageRole, Session, SessionFork,
     };
     use crate::json::JsonValue;
     use crate::usage::TokenUsage;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn session_timestamps_are_monotonic_under_tight_loops() {
+        let first = current_time_millis();
+        let second = current_time_millis();
+        let third = current_time_millis();
+
+        assert!(first < second);
+        assert!(second < third);
+    }
 
     #[test]
     fn persists_and_restores_session_jsonl() {

--- a/rust/crates/runtime/src/session_control.rs
+++ b/rust/crates/runtime/src/session_control.rs
@@ -148,7 +148,7 @@ impl SessionStore {
                 .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
                 .map(|duration| duration.as_millis())
                 .unwrap_or_default();
-            let (id, message_count, parent_session_id, branch_name) =
+            let (id, updated_at_ms, message_count, parent_session_id, branch_name) =
                 match Session::load_from_path(&path) {
                     Ok(session) => {
                         let parent_session_id = session
@@ -161,6 +161,7 @@ impl SessionStore {
                             .and_then(|fork| fork.branch_name.clone());
                         (
                             session.session_id,
+                            session.updated_at_ms,
                             session.messages.len(),
                             parent_session_id,
                             branch_name,
@@ -172,6 +173,7 @@ impl SessionStore {
                             .unwrap_or("unknown")
                             .to_string(),
                         0,
+                        0,
                         None,
                         None,
                     ),
@@ -179,18 +181,14 @@ impl SessionStore {
             sessions.push(ManagedSessionSummary {
                 id,
                 path,
+                updated_at_ms,
                 modified_epoch_millis,
                 message_count,
                 parent_session_id,
                 branch_name,
             });
         }
-        sessions.sort_by(|left, right| {
-            right
-                .modified_epoch_millis
-                .cmp(&left.modified_epoch_millis)
-                .then_with(|| right.id.cmp(&left.id))
-        });
+        sort_managed_sessions(&mut sessions);
         Ok(sessions)
     }
 
@@ -270,10 +268,21 @@ pub struct SessionHandle {
 pub struct ManagedSessionSummary {
     pub id: String,
     pub path: PathBuf,
+    pub updated_at_ms: u64,
     pub modified_epoch_millis: u128,
     pub message_count: usize,
     pub parent_session_id: Option<String>,
     pub branch_name: Option<String>,
+}
+
+fn sort_managed_sessions(sessions: &mut [ManagedSessionSummary]) {
+    sessions.sort_by(|left, right| {
+        right
+            .updated_at_ms
+            .cmp(&left.updated_at_ms)
+            .then_with(|| right.modified_epoch_millis.cmp(&left.modified_epoch_millis))
+            .then_with(|| right.id.cmp(&left.id))
+    });
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -439,7 +448,7 @@ pub fn list_managed_sessions_for(
             .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
             .map(|duration| duration.as_millis())
             .unwrap_or_default();
-        let (id, message_count, parent_session_id, branch_name) =
+        let (id, updated_at_ms, message_count, parent_session_id, branch_name) =
             match Session::load_from_path(&path) {
                 Ok(session) => {
                     let parent_session_id = session
@@ -452,6 +461,7 @@ pub fn list_managed_sessions_for(
                         .and_then(|fork| fork.branch_name.clone());
                     (
                         session.session_id,
+                        session.updated_at_ms,
                         session.messages.len(),
                         parent_session_id,
                         branch_name,
@@ -463,6 +473,7 @@ pub fn list_managed_sessions_for(
                         .unwrap_or("unknown")
                         .to_string(),
                     0,
+                    0,
                     None,
                     None,
                 ),
@@ -470,18 +481,14 @@ pub fn list_managed_sessions_for(
         sessions.push(ManagedSessionSummary {
             id,
             path,
+            updated_at_ms,
             modified_epoch_millis,
             message_count,
             parent_session_id,
             branch_name,
         });
     }
-    sessions.sort_by(|left, right| {
-        right
-            .modified_epoch_millis
-            .cmp(&left.modified_epoch_millis)
-            .then_with(|| right.id.cmp(&left.id))
-    });
+    sort_managed_sessions(&mut sessions);
     Ok(sessions)
 }
 
@@ -630,6 +637,35 @@ mod tests {
             .iter()
             .find(|summary| summary.id == id)
             .expect("session summary should exist")
+    }
+
+    #[test]
+    fn latest_session_prefers_semantic_updated_at_over_file_mtime() {
+        let mut sessions = vec![
+            ManagedSessionSummary {
+                id: "older-file-newer-session".to_string(),
+                path: PathBuf::from("/tmp/older"),
+                updated_at_ms: 200,
+                modified_epoch_millis: 100,
+                message_count: 2,
+                parent_session_id: None,
+                branch_name: None,
+            },
+            ManagedSessionSummary {
+                id: "newer-file-older-session".to_string(),
+                path: PathBuf::from("/tmp/newer"),
+                updated_at_ms: 100,
+                modified_epoch_millis: 200,
+                message_count: 1,
+                parent_session_id: None,
+                branch_name: None,
+            },
+        ];
+
+        crate::session_control::sort_managed_sessions(&mut sessions);
+
+        assert_eq!(sessions[0].id, "older-file-newer-session");
+        assert_eq!(sessions[1].id, "newer-file-older-session");
     }
 
     #[test]

--- a/rust/crates/runtime/src/worker_boot.rs
+++ b/rust/crates/runtime/src/worker_boot.rs
@@ -114,6 +114,7 @@ pub enum WorkerTrustResolution {
 pub enum WorkerPromptTarget {
     Shell,
     WrongTarget,
+    WrongTask,
     Unknown,
 }
 
@@ -130,8 +131,22 @@ pub enum WorkerEventPayload {
         observed_target: WorkerPromptTarget,
         #[serde(skip_serializing_if = "Option::is_none")]
         observed_cwd: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        observed_prompt_preview: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        task_receipt: Option<WorkerTaskReceipt>,
         recovery_armed: bool,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkerTaskReceipt {
+    pub repo: String,
+    pub task_kind: String,
+    pub source_surface: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_artifacts: Vec<String>,
+    pub objective_preview: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -156,6 +171,7 @@ pub struct Worker {
     pub prompt_delivery_attempts: u32,
     pub prompt_in_flight: bool,
     pub last_prompt: Option<String>,
+    pub expected_receipt: Option<WorkerTaskReceipt>,
     pub replay_prompt: Option<String>,
     pub last_error: Option<WorkerFailure>,
     pub created_at: u64,
@@ -218,6 +234,7 @@ impl WorkerRegistry {
             prompt_delivery_attempts: 0,
             prompt_in_flight: false,
             last_prompt: None,
+            expected_receipt: None,
             replay_prompt: None,
             last_error: None,
             created_at: ts,
@@ -297,6 +314,7 @@ impl WorkerRegistry {
                     &lowered,
                     worker.last_prompt.as_deref(),
                     &worker.cwd,
+                    worker.expected_receipt.as_ref(),
                 )
             })
             .flatten()
@@ -310,6 +328,10 @@ impl WorkerRegistry {
                 }
                 WorkerPromptTarget::WrongTarget => format!(
                     "worker prompt landed in the wrong target instead of {}: {}",
+                    worker.cwd, prompt_preview
+                ),
+                WorkerPromptTarget::WrongTask => format!(
+                    "worker prompt receipt mismatched the expected task context for {}: {}",
                     worker.cwd, prompt_preview
                 ),
                 WorkerPromptTarget::Unknown => format!(
@@ -331,6 +353,8 @@ impl WorkerRegistry {
                     prompt_preview: prompt_preview.clone(),
                     observed_target: observation.target,
                     observed_cwd: observation.observed_cwd.clone(),
+                    observed_prompt_preview: observation.observed_prompt_preview.clone(),
+                    task_receipt: worker.expected_receipt.clone(),
                     recovery_armed: false,
                 }),
             );
@@ -346,6 +370,8 @@ impl WorkerRegistry {
                         prompt_preview,
                         observed_target: observation.target,
                         observed_cwd: observation.observed_cwd,
+                        observed_prompt_preview: observation.observed_prompt_preview,
+                        task_receipt: worker.expected_receipt.clone(),
                         recovery_armed: true,
                     }),
                 );
@@ -416,7 +442,12 @@ impl WorkerRegistry {
         Ok(worker.clone())
     }
 
-    pub fn send_prompt(&self, worker_id: &str, prompt: Option<&str>) -> Result<Worker, String> {
+    pub fn send_prompt(
+        &self,
+        worker_id: &str,
+        prompt: Option<&str>,
+        task_receipt: Option<WorkerTaskReceipt>,
+    ) -> Result<Worker, String> {
         let mut inner = self.inner.lock().expect("worker registry lock poisoned");
         let worker = inner
             .workers
@@ -440,6 +471,7 @@ impl WorkerRegistry {
         worker.prompt_delivery_attempts += 1;
         worker.prompt_in_flight = true;
         worker.last_prompt = Some(next_prompt.clone());
+        worker.expected_receipt = task_receipt;
         worker.replay_prompt = None;
         worker.last_error = None;
         worker.status = WorkerStatus::Running;
@@ -600,6 +632,7 @@ fn prompt_misdelivery_is_relevant(worker: &Worker) -> bool {
 struct PromptDeliveryObservation {
     target: WorkerPromptTarget,
     observed_cwd: Option<String>,
+    observed_prompt_preview: Option<String>,
 }
 
 fn push_event(
@@ -833,6 +866,7 @@ fn detect_prompt_misdelivery(
     lowered: &str,
     prompt: Option<&str>,
     expected_cwd: &str,
+    expected_receipt: Option<&WorkerTaskReceipt>,
 ) -> Option<PromptDeliveryObservation> {
     let Some(prompt) = prompt else {
         return None;
@@ -847,12 +881,30 @@ fn detect_prompt_misdelivery(
         return None;
     }
     let prompt_visible = lowered.contains(&prompt_snippet);
+    let observed_prompt_preview = detect_prompt_echo(screen_text);
+
+    if let Some(receipt) = expected_receipt {
+        let receipt_visible = task_receipt_visible(lowered, receipt);
+        let mismatched_prompt_visible = observed_prompt_preview
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .is_some_and(|preview| !preview.contains(&prompt_snippet));
+
+        if (prompt_visible || mismatched_prompt_visible) && !receipt_visible {
+            return Some(PromptDeliveryObservation {
+                target: WorkerPromptTarget::WrongTask,
+                observed_cwd: detect_observed_shell_cwd(screen_text),
+                observed_prompt_preview,
+            });
+        }
+    }
 
     if let Some(observed_cwd) = detect_observed_shell_cwd(screen_text) {
         if prompt_visible && !cwd_matches_observed_target(expected_cwd, &observed_cwd) {
             return Some(PromptDeliveryObservation {
                 target: WorkerPromptTarget::WrongTarget,
                 observed_cwd: Some(observed_cwd),
+                observed_prompt_preview,
             });
         }
     }
@@ -870,6 +922,7 @@ fn detect_prompt_misdelivery(
     (shell_error && prompt_visible).then_some(PromptDeliveryObservation {
         target: WorkerPromptTarget::Shell,
         observed_cwd: None,
+        observed_prompt_preview,
     })
 }
 
@@ -882,10 +935,39 @@ fn prompt_preview(prompt: &str) -> String {
     format!("{}…", preview.trim_end())
 }
 
+fn detect_prompt_echo(screen_text: &str) -> Option<String> {
+    screen_text.lines().find_map(|line| {
+        line.trim_start()
+            .strip_prefix('›')
+            .or_else(|| line.trim_start().strip_prefix('?'))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn task_receipt_visible(lowered_screen_text: &str, receipt: &WorkerTaskReceipt) -> bool {
+    let expected_tokens = [
+        receipt.repo.to_ascii_lowercase(),
+        receipt.task_kind.to_ascii_lowercase(),
+        receipt.source_surface.to_ascii_lowercase(),
+        receipt.objective_preview.to_ascii_lowercase(),
+    ];
+
+    expected_tokens
+        .iter()
+        .all(|token| lowered_screen_text.contains(token))
+        && receipt
+            .expected_artifacts
+            .iter()
+            .all(|artifact| lowered_screen_text.contains(&artifact.to_ascii_lowercase()))
+}
+
 fn prompt_misdelivery_detail(observation: &PromptDeliveryObservation) -> &'static str {
     match observation.target {
         WorkerPromptTarget::Shell => "shell misdelivery detected",
         WorkerPromptTarget::WrongTarget => "prompt landed in wrong target",
+        WorkerPromptTarget::WrongTask => "prompt receipt mismatched expected task context",
         WorkerPromptTarget::Unknown => "prompt delivery failure detected",
     }
 }
@@ -1001,7 +1083,7 @@ mod tests {
             WorkerFailureKind::TrustGate
         );
 
-        let send_before_resolve = registry.send_prompt(&worker.worker_id, Some("ship it"));
+        let send_before_resolve = registry.send_prompt(&worker.worker_id, Some("ship it"), None);
         assert!(send_before_resolve
             .expect_err("prompt delivery should be gated")
             .contains("not ready for prompt delivery"));
@@ -1041,7 +1123,7 @@ mod tests {
             .expect("ready observe should succeed");
 
         let running = registry
-            .send_prompt(&worker.worker_id, Some("Implement worker handshake"))
+            .send_prompt(&worker.worker_id, Some("Implement worker handshake"), None)
             .expect("prompt send should succeed");
         assert_eq!(running.status, WorkerStatus::Running);
         assert_eq!(running.prompt_delivery_attempts, 1);
@@ -1077,6 +1159,8 @@ mod tests {
                 prompt_preview: "Implement worker handshake".to_string(),
                 observed_target: WorkerPromptTarget::Shell,
                 observed_cwd: None,
+                observed_prompt_preview: None,
+                task_receipt: None,
                 recovery_armed: false,
             })
         );
@@ -1092,12 +1176,14 @@ mod tests {
                 prompt_preview: "Implement worker handshake".to_string(),
                 observed_target: WorkerPromptTarget::Shell,
                 observed_cwd: None,
+                observed_prompt_preview: None,
+                task_receipt: None,
                 recovery_armed: true,
             })
         );
 
         let replayed = registry
-            .send_prompt(&worker.worker_id, None)
+            .send_prompt(&worker.worker_id, None, None)
             .expect("replay send should succeed");
         assert_eq!(replayed.status, WorkerStatus::Running);
         assert!(replayed.replay_prompt.is_none());
@@ -1112,7 +1198,11 @@ mod tests {
             .observe(&worker.worker_id, "Ready for input\n>")
             .expect("ready observe should succeed");
         registry
-            .send_prompt(&worker.worker_id, Some("Run the worker bootstrap tests"))
+            .send_prompt(
+                &worker.worker_id,
+                Some("Run the worker bootstrap tests"),
+                None,
+            )
             .expect("prompt send should succeed");
 
         let recovered = registry
@@ -1143,9 +1233,79 @@ mod tests {
                 prompt_preview: "Run the worker bootstrap tests".to_string(),
                 observed_target: WorkerPromptTarget::WrongTarget,
                 observed_cwd: Some("/tmp/repo-target-b".to_string()),
+                observed_prompt_preview: None,
+                task_receipt: None,
                 recovery_armed: false,
             })
         );
+    }
+
+    #[test]
+    fn wrong_task_receipt_mismatch_is_detected_before_execution_continues() {
+        let registry = WorkerRegistry::new();
+        let worker = registry.create("/tmp/repo-task", &[], true);
+        registry
+            .observe(&worker.worker_id, "Ready for input\n>")
+            .expect("ready observe should succeed");
+        registry
+            .send_prompt(
+                &worker.worker_id,
+                Some("Implement worker handshake"),
+                Some(WorkerTaskReceipt {
+                    repo: "claw-code".to_string(),
+                    task_kind: "repo_code".to_string(),
+                    source_surface: "omx_team".to_string(),
+                    expected_artifacts: vec!["patch".to_string(), "tests".to_string()],
+                    objective_preview: "Implement worker handshake".to_string(),
+                }),
+            )
+            .expect("prompt send should succeed");
+
+        let recovered = registry
+            .observe(
+                &worker.worker_id,
+                "› Explain this KakaoTalk screenshot for a friend\nI can help analyze the screenshot…",
+            )
+            .expect("mismatch observe should succeed");
+
+        assert_eq!(recovered.status, WorkerStatus::ReadyForPrompt);
+        assert_eq!(
+            recovered
+                .last_error
+                .expect("wrong-task error should exist")
+                .kind,
+            WorkerFailureKind::PromptDelivery
+        );
+        let misdelivery = recovered
+            .events
+            .iter()
+            .find(|event| event.kind == WorkerEventKind::PromptMisdelivery)
+            .expect("wrong-task event should exist");
+        assert_eq!(
+            misdelivery.payload,
+            Some(WorkerEventPayload::PromptDelivery {
+                prompt_preview: "Implement worker handshake".to_string(),
+                observed_target: WorkerPromptTarget::WrongTask,
+                observed_cwd: None,
+                observed_prompt_preview: Some(
+                    "Explain this KakaoTalk screenshot for a friend".to_string()
+                ),
+                task_receipt: Some(WorkerTaskReceipt {
+                    repo: "claw-code".to_string(),
+                    task_kind: "repo_code".to_string(),
+                    source_surface: "omx_team".to_string(),
+                    expected_artifacts: vec!["patch".to_string(), "tests".to_string()],
+                    objective_preview: "Implement worker handshake".to_string(),
+                }),
+                recovery_armed: false,
+            })
+        );
+        let replay = recovered
+            .events
+            .iter()
+            .find(|event| event.kind == WorkerEventKind::PromptReplayArmed)
+            .expect("replay event should exist");
+        assert_eq!(replay.status, WorkerStatus::ReadyForPrompt);
     }
 
     #[test]
@@ -1193,7 +1353,7 @@ mod tests {
             .observe(&worker.worker_id, "Ready for input\n>")
             .expect("ready observe should succeed");
         registry
-            .send_prompt(&worker.worker_id, Some("Run tests"))
+            .send_prompt(&worker.worker_id, Some("Run tests"), None)
             .expect("prompt send should succeed");
 
         let restarted = registry
@@ -1281,7 +1441,7 @@ mod tests {
             .observe(&worker.worker_id, "Ready for input\n>")
             .expect("ready observe should succeed");
         registry
-            .send_prompt(&worker.worker_id, Some("Run tests"))
+            .send_prompt(&worker.worker_id, Some("Run tests"), None)
             .expect("prompt send should succeed");
 
         let failed = registry
@@ -1306,7 +1466,7 @@ mod tests {
             .observe(&worker.worker_id, "Ready for input\n>")
             .expect("ready observe should succeed");
         registry
-            .send_prompt(&worker.worker_id, Some("Run tests"))
+            .send_prompt(&worker.worker_id, Some("Run tests"), None)
             .expect("prompt send should succeed");
 
         let finished = registry

--- a/rust/crates/runtime/tests/reliability_integration.rs
+++ b/rust/crates/runtime/tests/reliability_integration.rs
@@ -252,7 +252,7 @@ fn prompt_misdelivery_arms_replay_and_maps_to_recovery_recipe() {
     assert_eq!(ready.status, WorkerStatus::ReadyForPrompt);
 
     let running = registry
-        .send_prompt(&worker.worker_id, Some("Investigate flaky boot"))
+        .send_prompt(&worker.worker_id, Some("Investigate flaky boot"), None)
         .expect("prompt send should succeed");
     assert_eq!(running.status, WorkerStatus::Running);
 

--- a/rust/crates/runtime/tests/runtime_workflows.rs
+++ b/rust/crates/runtime/tests/runtime_workflows.rs
@@ -99,7 +99,11 @@ fn lane_event_emission_serializes_prompt_misdelivery_failures() {
         .observe(&worker.worker_id, "Ready for input\n>")
         .expect("worker should become ready");
     registry
-        .send_prompt(&worker.worker_id, Some("Run lane event parity checks"))
+        .send_prompt(
+            &worker.worker_id,
+            Some("Run lane event parity checks"),
+            None,
+        )
         .expect("prompt dispatch should succeed");
 
     let failed = registry

--- a/rust/crates/runtime/tests/worker_lane_hook_task_config_integration.rs
+++ b/rust/crates/runtime/tests/worker_lane_hook_task_config_integration.rs
@@ -105,7 +105,11 @@ fn lane_event_emission_serializes_worker_prompt_delivery_failure() {
         .observe(&worker.worker_id, "Ready for input\n>")
         .expect("ready observe should succeed");
     registry
-        .send_prompt(&worker.worker_id, Some("Run lane event emission test"))
+        .send_prompt(
+            &worker.worker_id,
+            Some("Run lane event emission test"),
+            None,
+        )
         .expect("prompt send should succeed");
 
     let failed = registry

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -12400,14 +12400,6 @@ mod sandbox_report_tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
-    fn normalize_test_path(path: &std::path::Path) -> String {
-        path.display()
-            .to_string()
-            .replace('/', "\\")
-            .trim_start_matches("\\\\?\\")
-            .to_string()
-    }
-
     #[test]
     fn sandbox_report_renders_expected_fields() {
         let report = format_sandbox_report(&runtime::SandboxStatus::default());
@@ -12474,14 +12466,20 @@ mod sandbox_report_tests {
         let error_msg = result
             .expect_err("missing manifests should error")
             .to_string();
-        let normalized_error = error_msg.replace('/', "\\");
-        let expected_root = normalize_test_path(&root);
         assert!(
             error_msg.contains("Manifest source files are missing"),
             "error message should mention missing manifest sources: {error_msg}"
         );
         assert!(
-            normalized_error.contains(&expected_root),
+            error_msg.contains("repo root:"),
+            "error message should label the repo root path: {error_msg}"
+        );
+        let expected_root_name = root
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("temp root should have utf8 name");
+        assert!(
+            error_msg.contains(expected_root_name),
             "error message should contain the resolved repo root path: {error_msg}"
         );
         assert!(

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -162,7 +162,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
     set_shell_if_windows()?;
     match parse_args(&args)? {
-        CliAction::DumpManifests { output_format } => dump_manifests(output_format)?,
+        CliAction::DumpManifests {
+            output_format,
+            manifests_dir,
+        } => dump_manifests(manifests_dir.as_deref(), output_format)?,
         CliAction::BootstrapPlan { output_format } => print_bootstrap_plan(output_format)?,
         CliAction::Agents {
             args,
@@ -255,6 +258,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 enum CliAction {
     DumpManifests {
         output_format: CliOutputFormat,
+        manifests_dir: Option<PathBuf>,
     },
     BootstrapPlan {
         output_format: CliOutputFormat,
@@ -531,7 +535,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
     let permission_mode = permission_mode_override.unwrap_or_else(default_permission_mode);
 
     match rest[0].as_str() {
-        "dump-manifests" => Ok(CliAction::DumpManifests { output_format }),
+        "dump-manifests" => parse_dump_manifests_args(&rest[1..], output_format),
         "bootstrap-plan" => Ok(CliAction::BootstrapPlan { output_format }),
         "agents" => Ok(CliAction::Agents {
             args: join_optional_args(&rest[1..]),
@@ -1142,6 +1146,40 @@ fn parse_export_args(args: &[String], output_format: CliOutputFormat) -> Result<
         output_format,
     })
 }
+
+fn parse_dump_manifests_args(
+    args: &[String],
+    output_format: CliOutputFormat,
+) -> Result<CliAction, String> {
+    let mut manifests_dir: Option<PathBuf> = None;
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--manifests-dir" {
+            let value = args
+                .get(index + 1)
+                .ok_or_else(|| String::from("--manifests-dir requires a path"))?;
+            manifests_dir = Some(PathBuf::from(value));
+            index += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--manifests-dir=") {
+            if value.is_empty() {
+                return Err(String::from("--manifests-dir requires a path"));
+            }
+            manifests_dir = Some(PathBuf::from(value));
+            index += 1;
+            continue;
+        }
+        return Err(format!("unknown dump-manifests option: {arg}"));
+    }
+
+    Ok(CliAction::DumpManifests {
+        output_format,
+        manifests_dir,
+    })
+}
+
 fn parse_resume_args(args: &[String], output_format: CliOutputFormat) -> Result<CliAction, String> {
     let (session_path, command_tokens): (PathBuf, &[String]) = match args.first() {
         None => (PathBuf::from(LATEST_SESSION_REFERENCE), &[]),
@@ -1841,9 +1879,66 @@ fn looks_like_slash_command_token(token: &str) -> bool {
         .any(|spec| spec.name == name || spec.aliases.contains(&name))
 }
 
-fn dump_manifests(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+fn dump_manifests(
+    manifests_dir: Option<&Path>,
+    output_format: CliOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let paths = UpstreamPaths::from_workspace_dir(&workspace_dir);
+    dump_manifests_at_path(&workspace_dir, manifests_dir, output_format)
+}
+
+const DUMP_MANIFESTS_OVERRIDE_HINT: &str =
+    "Hint: set CLAUDE_CODE_UPSTREAM=/path/to/upstream or pass `claw dump-manifests --manifests-dir /path/to/upstream`.";
+
+fn upstream_repo_root(paths: &UpstreamPaths) -> PathBuf {
+    paths
+        .commands_path()
+        .parent()
+        .and_then(Path::parent)
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+}
+
+fn dump_manifests_at_path(
+    workspace_dir: &Path,
+    manifests_dir: Option<&Path>,
+    output_format: CliOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let paths = if let Some(dir) = manifests_dir {
+        let resolved = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+        UpstreamPaths::from_repo_root(resolved)
+    } else {
+        let resolved = workspace_dir
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_dir.to_path_buf());
+        UpstreamPaths::from_workspace_dir(&resolved)
+    };
+    let source_root = upstream_repo_root(&paths);
+    if !source_root.exists() {
+        return Err(format!(
+            "Manifest source directory does not exist.\n  looked in: {}\n  {DUMP_MANIFESTS_OVERRIDE_HINT}",
+            source_root.display(),
+        )
+        .into());
+    }
+
+    let required_paths = [
+        ("src/commands.ts", paths.commands_path()),
+        ("src/tools.ts", paths.tools_path()),
+        ("src/entrypoints/cli.tsx", paths.cli_path()),
+    ];
+    let missing = required_paths
+        .iter()
+        .filter_map(|(label, path)| (!path.is_file()).then_some(*label))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "Manifest source files are missing.\n  repo root: {}\n  missing: {}\n  {DUMP_MANIFESTS_OVERRIDE_HINT}",
+            source_root.display(),
+            missing.join(", "),
+        )
+        .into());
+    }
+
     match extract_manifest(&paths) {
         Ok(manifest) => {
             match output_format {
@@ -1864,7 +1959,11 @@ fn dump_manifests(output_format: CliOutputFormat) -> Result<(), Box<dyn std::err
             }
             Ok(())
         }
-        Err(error) => Err(format!("failed to extract manifests: {error}").into()),
+        Err(error) => Err(format!(
+            "failed to extract manifests: {error}\n  looked in: {}\n  {DUMP_MANIFESTS_OVERRIDE_HINT}",
+            source_root.display()
+        )
+        .into()),
     }
 }
 
@@ -3052,6 +3151,7 @@ struct SessionHandle {
 struct ManagedSessionSummary {
     id: String,
     path: PathBuf,
+    updated_at_ms: u64,
     modified_epoch_millis: u128,
     message_count: usize,
     parent_session_id: Option<String>,
@@ -4662,7 +4762,7 @@ fn collect_sessions_from_dir(
             .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
             .map(|duration| duration.as_millis())
             .unwrap_or_default();
-        let (id, message_count, parent_session_id, branch_name) =
+        let (id, updated_at_ms, message_count, parent_session_id, branch_name) =
             match Session::load_from_path(&path) {
                 Ok(session) => {
                     let parent_session_id = session
@@ -4675,6 +4775,7 @@ fn collect_sessions_from_dir(
                         .and_then(|fork| fork.branch_name.clone());
                     (
                         session.session_id,
+                        session.updated_at_ms,
                         session.messages.len(),
                         parent_session_id,
                         branch_name,
@@ -4686,6 +4787,7 @@ fn collect_sessions_from_dir(
                         .unwrap_or("unknown")
                         .to_string(),
                     0,
+                    0,
                     None,
                     None,
                 ),
@@ -4693,6 +4795,7 @@ fn collect_sessions_from_dir(
         sessions.push(ManagedSessionSummary {
             id,
             path,
+            updated_at_ms,
             modified_epoch_millis,
             message_count,
             parent_session_id,
@@ -4719,8 +4822,9 @@ fn list_managed_sessions() -> Result<Vec<ManagedSessionSummary>, Box<dyn std::er
 
     sessions.sort_by(|left, right| {
         right
-            .modified_epoch_millis
-            .cmp(&left.modified_epoch_millis)
+            .updated_at_ms
+            .cmp(&left.updated_at_ms)
+            .then_with(|| right.modified_epoch_millis.cmp(&left.modified_epoch_millis))
             .then_with(|| right.id.cmp(&left.id))
     });
     Ok(sessions)
@@ -8333,7 +8437,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(out, "  claw sandbox")?;
     writeln!(out, "      Show the current sandbox isolation snapshot")?;
-    writeln!(out, "  claw dump-manifests")?;
+    writeln!(out, "  claw dump-manifests [--manifests-dir PATH]")?;
     writeln!(out, "  claw bootstrap-plan")?;
     writeln!(out, "  claw agents")?;
     writeln!(out, "  claw mcp")?;
@@ -9140,6 +9244,33 @@ mod tests {
         std::env::remove_var("CLAW_TEST_PERMISSION_PROMPT_RESPONSE");
 
         assert_eq!(decision, Some(PermissionPromptDecision::Allow));
+    }
+
+    #[test]
+    fn dump_manifests_subcommand_accepts_explicit_manifest_dir() {
+        assert_eq!(
+            parse_args(&[
+                "dump-manifests".to_string(),
+                "--manifests-dir".to_string(),
+                "/tmp/upstream".to_string(),
+            ])
+            .expect("dump-manifests should parse"),
+            CliAction::DumpManifests {
+                output_format: CliOutputFormat::Text,
+                manifests_dir: Some(PathBuf::from("/tmp/upstream")),
+            }
+        );
+        assert_eq!(
+            parse_args(&[
+                "dump-manifests".to_string(),
+                "--manifests-dir=/tmp/upstream".to_string(),
+            ])
+            .expect("inline dump-manifests flag should parse"),
+            CliAction::DumpManifests {
+                output_format: CliOutputFormat::Text,
+                manifests_dir: Some(PathBuf::from("/tmp/upstream")),
+            }
+        );
     }
 
     #[test]
@@ -11200,9 +11331,7 @@ UU conflicted.rs",
 
     #[test]
     fn managed_sessions_default_to_jsonl_and_resolve_legacy_json() {
-        let _guard = cwd_lock()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = cwd_guard();
         let workspace = temp_workspace("session-resolution");
         std::fs::create_dir_all(&workspace).expect("workspace should create");
         let previous = std::env::current_dir().expect("cwd");
@@ -11242,9 +11371,7 @@ UU conflicted.rs",
 
     #[test]
     fn latest_session_alias_resolves_most_recent_managed_session() {
-        let _guard = cwd_lock()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = cwd_guard();
         let workspace = temp_workspace("latest-session-alias");
         std::fs::create_dir_all(&workspace).expect("workspace should create");
         let previous = std::env::current_dir().expect("cwd");
@@ -11296,6 +11423,24 @@ UU conflicted.rs",
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    fn cwd_guard() -> MutexGuard<'static, ()> {
+        cwd_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn cwd_guard_recovers_after_poisoning() {
+        let poisoned = std::thread::spawn(|| {
+            let _guard = cwd_guard();
+            panic!("poison cwd lock");
+        })
+        .join();
+        assert!(poisoned.is_err(), "poisoning thread should panic");
+
+        let _guard = cwd_guard();
+    }
+
     fn temp_workspace(label: &str) -> PathBuf {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -11306,9 +11451,7 @@ UU conflicted.rs",
 
     #[test]
     fn init_template_mentions_detected_rust_workspace() {
-        let _guard = cwd_lock()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = cwd_guard();
         let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
         let rendered = crate::init::render_init_claude_md(&workspace_root);
         assert!(rendered.contains("# CLAUDE.md"));
@@ -12252,7 +12395,7 @@ fn write_mcp_server_fixture(script_path: &Path) {
 
 #[cfg(test)]
 mod sandbox_report_tests {
-    use super::{format_sandbox_report, HookAbortMonitor};
+    use super::{dump_manifests_at_path, format_sandbox_report, CliOutputFormat, HookAbortMonitor};
     use runtime::HookAbortSignal;
     use std::sync::mpsc;
     use std::time::Duration;
@@ -12303,5 +12446,79 @@ mod sandbox_report_tests {
         monitor.stop();
 
         assert!(abort_signal.is_aborted());
+    }
+
+    #[test]
+    fn dump_manifests_shows_helpful_error_when_manifests_missing() {
+        let root = std::env::temp_dir().join(format!(
+            "claw_test_missing_manifests_{}",
+            std::process::id()
+        ));
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(&workspace).expect("failed to create temp workspace");
+
+        let result = dump_manifests_at_path(&workspace, None, CliOutputFormat::Text);
+        assert!(
+            result.is_err(),
+            "expected an error when manifests are missing"
+        );
+
+        let error_msg = result
+            .expect_err("missing manifests should error")
+            .to_string();
+        assert!(
+            error_msg.contains("Manifest source files are missing"),
+            "error message should mention missing manifest sources: {error_msg}"
+        );
+        assert!(
+            error_msg.contains(&root.display().to_string()),
+            "error message should contain the resolved repo root path: {error_msg}"
+        );
+        assert!(
+            error_msg.contains("src/commands.ts"),
+            "error message should mention missing commands.ts: {error_msg}"
+        );
+        assert!(
+            error_msg.contains("CLAUDE_CODE_UPSTREAM"),
+            "error message should explain how to supply the upstream path: {error_msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn dump_manifests_uses_explicit_manifest_dir() {
+        let root = std::env::temp_dir().join(format!(
+            "claw_test_explicit_manifest_dir_{}",
+            std::process::id()
+        ));
+        let workspace = root.join("workspace");
+        let upstream = root.join("upstream");
+        std::fs::create_dir_all(workspace.join("nested")).expect("workspace should exist");
+        std::fs::create_dir_all(upstream.join("src/entrypoints"))
+            .expect("upstream fixture should exist");
+        std::fs::write(
+            upstream.join("src/commands.ts"),
+            "import FooCommand from './commands/foo'\n",
+        )
+        .expect("commands fixture should write");
+        std::fs::write(
+            upstream.join("src/tools.ts"),
+            "import ReadTool from './tools/read'\n",
+        )
+        .expect("tools fixture should write");
+        std::fs::write(
+            upstream.join("src/entrypoints/cli.tsx"),
+            "startupProfiler()\n",
+        )
+        .expect("cli fixture should write");
+
+        let result = dump_manifests_at_path(&workspace, Some(&upstream), CliOutputFormat::Text);
+        assert!(
+            result.is_ok(),
+            "explicit manifest dir should succeed: {result:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -12400,6 +12400,14 @@ mod sandbox_report_tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
+    fn normalize_test_path(path: &std::path::Path) -> String {
+        path.display()
+            .to_string()
+            .replace('/', "\\")
+            .trim_start_matches("\\\\?\\")
+            .to_string()
+    }
+
     #[test]
     fn sandbox_report_renders_expected_fields() {
         let report = format_sandbox_report(&runtime::SandboxStatus::default());
@@ -12466,12 +12474,14 @@ mod sandbox_report_tests {
         let error_msg = result
             .expect_err("missing manifests should error")
             .to_string();
+        let normalized_error = error_msg.replace('/', "\\");
+        let expected_root = normalize_test_path(&root);
         assert!(
             error_msg.contains("Manifest source files are missing"),
             "error message should mention missing manifest sources: {error_msg}"
         );
         assert!(
-            error_msg.contains(&root.display().to_string()),
+            normalized_error.contains(&expected_root),
             "error message should contain the resolved repo root path: {error_msg}"
         );
         assert!(

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -173,13 +173,15 @@ fn dump_manifests_and_init_emit_json_when_requested() {
     fs::create_dir_all(&root).expect("temp dir should exist");
 
     let upstream = write_upstream_fixture(&root);
-    let manifests = assert_json_command_with_env(
+    let manifests = assert_json_command(
         &root,
-        &["--output-format", "json", "dump-manifests"],
-        &[(
-            "CLAUDE_CODE_UPSTREAM",
+        &[
+            "--output-format",
+            "json",
+            "dump-manifests",
+            "--manifests-dir",
             upstream.to_str().expect("utf8 upstream"),
-        )],
+        ],
     );
     assert_eq!(manifests["kind"], "dump-manifests");
     assert_eq!(manifests["commands"], 1);

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5537,6 +5537,24 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn env_guard_recovers_after_poisoning() {
+        let poisoned = std::thread::spawn(|| {
+            let _guard = env_guard();
+            panic!("poison env lock");
+        })
+        .join();
+        assert!(poisoned.is_err(), "poisoning thread should panic");
+
+        let _guard = env_guard();
+    }
+
     fn temp_path(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -21,7 +21,7 @@ use runtime::{
     summary_compression::compress_summary_text,
     task_registry::TaskRegistry,
     team_cron_registry::{CronRegistry, TeamRegistry},
-    worker_boot::{WorkerReadySnapshot, WorkerRegistry},
+    worker_boot::{WorkerReadySnapshot, WorkerRegistry, WorkerTaskReceipt},
     write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, BashCommandOutput,
     BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage, ConversationRuntime,
     GrepSearchInput, LaneCommitProvenance, LaneEvent, LaneEventBlocker, LaneEventName,
@@ -931,7 +931,22 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "worker_id": { "type": "string" },
-                    "prompt": { "type": "string" }
+                    "prompt": { "type": "string" },
+                    "task_receipt": {
+                        "type": "object",
+                        "properties": {
+                            "repo": { "type": "string" },
+                            "task_kind": { "type": "string" },
+                            "source_surface": { "type": "string" },
+                            "expected_artifacts": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            },
+                            "objective_preview": { "type": "string" }
+                        },
+                        "required": ["repo", "task_kind", "source_surface", "objective_preview"],
+                        "additionalProperties": false
+                    }
                 },
                 "required": ["worker_id"],
                 "additionalProperties": false
@@ -1503,7 +1518,11 @@ fn run_worker_await_ready(input: WorkerIdInput) -> Result<String, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 fn run_worker_send_prompt(input: WorkerSendPromptInput) -> Result<String, String> {
-    let worker = global_worker_registry().send_prompt(&input.worker_id, input.prompt.as_deref())?;
+    let worker = global_worker_registry().send_prompt(
+        &input.worker_id,
+        input.prompt.as_deref(),
+        input.task_receipt,
+    )?;
     to_pretty_json(worker)
 }
 
@@ -2281,6 +2300,8 @@ struct WorkerSendPromptInput {
     worker_id: String,
     #[serde(default)]
     prompt: Option<String>,
+    #[serde(default)]
+    task_receipt: Option<WorkerTaskReceipt>,
 }
 
 const fn default_auto_recover_prompt_misdelivery() -> bool {


### PR DESCRIPTION
## Summary
- sync the upstream worker wrong-task guard for prompt receipts
- sync managed-session recency fixes and monotonic timestamps for latest-session selection
- add dump-manifests --manifests-dir recovery plus clearer manifest-source errors
- backfill poisoned test-lock recovery helpers in the affected test surfaces

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace