### PR TITLE
[codex] Align shell tool wrappers with TS session behavior

### DIFF
--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -1,7 +1,10 @@
 use std::env;
+use std::fs::{self, OpenOptions};
 use std::io;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::process::Command as TokioCommand;
@@ -12,9 +15,17 @@ use crate::sandbox::{
     build_linux_sandbox_command, resolve_sandbox_status_for_request, FilesystemIsolationMode,
     SandboxConfig, SandboxStatus,
 };
+use crate::tool_session::current_tool_session_storage_root;
 #[cfg(windows)]
 use crate::windows_path_to_posix_path;
 use crate::{bash_shell_path, ConfigLoader};
+
+static SHELL_OUTPUT_COUNTER: AtomicU64 = AtomicU64::new(0);
+const CLAW_STATE_DIR: &str = ".claw";
+const TOOL_RESULTS_DIR: &str = "tool-results";
+const TASK_OUTPUTS_DIR: &str = "tasks";
+const MAX_PERSISTED_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
+const SHELL_TASK_ID_ALPHABET: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BashCommandInput {
@@ -39,31 +50,109 @@ pub struct BashCommandInput {
 pub struct BashCommandOutput {
     pub stdout: String,
     pub stderr: String,
-    #[serde(rename = "rawOutputPath")]
+    #[serde(rename = "rawOutputPath", skip_serializing_if = "Option::is_none")]
     pub raw_output_path: Option<String>,
     pub interrupted: bool,
-    #[serde(rename = "isImage")]
+    #[serde(rename = "isImage", skip_serializing_if = "Option::is_none")]
     pub is_image: Option<bool>,
-    #[serde(rename = "backgroundTaskId")]
+    #[serde(rename = "backgroundTaskId", skip_serializing_if = "Option::is_none")]
     pub background_task_id: Option<String>,
-    #[serde(rename = "backgroundedByUser")]
+    #[serde(rename = "backgroundedByUser", skip_serializing_if = "Option::is_none")]
     pub backgrounded_by_user: Option<bool>,
-    #[serde(rename = "assistantAutoBackgrounded")]
+    #[serde(
+        rename = "assistantAutoBackgrounded",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub assistant_auto_backgrounded: Option<bool>,
-    #[serde(rename = "dangerouslyDisableSandbox")]
+    #[serde(
+        rename = "dangerouslyDisableSandbox",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dangerously_disable_sandbox: Option<bool>,
-    #[serde(rename = "returnCodeInterpretation")]
+    #[serde(
+        rename = "returnCodeInterpretation",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub return_code_interpretation: Option<String>,
-    #[serde(rename = "noOutputExpected")]
+    #[serde(rename = "noOutputExpected", skip_serializing_if = "Option::is_none")]
     pub no_output_expected: Option<bool>,
-    #[serde(rename = "structuredContent")]
+    #[serde(rename = "structuredContent", skip_serializing_if = "Option::is_none")]
     pub structured_content: Option<Vec<serde_json::Value>>,
-    #[serde(rename = "persistedOutputPath")]
+    #[serde(
+        rename = "persistedOutputPath",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub persisted_output_path: Option<String>,
-    #[serde(rename = "persistedOutputSize")]
+    #[serde(
+        rename = "persistedOutputSize",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub persisted_output_size: Option<u64>,
-    #[serde(rename = "sandboxStatus")]
+    #[serde(rename = "sandboxStatus", skip_serializing_if = "Option::is_none")]
     pub sandbox_status: Option<SandboxStatus>,
+}
+
+#[derive(Debug)]
+pub struct BackgroundShellOutputCapture {
+    pub task_id: String,
+    pub output_path: String,
+    pub stdout: Stdio,
+    pub stderr: Stdio,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedShellCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub persisted_output_path: Option<String>,
+    pub persisted_output_size: Option<u64>,
+    pub no_output_expected: bool,
+}
+
+pub fn prepare_background_shell_output(
+    cwd: &Path,
+    _tool_name: &str,
+) -> io::Result<BackgroundShellOutputCapture> {
+    let task_id = next_shell_task_id();
+    let output_path = shell_task_output_path(cwd, &task_id);
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let stdout = OpenOptions::new()
+        .create_new(true)
+        .append(true)
+        .open(&output_path)?;
+    let stderr = stdout.try_clone()?;
+    Ok(BackgroundShellOutputCapture {
+        task_id,
+        output_path: output_path.to_string_lossy().into_owned(),
+        stdout: Stdio::from(stdout),
+        stderr: Stdio::from(stderr),
+    })
+}
+
+#[must_use]
+pub fn prepare_shell_command_output(
+    cwd: &Path,
+    _tool_name: &str,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> PreparedShellCommandOutput {
+    let raw_stdout = String::from_utf8_lossy(stdout).into_owned();
+    let raw_stderr = String::from_utf8_lossy(stderr).into_owned();
+    let persisted = if stdout.len() > MAX_OUTPUT_BYTES {
+        persist_stdout_for_model(cwd, stdout).ok()
+    } else {
+        None
+    };
+
+    PreparedShellCommandOutput {
+        stdout: preview_output(&raw_stdout, MAX_OUTPUT_BYTES),
+        stderr: truncate_output(&raw_stderr),
+        persisted_output_path: persisted.as_ref().map(|value| value.path.clone()),
+        persisted_output_size: persisted.map(|value| value.original_size),
+        no_output_expected: raw_stdout.trim().is_empty() && raw_stderr.trim().is_empty(),
+    }
 }
 
 pub fn execute_bash(input: BashCommandInput) -> io::Result<BashCommandOutput> {
@@ -71,22 +160,23 @@ pub fn execute_bash(input: BashCommandInput) -> io::Result<BashCommandOutput> {
     let sandbox_status = sandbox_status_for_input(&input, &cwd);
 
     if input.run_in_background.unwrap_or(false) {
+        let background_output = prepare_background_shell_output(&cwd, "bash")?;
         let mut child = prepare_command(&input.command, &cwd, &sandbox_status, false)?;
-        let child = child
+        child
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(background_output.stdout)
+            .stderr(background_output.stderr)
             .spawn()?;
 
         return Ok(BashCommandOutput {
             stdout: String::new(),
             stderr: String::new(),
-            raw_output_path: None,
+            raw_output_path: Some(background_output.output_path),
             interrupted: false,
             is_image: None,
-            background_task_id: Some(child.id().to_string()),
-            backgrounded_by_user: Some(false),
-            assistant_auto_backgrounded: Some(false),
+            background_task_id: Some(background_output.task_id),
+            backgrounded_by_user: None,
+            assistant_auto_backgrounded: None,
             dangerously_disable_sandbox: input.dangerously_disable_sandbox,
             return_code_interpretation: None,
             no_output_expected: Some(true),
@@ -123,7 +213,7 @@ async fn execute_bash_async(
                     assistant_auto_backgrounded: None,
                     dangerously_disable_sandbox: input.dangerously_disable_sandbox,
                     return_code_interpretation: Some(String::from("timeout")),
-                    no_output_expected: Some(true),
+                    no_output_expected: Some(false),
                     structured_content: None,
                     persisted_output_path: None,
                     persisted_output_size: None,
@@ -136,9 +226,8 @@ async fn execute_bash_async(
     };
 
     let (output, interrupted) = output_result;
-    let stdout = truncate_output(&String::from_utf8_lossy(&output.stdout));
-    let stderr = truncate_output(&String::from_utf8_lossy(&output.stderr));
-    let no_output_expected = Some(stdout.trim().is_empty() && stderr.trim().is_empty());
+    let prepared_output =
+        prepare_shell_command_output(&cwd, "bash", &output.stdout, &output.stderr);
     let return_code_interpretation = output.status.code().and_then(|code| {
         if code == 0 {
             None
@@ -148,8 +237,8 @@ async fn execute_bash_async(
     });
 
     Ok(BashCommandOutput {
-        stdout,
-        stderr,
+        stdout: prepared_output.stdout,
+        stderr: prepared_output.stderr,
         raw_output_path: None,
         interrupted,
         is_image: None,
@@ -158,12 +247,82 @@ async fn execute_bash_async(
         assistant_auto_backgrounded: None,
         dangerously_disable_sandbox: input.dangerously_disable_sandbox,
         return_code_interpretation,
-        no_output_expected,
+        no_output_expected: Some(prepared_output.no_output_expected),
         structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
+        persisted_output_path: prepared_output.persisted_output_path,
+        persisted_output_size: prepared_output.persisted_output_size,
         sandbox_status: Some(sandbox_status),
     })
+}
+
+fn persist_stdout_for_model(cwd: &Path, stdout: &[u8]) -> io::Result<PersistedShellOutput> {
+    let path = tool_results_dir(cwd).join(format!("{}.txt", next_shell_task_id()));
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let bytes_to_write = stdout
+        .len()
+        .min(usize::try_from(MAX_PERSISTED_OUTPUT_BYTES).expect("persisted output cap fits usize"));
+    fs::write(&path, &stdout[..bytes_to_write])?;
+    Ok(PersistedShellOutput {
+        path: path.to_string_lossy().into_owned(),
+        original_size: u64::try_from(stdout.len()).expect("stdout length fits u64"),
+    })
+}
+
+fn tool_results_dir(cwd: &Path) -> PathBuf {
+    shell_output_root(cwd).join(TOOL_RESULTS_DIR)
+}
+
+fn task_outputs_dir(cwd: &Path) -> PathBuf {
+    shell_output_root(cwd).join(TASK_OUTPUTS_DIR)
+}
+
+#[must_use]
+pub fn shell_task_output_path(cwd: &Path, task_id: &str) -> PathBuf {
+    task_outputs_dir(cwd).join(format!("{task_id}.output"))
+}
+
+fn shell_output_root(cwd: &Path) -> PathBuf {
+    current_tool_session_storage_root(cwd).unwrap_or_else(|| cwd.join(CLAW_STATE_DIR))
+}
+
+fn next_shell_task_id() -> String {
+    let counter = SHELL_OUTPUT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let time_seed = duration.as_secs().rotate_left(32) ^ u64::from(duration.subsec_nanos());
+    let mut value = time_seed ^ counter.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    let alphabet_len =
+        u64::try_from(SHELL_TASK_ID_ALPHABET.len()).expect("alphabet length fits into u64");
+    let mut suffix = [b'0'; 8];
+
+    for ch in suffix.iter_mut().rev() {
+        let idx = usize::try_from(value % alphabet_len).expect("task id index fits into usize");
+        *ch = SHELL_TASK_ID_ALPHABET[idx];
+        value /= alphabet_len;
+    }
+
+    let suffix = std::str::from_utf8(&suffix).expect("task id alphabet is ASCII");
+    format!("b{suffix}")
+}
+
+struct PersistedShellOutput {
+    path: String,
+    original_size: u64,
+}
+
+fn preview_output(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
 }
 
 fn sandbox_status_for_input(input: &BashCommandInput, cwd: &std::path::Path) -> SandboxStatus {
@@ -291,13 +450,20 @@ impl BashEnvCommand for TokioCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_bash, BashCommandInput};
+    use super::{
+        execute_bash, prepare_background_shell_output, prepare_shell_command_output,
+        BashCommandInput, MAX_OUTPUT_BYTES,
+    };
+    use crate::tool_session::with_tool_session_context;
     #[cfg(windows)]
     use crate::{bash_shell_path, set_shell_if_windows, test_env_lock};
+    use std::fs;
+    use std::path::PathBuf;
     #[cfg(windows)]
     use std::process::Command;
     #[cfg(windows)]
     use std::sync::OnceLock;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[cfg(windows)]
     fn windows_bash_smoke_ok() -> bool {
@@ -325,6 +491,14 @@ mod tests {
     }
 
     const TEST_TIMEOUT_MS: u64 = 5_000;
+
+    fn temp_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("clawd-runtime-bash-{unique}-{name}"))
+    }
 
     #[test]
     fn executes_simple_command() {
@@ -396,6 +570,131 @@ mod tests {
         .expect("bash command should execute");
 
         assert!(!output.sandbox_status.expect("sandbox status").enabled);
+    }
+
+    #[test]
+    fn prepare_shell_command_output_persists_large_stdout() {
+        let cwd = temp_path("persisted-output");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let stdout = vec![b'x'; MAX_OUTPUT_BYTES + 128];
+
+        let prepared = prepare_shell_command_output(&cwd, "bash", &stdout, b"");
+
+        let persisted_path = prepared
+            .persisted_output_path
+            .as_ref()
+            .expect("persisted output path");
+        let persisted_bytes = fs::read(persisted_path).expect("read persisted output");
+        assert_eq!(persisted_bytes, stdout);
+        assert_eq!(
+            prepared.persisted_output_size,
+            Some(u64::try_from(MAX_OUTPUT_BYTES + 128).expect("size fits u64"))
+        );
+        assert_eq!(prepared.stdout, "x".repeat(MAX_OUTPUT_BYTES));
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn prepare_background_shell_output_creates_output_file() {
+        let cwd = temp_path("background-output");
+        fs::create_dir_all(&cwd).expect("create cwd");
+
+        let prepared =
+            prepare_background_shell_output(&cwd, "bash").expect("prepare background output");
+        let output_path = PathBuf::from(&prepared.output_path);
+
+        assert!(output_path.exists(), "expected {output_path:?} to exist");
+        assert!(prepared.task_id.starts_with('b'));
+        assert_eq!(prepared.task_id.len(), 9);
+
+        drop(prepared);
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn prepare_background_shell_output_uses_session_isolated_directory_when_context_exists() {
+        let cwd = temp_path("session-background-output");
+        let session_path = cwd
+            .join(".claw")
+            .join("sessions")
+            .join("workspace-hash")
+            .join("session-123.jsonl");
+        fs::create_dir_all(
+            session_path
+                .parent()
+                .expect("session path should have a parent"),
+        )
+        .expect("create session dir");
+
+        let output_path = with_tool_session_context("session-123", Some(&session_path), || {
+            prepare_background_shell_output(&cwd, "bash")
+                .expect("prepare background output")
+                .output_path
+        });
+
+        let output_path = PathBuf::from(output_path);
+        assert!(
+            output_path.starts_with(
+                cwd.join(".claw")
+                    .join("sessions")
+                    .join("workspace-hash")
+                    .join("session-123")
+                    .join("tasks")
+            ),
+            "expected {output_path:?} to be under the session-specific tasks directory"
+        );
+        assert_eq!(
+            output_path
+                .parent()
+                .expect("output path should have a parent"),
+            cwd.join(".claw")
+                .join("sessions")
+                .join("workspace-hash")
+                .join("session-123")
+                .join("tasks")
+        );
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn prepare_shell_command_output_uses_session_isolated_tool_results_directory() {
+        let cwd = temp_path("session-persisted-output");
+        let session_path = cwd
+            .join(".claw")
+            .join("sessions")
+            .join("workspace-hash")
+            .join("session-456.jsonl");
+        fs::create_dir_all(
+            session_path
+                .parent()
+                .expect("session path should have a parent"),
+        )
+        .expect("create session dir");
+        let stdout = vec![b'y'; MAX_OUTPUT_BYTES + 64];
+
+        let prepared = with_tool_session_context("session-456", Some(&session_path), || {
+            prepare_shell_command_output(&cwd, "bash", &stdout, b"")
+        });
+
+        let persisted_path = PathBuf::from(
+            prepared
+                .persisted_output_path
+                .expect("persisted output path should exist"),
+        );
+        assert_eq!(
+            persisted_path
+                .parent()
+                .expect("persisted path should have a parent"),
+            cwd.join(".claw")
+                .join("sessions")
+                .join("workspace-hash")
+                .join("session-456")
+                .join("tool-results")
+        );
+
+        let _ = fs::remove_dir_all(cwd);
     }
 }
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -13,6 +13,7 @@ use crate::permissions::{
     PermissionContext, PermissionOutcome, PermissionPolicy, PermissionPrompter,
 };
 use crate::session::{ContentBlock, ConversationMessage, Session};
+use crate::tool_session::with_tool_session_context;
 use crate::usage::{TokenUsage, UsageTracker};
 
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 100_000;
@@ -313,7 +314,11 @@ where
                 system_prompt: self.system_prompt.clone(),
                 messages: self.session.messages.clone(),
             };
-            let events = match self.api_client.stream(request) {
+            let events = match with_tool_session_context(
+                &self.session.session_id,
+                self.session.persistence_path(),
+                || self.api_client.stream(request),
+            ) {
                 Ok(events) => events,
                 Err(error) => {
                     self.record_turn_failed(iterations, &error);
@@ -407,11 +412,14 @@ where
                 let result_message = match permission_outcome {
                     PermissionOutcome::Allow => {
                         self.record_tool_started(iterations, &tool_name);
-                        let (mut output, mut is_error) =
-                            match self.tool_executor.execute(&tool_name, &effective_input) {
+                        let (mut output, mut is_error) = with_tool_session_context(
+                            &self.session.session_id,
+                            self.session.persistence_path(),
+                            || match self.tool_executor.execute(&tool_name, &effective_input) {
                                 Ok(output) => (output, false),
                                 Err(error) => (error.to_string(), true),
-                            };
+                            },
+                        );
                         output = merge_hook_feedback(pre_hook_result.messages(), output, false);
 
                         let post_hook_result = if is_error {

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -40,6 +40,7 @@ pub mod summary_compression;
 pub mod task_packet;
 pub mod task_registry;
 pub mod team_cron_registry;
+mod tool_session;
 #[cfg(test)]
 mod trust_resolver;
 mod usage;
@@ -52,7 +53,11 @@ pub use appfs::{
     AppfsRuntimeManifestControlPlane, APPFS_MULTI_AGENT_MODE_SHARED,
     APPFS_RUNTIME_MANIFEST_REL_PATH,
 };
-pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
+pub use bash::{
+    execute_bash, prepare_background_shell_output, prepare_shell_command_output,
+    shell_task_output_path, BackgroundShellOutputCapture, BashCommandInput, BashCommandOutput,
+    PreparedShellCommandOutput,
+};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};
 pub use compact::{

--- a/rust/crates/runtime/src/tool_session.rs
+++ b/rust/crates/runtime/src/tool_session.rs
@@ -1,0 +1,106 @@
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
+use crate::session_control::SessionStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolSessionContext {
+    session_id: String,
+    persistence_path: Option<PathBuf>,
+}
+
+thread_local! {
+    static CURRENT_TOOL_SESSION_CONTEXT: RefCell<Option<ToolSessionContext>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn with_tool_session_context<R>(
+    session_id: &str,
+    persistence_path: Option<&Path>,
+    action: impl FnOnce() -> R,
+) -> R {
+    struct ResetGuard {
+        previous: Option<ToolSessionContext>,
+    }
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            CURRENT_TOOL_SESSION_CONTEXT.with(|slot| {
+                *slot.borrow_mut() = self.previous.take();
+            });
+        }
+    }
+
+    let previous = CURRENT_TOOL_SESSION_CONTEXT.with(|slot| {
+        slot.replace(Some(ToolSessionContext {
+            session_id: session_id.to_string(),
+            persistence_path: persistence_path.map(Path::to_path_buf),
+        }))
+    });
+    let _guard = ResetGuard { previous };
+    action()
+}
+
+pub(crate) fn current_tool_session_storage_root(cwd: &Path) -> Option<PathBuf> {
+    CURRENT_TOOL_SESSION_CONTEXT.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .and_then(|context| derive_tool_session_storage_root(context, cwd))
+    })
+}
+
+fn derive_tool_session_storage_root(context: &ToolSessionContext, cwd: &Path) -> Option<PathBuf> {
+    if let Some(parent) = context.persistence_path.as_deref().and_then(Path::parent) {
+        return Some(parent.join(&context.session_id));
+    }
+
+    SessionStore::from_cwd(cwd)
+        .ok()
+        .map(|store| store.sessions_dir().join(&context.session_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{current_tool_session_storage_root, with_tool_session_context};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("runtime-tool-session-{unique}-{name}"))
+    }
+
+    #[test]
+    fn derives_storage_root_from_persistence_path_parent_and_session_id() {
+        let cwd = temp_dir("root-from-path");
+        let persistence_path = cwd
+            .join(".claw")
+            .join("sessions")
+            .join("workspace-hash")
+            .join("session-123.jsonl");
+        fs::create_dir_all(
+            persistence_path
+                .parent()
+                .expect("persistence path should have a parent"),
+        )
+        .expect("create session dir");
+
+        let root = with_tool_session_context("session-123", Some(&persistence_path), || {
+            current_tool_session_storage_root(&cwd)
+        })
+        .expect("storage root");
+
+        assert_eq!(
+            root,
+            cwd.join(".claw")
+                .join("sessions")
+                .join("workspace-hash")
+                .join("session-123")
+        );
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+}

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -57,7 +57,8 @@ use runtime::{
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tools::{
-    execute_tool, mvp_tool_specs, GlobalToolRegistry, RuntimeToolDefinition, ToolSearchOutput,
+    execute_tool, model_visible_tool_result, mvp_tool_specs, GlobalToolRegistry,
+    RuntimeToolDefinition, ToolSearchOutput,
 };
 
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
@@ -8371,16 +8372,18 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                     },
                     ContentBlock::ToolResult {
                         tool_use_id,
+                        tool_name,
                         output,
                         is_error,
                         ..
-                    } => InputContentBlock::ToolResult {
-                        tool_use_id: tool_use_id.clone(),
-                        content: vec![ToolResultContentBlock::Text {
-                            text: output.clone(),
-                        }],
-                        is_error: *is_error,
-                    },
+                    } => {
+                        let result = model_visible_tool_result(tool_name, output, *is_error);
+                        InputContentBlock::ToolResult {
+                            tool_use_id: tool_use_id.clone(),
+                            content: result.content,
+                            is_error: result.is_error,
+                        }
+                    }
                 })
                 .collect::<Vec<_>>();
             (!content.is_empty()).then(|| InputMessage {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -17,7 +17,8 @@ use runtime::{
     lsp_client::LspRegistry,
     mcp_tool_bridge::McpToolRegistry,
     permission_enforcer::{EnforcementResult, PermissionEnforcer},
-    read_file,
+    prepare_background_shell_output, prepare_shell_command_output, read_file,
+    shell_task_output_path,
     summary_compression::compress_summary_text,
     task_registry::TaskRegistry,
     team_cron_registry::{CronRegistry, TeamRegistry},
@@ -1828,6 +1829,30 @@ fn run_bash(input: BashCommandInput) -> Result<String, String> {
 }
 
 fn workspace_test_branch_preflight(command: &str) -> Option<BashCommandOutput> {
+    let preflight = workspace_test_branch_preflight_details(command)?;
+    Some(branch_divergence_output(
+        command,
+        &preflight.branch,
+        &preflight.main_ref,
+        preflight.commits_behind,
+        preflight.commits_ahead,
+        &preflight.missing_fixes,
+    ))
+}
+
+fn powershell_test_branch_preflight(command: &str) -> Option<PowerShellCommandOutput> {
+    let preflight = workspace_test_branch_preflight_details(command)?;
+    Some(powershell_branch_divergence_output(
+        command,
+        &preflight.branch,
+        &preflight.main_ref,
+        preflight.commits_behind,
+        preflight.commits_ahead,
+        &preflight.missing_fixes,
+    ))
+}
+
+fn workspace_test_branch_preflight_details(command: &str) -> Option<BranchDivergencePreflight> {
     if !is_workspace_test_command(command) {
         return None;
     }
@@ -1840,27 +1865,33 @@ fn workspace_test_branch_preflight(command: &str) -> Option<BashCommandOutput> {
         BranchFreshness::Stale {
             commits_behind,
             missing_fixes,
-        } => Some(branch_divergence_output(
-            command,
-            &branch,
-            &main_ref,
+        } => Some(BranchDivergencePreflight {
+            branch,
+            main_ref,
             commits_behind,
-            None,
-            &missing_fixes,
-        )),
+            commits_ahead: None,
+            missing_fixes,
+        }),
         BranchFreshness::Diverged {
             ahead,
             behind,
             missing_fixes,
-        } => Some(branch_divergence_output(
-            command,
-            &branch,
-            &main_ref,
-            behind,
-            Some(ahead),
-            &missing_fixes,
-        )),
+        } => Some(BranchDivergencePreflight {
+            branch,
+            main_ref,
+            commits_behind: behind,
+            commits_ahead: Some(ahead),
+            missing_fixes,
+        }),
     }
+}
+
+struct BranchDivergencePreflight {
+    branch: String,
+    main_ref: String,
+    commits_behind: usize,
+    commits_ahead: Option<usize>,
+    missing_fixes: Vec<String>,
 }
 
 fn is_workspace_test_command(command: &str) -> bool {
@@ -1923,17 +1954,13 @@ fn branch_divergence_output(
     commits_ahead: Option<usize>,
     missing_fixes: &[String],
 ) -> BashCommandOutput {
-    let relation = commits_ahead.map_or_else(
-        || format!("is {commits_behind} commit(s) behind"),
-        |ahead| format!("has diverged ({ahead} ahead, {commits_behind} behind)"),
-    );
-    let missing_summary = if missing_fixes.is_empty() {
-        "(none surfaced)".to_string()
-    } else {
-        missing_fixes.join("; ")
-    };
-    let stderr = format!(
-        "branch divergence detected before workspace tests: `{branch}` {relation} `{main_ref}`. Missing commits: {missing_summary}. Merge or rebase `{main_ref}` before re-running `{command}`."
+    let stderr = branch_divergence_stderr(
+        command,
+        branch,
+        main_ref,
+        commits_behind,
+        commits_ahead,
+        missing_fixes,
     );
 
     BashCommandOutput {
@@ -1971,6 +1998,58 @@ fn branch_divergence_output(
         persisted_output_size: None,
         sandbox_status: None,
     }
+}
+
+fn powershell_branch_divergence_output(
+    command: &str,
+    branch: &str,
+    main_ref: &str,
+    commits_behind: usize,
+    commits_ahead: Option<usize>,
+    missing_fixes: &[String],
+) -> PowerShellCommandOutput {
+    PowerShellCommandOutput {
+        stdout: String::new(),
+        stderr: branch_divergence_stderr(
+            command,
+            branch,
+            main_ref,
+            commits_behind,
+            commits_ahead,
+            missing_fixes,
+        ),
+        interrupted: false,
+        return_code_interpretation: Some("preflight_blocked:branch_divergence".to_string()),
+        is_image: None,
+        persisted_output_path: None,
+        persisted_output_size: None,
+        background_task_id: None,
+        backgrounded_by_user: None,
+        assistant_auto_backgrounded: None,
+        structured_content: None,
+    }
+}
+
+fn branch_divergence_stderr(
+    command: &str,
+    branch: &str,
+    main_ref: &str,
+    commits_behind: usize,
+    commits_ahead: Option<usize>,
+    missing_fixes: &[String],
+) -> String {
+    let relation = commits_ahead.map_or_else(
+        || format!("is {commits_behind} commit(s) behind"),
+        |ahead| format!("has diverged ({ahead} ahead, {commits_behind} behind)"),
+    );
+    let missing_summary = if missing_fixes.is_empty() {
+        "(none surfaced)".to_string()
+    } else {
+        missing_fixes.join("; ")
+    };
+    format!(
+        "branch divergence detected before workspace tests: `{branch}` {relation} `{main_ref}`. Missing commits: {missing_summary}. Merge or rebase `{main_ref}` before re-running `{command}`."
+    )
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -2241,6 +2320,41 @@ struct PowerShellInput {
     timeout: Option<u64>,
     description: Option<String>,
     run_in_background: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct PowerShellCommandOutput {
+    stdout: String,
+    stderr: String,
+    interrupted: bool,
+    #[serde(
+        rename = "returnCodeInterpretation",
+        skip_serializing_if = "Option::is_none"
+    )]
+    return_code_interpretation: Option<String>,
+    #[serde(rename = "isImage", skip_serializing_if = "Option::is_none")]
+    is_image: Option<bool>,
+    #[serde(
+        rename = "persistedOutputPath",
+        skip_serializing_if = "Option::is_none"
+    )]
+    persisted_output_path: Option<String>,
+    #[serde(
+        rename = "persistedOutputSize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    persisted_output_size: Option<u64>,
+    #[serde(rename = "backgroundTaskId", skip_serializing_if = "Option::is_none")]
+    background_task_id: Option<String>,
+    #[serde(rename = "backgroundedByUser", skip_serializing_if = "Option::is_none")]
+    backgrounded_by_user: Option<bool>,
+    #[serde(
+        rename = "assistantAutoBackgrounded",
+        skip_serializing_if = "Option::is_none"
+    )]
+    assistant_auto_backgrounded: Option<bool>,
+    #[serde(rename = "structuredContent", skip_serializing_if = "Option::is_none")]
+    structured_content: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4066,6 +4180,407 @@ fn tool_specs_for_allowed_tools(allowed_tools: Option<&BTreeSet<String>>) -> Vec
         .collect()
 }
 
+const PERSISTED_OUTPUT_TAG: &str = "<persisted-output>";
+const PERSISTED_OUTPUT_CLOSING_TAG: &str = "</persisted-output>";
+const PERSISTED_OUTPUT_PREVIEW_BYTES: usize = 2_000;
+const INTERRUPTED_COMMAND_TAG: &str = "<error>Command was aborted before completion</error>";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelVisibleToolResult {
+    pub content: Vec<ToolResultContentBlock>,
+    pub is_error: bool,
+}
+
+impl ModelVisibleToolResult {
+    fn raw_text(output: &str, is_error: bool) -> Self {
+        Self {
+            content: vec![ToolResultContentBlock::Text {
+                text: output.to_string(),
+            }],
+            is_error,
+        }
+    }
+}
+
+#[must_use]
+pub fn model_visible_tool_result(
+    tool_name: &str,
+    output: &str,
+    is_error: bool,
+) -> ModelVisibleToolResult {
+    if !matches!(tool_name, "bash" | "PowerShell") {
+        return ModelVisibleToolResult::raw_text(output, is_error);
+    }
+
+    let Some((shell_output, trailing_text)) = parse_shell_tool_result(tool_name, output) else {
+        return ModelVisibleToolResult::raw_text(output, is_error);
+    };
+
+    let mut result = shell_tool_result_to_model_visible_result(&shell_output, is_error);
+    append_trailing_tool_text(&mut result.content, trailing_text);
+    result
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct NormalizedShellToolResult {
+    stdout: String,
+    stderr: String,
+    interrupted: bool,
+    structured_content: Option<Vec<Value>>,
+    persisted_output_path: Option<String>,
+    persisted_output_size: Option<u64>,
+    background_task_id: Option<String>,
+    backgrounded_by_user: Option<bool>,
+    assistant_auto_backgrounded: Option<bool>,
+    background_output_path: Option<String>,
+}
+
+impl From<BashCommandOutput> for NormalizedShellToolResult {
+    fn from(value: BashCommandOutput) -> Self {
+        let background_output_path = value.raw_output_path.clone().or_else(|| {
+            value
+                .background_task_id
+                .as_deref()
+                .and_then(derive_background_output_path)
+        });
+        Self {
+            stdout: value.stdout,
+            stderr: value.stderr,
+            interrupted: value.interrupted,
+            structured_content: value.structured_content,
+            persisted_output_path: value.persisted_output_path,
+            persisted_output_size: value.persisted_output_size,
+            background_task_id: value.background_task_id,
+            backgrounded_by_user: value.backgrounded_by_user,
+            assistant_auto_backgrounded: value.assistant_auto_backgrounded,
+            background_output_path,
+        }
+    }
+}
+
+impl From<PowerShellCommandOutput> for NormalizedShellToolResult {
+    fn from(value: PowerShellCommandOutput) -> Self {
+        let background_output_path = value
+            .background_task_id
+            .as_deref()
+            .and_then(derive_background_output_path);
+        Self {
+            stdout: value.stdout,
+            stderr: value.stderr,
+            interrupted: value.interrupted,
+            structured_content: value.structured_content,
+            persisted_output_path: value.persisted_output_path,
+            persisted_output_size: value.persisted_output_size,
+            background_task_id: value.background_task_id,
+            backgrounded_by_user: value.backgrounded_by_user,
+            assistant_auto_backgrounded: value.assistant_auto_backgrounded,
+            background_output_path,
+        }
+    }
+}
+
+fn derive_background_output_path(task_id: &str) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    Some(
+        shell_task_output_path(&cwd, task_id)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn parse_shell_tool_result<'a>(
+    tool_name: &str,
+    output: &'a str,
+) -> Option<(NormalizedShellToolResult, &'a str)> {
+    if let Some(parsed) = parse_shell_tool_result_json(tool_name, output) {
+        return Some((parsed, ""));
+    }
+
+    let (json_prefix, trailing_text) = split_json_prefix(output)?;
+    let parsed = parse_shell_tool_result_json(tool_name, json_prefix)?;
+    Some((parsed, trailing_text))
+}
+
+fn parse_shell_tool_result_json(
+    tool_name: &str,
+    output: &str,
+) -> Option<NormalizedShellToolResult> {
+    match tool_name {
+        "bash" => serde_json::from_str::<BashCommandOutput>(output)
+            .ok()
+            .map(NormalizedShellToolResult::from),
+        "PowerShell" => serde_json::from_str::<PowerShellCommandOutput>(output)
+            .ok()
+            .map(NormalizedShellToolResult::from),
+        _ => None,
+    }
+}
+
+fn split_json_prefix(input: &str) -> Option<(&str, &str)> {
+    let start = input.find(|ch: char| !ch.is_whitespace())?;
+    let mut stack = Vec::new();
+    let mut in_string = false;
+    let mut escape = false;
+    let mut end = None;
+
+    for (offset, ch) in input[start..].char_indices() {
+        if offset == 0 {
+            match ch {
+                '{' => stack.push('}'),
+                '[' => stack.push(']'),
+                _ => return None,
+            }
+            continue;
+        }
+
+        if in_string {
+            if escape {
+                escape = false;
+                continue;
+            }
+            match ch {
+                '\\' => escape = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
+            '}' | ']' => {
+                if stack.pop() != Some(ch) {
+                    return None;
+                }
+                if stack.is_empty() {
+                    end = Some(start + offset + ch.len_utf8());
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let end = end?;
+    Some((&input[start..end], &input[end..]))
+}
+
+fn shell_tool_result_to_model_visible_result(
+    output: &NormalizedShellToolResult,
+    is_error: bool,
+) -> ModelVisibleToolResult {
+    if let Some(structured_content) = output
+        .structured_content
+        .as_ref()
+        .filter(|content| !content.is_empty())
+    {
+        return ModelVisibleToolResult {
+            content: structured_content
+                .iter()
+                .map(tool_result_content_block_from_value)
+                .collect(),
+            is_error: is_error || output.interrupted,
+        };
+    }
+
+    let mut sections = Vec::new();
+    let mut processed_stdout = normalize_shell_stdout(&output.stdout);
+    if let Some(path) = output.persisted_output_path.as_deref() {
+        let (preview, has_more) =
+            generate_tool_result_preview(&processed_stdout, PERSISTED_OUTPUT_PREVIEW_BYTES);
+        processed_stdout = build_large_tool_result_message(
+            path,
+            output.persisted_output_size.unwrap_or(0),
+            &preview,
+            has_more,
+        );
+    }
+    if !processed_stdout.is_empty() {
+        sections.push(processed_stdout);
+    }
+
+    let mut error_message = output.stderr.trim().to_string();
+    if output.interrupted {
+        if !error_message.is_empty() {
+            error_message.push('\n');
+        }
+        error_message.push_str(INTERRUPTED_COMMAND_TAG);
+    }
+    if !error_message.is_empty() {
+        sections.push(error_message);
+    }
+
+    if let Some(background_info) = build_background_info(output) {
+        sections.push(background_info);
+    }
+
+    ModelVisibleToolResult {
+        content: vec![ToolResultContentBlock::Text {
+            text: sections.join("\n"),
+        }],
+        is_error: is_error || output.interrupted,
+    }
+}
+
+fn tool_result_content_block_from_value(value: &Value) -> ToolResultContentBlock {
+    match value {
+        Value::String(text) => ToolResultContentBlock::Text { text: text.clone() },
+        _ => ToolResultContentBlock::Json {
+            value: value.clone(),
+        },
+    }
+}
+
+fn normalize_shell_stdout(stdout: &str) -> String {
+    strip_leading_blank_lines(stdout).trim_end().to_string()
+}
+
+fn strip_leading_blank_lines(mut text: &str) -> &str {
+    while let Some(newline_idx) = text.find('\n') {
+        let (line, rest) = text.split_at(newline_idx + 1);
+        if line.trim().is_empty() {
+            text = rest;
+        } else {
+            return text;
+        }
+    }
+
+    if text.trim().is_empty() {
+        ""
+    } else {
+        text
+    }
+}
+
+fn generate_tool_result_preview(content: &str, max_bytes: usize) -> (String, bool) {
+    if content.len() <= max_bytes {
+        return (content.to_string(), false);
+    }
+
+    let mut cut_point = max_bytes.min(content.len());
+    while cut_point > 0 && !content.is_char_boundary(cut_point) {
+        cut_point -= 1;
+    }
+
+    let truncated = &content[..cut_point];
+    let final_cut = truncated
+        .rfind('\n')
+        .filter(|idx| *idx > cut_point / 2)
+        .unwrap_or(cut_point);
+
+    (content[..final_cut].to_string(), true)
+}
+
+fn build_large_tool_result_message(
+    filepath: &str,
+    original_size: u64,
+    preview: &str,
+    has_more: bool,
+) -> String {
+    let mut message = format!(
+        "{PERSISTED_OUTPUT_TAG}\nOutput too large ({}). Full output saved to: {filepath}\n\nPreview (first {}):\n{preview}",
+        format_file_size(original_size),
+        format_file_size(PERSISTED_OUTPUT_PREVIEW_BYTES as u64),
+    );
+    if has_more {
+        message.push_str("\n...\n");
+    } else {
+        message.push('\n');
+    }
+    message.push_str(PERSISTED_OUTPUT_CLOSING_TAG);
+    message
+}
+
+fn format_file_size(size_in_bytes: u64) -> String {
+    if size_in_bytes < 1_024 {
+        return format!("{size_in_bytes} bytes");
+    }
+
+    let kb_tenths = scale_to_tenths(u128::from(size_in_bytes), 1_024);
+    if kb_tenths < 10 * 1_024 {
+        return format!("{}KB", format_size_unit(kb_tenths));
+    }
+
+    let mb_tenths = scale_to_tenths(u128::from(size_in_bytes), 1_024 * 1_024);
+    if mb_tenths < 10 * 1_024 {
+        return format!("{}MB", format_size_unit(mb_tenths));
+    }
+
+    let gb_tenths = scale_to_tenths(u128::from(size_in_bytes), 1_024 * 1_024 * 1_024);
+    format!("{}GB", format_size_unit(gb_tenths))
+}
+
+fn scale_to_tenths(size_in_bytes: u128, unit_size: u128) -> u128 {
+    ((size_in_bytes * 10) + (unit_size / 2)) / unit_size
+}
+
+fn format_size_unit(size_in_tenths: u128) -> String {
+    let whole = size_in_tenths / 10;
+    let fraction = size_in_tenths % 10;
+    if fraction == 0 {
+        whole.to_string()
+    } else {
+        format!("{whole}.{fraction}")
+    }
+}
+
+fn build_background_info(output: &NormalizedShellToolResult) -> Option<String> {
+    let task_id = output.background_task_id.as_deref()?;
+    let output_path = output.background_output_path.as_deref();
+
+    let message = if output.assistant_auto_backgrounded.unwrap_or(false) {
+        match output_path {
+            Some(path) => format!(
+                "Command exceeded the assistant-mode blocking budget (15s) and was moved to the background with ID: {task_id}. It is still running - you will be notified when it completes. Output is being written to: {path}. In assistant mode, delegate long-running work to a subagent or use run_in_background to keep this conversation responsive."
+            ),
+            None => format!(
+                "Command exceeded the assistant-mode blocking budget (15s) and was moved to the background with ID: {task_id}. It is still running - you will be notified when it completes. In assistant mode, delegate long-running work to a subagent or use run_in_background to keep this conversation responsive."
+            ),
+        }
+    } else if output.backgrounded_by_user.unwrap_or(false) {
+        match output_path {
+            Some(path) => {
+                format!(
+                    "Command was manually backgrounded by user with ID: {task_id}. Output is being written to: {path}"
+                )
+            }
+            None => format!("Command was manually backgrounded by user with ID: {task_id}"),
+        }
+    } else {
+        match output_path {
+            Some(path) => {
+                format!("Command running in background with ID: {task_id}. Output is being written to: {path}")
+            }
+            None => format!("Command running in background with ID: {task_id}"),
+        }
+    };
+
+    Some(message)
+}
+
+fn append_trailing_tool_text(content: &mut Vec<ToolResultContentBlock>, trailing_text: &str) {
+    let trimmed = trailing_text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    if content.len() == 1 {
+        if let Some(ToolResultContentBlock::Text { text }) = content.first_mut() {
+            if !text.is_empty() {
+                text.push_str("\n\n");
+            }
+            text.push_str(trimmed);
+            return;
+        }
+    }
+
+    content.push(ToolResultContentBlock::Text {
+        text: trimmed.to_string(),
+    });
+}
+
 fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
     messages
         .iter()
@@ -4087,16 +4602,18 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                     },
                     ContentBlock::ToolResult {
                         tool_use_id,
+                        tool_name,
                         output,
                         is_error,
                         ..
-                    } => InputContentBlock::ToolResult {
-                        tool_use_id: tool_use_id.clone(),
-                        content: vec![ToolResultContentBlock::Text {
-                            text: output.clone(),
-                        }],
-                        is_error: *is_error,
-                    },
+                    } => {
+                        let result = model_visible_tool_result(tool_name, output, *is_error);
+                        InputContentBlock::ToolResult {
+                            tool_use_id: tool_use_id.clone(),
+                            content: result.content,
+                            is_error: result.is_error,
+                        }
+                    }
                 })
                 .collect::<Vec<_>>();
             (!content.is_empty()).then(|| InputMessage {
@@ -5222,9 +5739,9 @@ fn iso8601_timestamp() -> String {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn execute_powershell(input: PowerShellInput) -> std::io::Result<runtime::BashCommandOutput> {
+fn execute_powershell(input: PowerShellInput) -> std::io::Result<PowerShellCommandOutput> {
     let _ = &input.description;
-    if let Some(output) = workspace_test_branch_preflight(&input.command) {
+    if let Some(output) = powershell_test_branch_preflight(&input.command) {
         return Ok(output);
     }
     let shell = detect_powershell_shell()?;
@@ -5317,33 +5834,33 @@ fn execute_shell_command(
     command: &str,
     timeout: Option<u64>,
     run_in_background: Option<bool>,
-) -> std::io::Result<runtime::BashCommandOutput> {
+) -> std::io::Result<PowerShellCommandOutput> {
+    let cwd = std::env::current_dir()?;
+
     if run_in_background.unwrap_or(false) {
-        let child = std::process::Command::new(shell)
+        let background_output = prepare_background_shell_output(&cwd, "powershell")?;
+        std::process::Command::new(shell)
             .arg("-NoProfile")
             .arg("-NonInteractive")
             .arg("-Command")
             .arg(command)
+            .current_dir(&cwd)
             .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .stdout(background_output.stdout)
+            .stderr(background_output.stderr)
             .spawn()?;
-        return Ok(runtime::BashCommandOutput {
+        return Ok(PowerShellCommandOutput {
             stdout: String::new(),
             stderr: String::new(),
-            raw_output_path: None,
             interrupted: false,
             is_image: None,
-            background_task_id: Some(child.id().to_string()),
-            backgrounded_by_user: Some(true),
-            assistant_auto_backgrounded: Some(false),
-            dangerously_disable_sandbox: None,
+            background_task_id: Some(background_output.task_id),
+            backgrounded_by_user: None,
+            assistant_auto_backgrounded: None,
             return_code_interpretation: None,
-            no_output_expected: Some(true),
-            structured_content: None,
             persisted_output_path: None,
             persisted_output_size: None,
-            sandbox_status: None,
+            structured_content: None,
         });
     }
 
@@ -5353,6 +5870,7 @@ fn execute_shell_command(
         .arg("-NonInteractive")
         .arg("-Command")
         .arg(command);
+    process.current_dir(&cwd);
     process
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
@@ -5363,25 +5881,27 @@ fn execute_shell_command(
         loop {
             if let Some(status) = child.try_wait()? {
                 let output = child.wait_with_output()?;
-                return Ok(runtime::BashCommandOutput {
-                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                    raw_output_path: None,
+                let prepared_output = prepare_shell_command_output(
+                    &cwd,
+                    "powershell",
+                    &output.stdout,
+                    &output.stderr,
+                );
+                return Ok(PowerShellCommandOutput {
+                    stdout: prepared_output.stdout,
+                    stderr: prepared_output.stderr,
                     interrupted: false,
                     is_image: None,
                     background_task_id: None,
                     backgrounded_by_user: None,
                     assistant_auto_backgrounded: None,
-                    dangerously_disable_sandbox: None,
                     return_code_interpretation: status
                         .code()
                         .filter(|code| *code != 0)
                         .map(|code| format!("exit_code:{code}")),
-                    no_output_expected: Some(output.stdout.is_empty() && output.stderr.is_empty()),
+                    persisted_output_path: prepared_output.persisted_output_path,
+                    persisted_output_size: prepared_output.persisted_output_size,
                     structured_content: None,
-                    persisted_output_path: None,
-                    persisted_output_size: None,
-                    sandbox_status: None,
                 });
             }
             if started.elapsed() >= Duration::from_millis(timeout_ms) {
@@ -5397,22 +5917,24 @@ Command exceeded timeout of {timeout_ms} ms",
                         stderr.trim_end()
                     )
                 };
-                return Ok(runtime::BashCommandOutput {
-                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                    stderr,
-                    raw_output_path: None,
+                let prepared_output = prepare_shell_command_output(
+                    &cwd,
+                    "powershell",
+                    &output.stdout,
+                    stderr.as_bytes(),
+                );
+                return Ok(PowerShellCommandOutput {
+                    stdout: prepared_output.stdout,
+                    stderr: prepared_output.stderr,
                     interrupted: true,
                     is_image: None,
                     background_task_id: None,
                     backgrounded_by_user: None,
                     assistant_auto_backgrounded: None,
-                    dangerously_disable_sandbox: None,
                     return_code_interpretation: Some(String::from("timeout")),
-                    no_output_expected: Some(false),
+                    persisted_output_path: prepared_output.persisted_output_path,
+                    persisted_output_size: prepared_output.persisted_output_size,
                     structured_content: None,
-                    persisted_output_path: None,
-                    persisted_output_size: None,
-                    sandbox_status: None,
                 });
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -5420,26 +5942,24 @@ Command exceeded timeout of {timeout_ms} ms",
     }
 
     let output = process.output()?;
-    Ok(runtime::BashCommandOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        raw_output_path: None,
+    let prepared_output =
+        prepare_shell_command_output(&cwd, "powershell", &output.stdout, &output.stderr);
+    Ok(PowerShellCommandOutput {
+        stdout: prepared_output.stdout,
+        stderr: prepared_output.stderr,
         interrupted: false,
         is_image: None,
         background_task_id: None,
         backgrounded_by_user: None,
         assistant_auto_backgrounded: None,
-        dangerously_disable_sandbox: None,
         return_code_interpretation: output
             .status
             .code()
             .filter(|code| *code != 0)
             .map(|code| format!("exit_code:{code}")),
-        no_output_expected: Some(output.stdout.is_empty() && output.stderr.is_empty()),
+        persisted_output_path: prepared_output.persisted_output_path,
+        persisted_output_size: prepared_output.persisted_output_size,
         structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
-        sandbox_status: None,
     })
 }
 
@@ -5519,16 +6039,18 @@ mod tests {
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, classify_lane_failure,
         derive_agent_state, execute_agent_with_spawn, execute_tool, final_assistant_text,
-        maybe_commit_provenance, mvp_tool_specs, permission_mode_from_plugin,
-        persist_agent_terminal_state, push_output_block, run_task_packet, AgentInput, AgentJob,
-        GlobalToolRegistry, LaneEventName, LaneFailureClass, ProviderRuntimeClient,
+        maybe_commit_provenance, model_visible_tool_result, mvp_tool_specs,
+        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
+        run_task_packet, AgentInput, AgentJob, GlobalToolRegistry, LaneEventName, LaneFailureClass,
+        ModelVisibleToolResult, PowerShellCommandOutput, ProviderRuntimeClient,
         SubagentToolExecutor,
     };
-    use api::OutputContentBlock;
+    use api::{OutputContentBlock, ToolResultContentBlock};
     use runtime::ProviderFallbackConfig;
     use runtime::{
-        permission_enforcer::PermissionEnforcer, ApiRequest, AssistantEvent, ConversationRuntime,
-        PermissionMode, PermissionPolicy, RuntimeError, Session, TaskPacket, ToolExecutor,
+        permission_enforcer::PermissionEnforcer, ApiRequest, AssistantEvent, BashCommandOutput,
+        ConversationRuntime, PermissionMode, PermissionPolicy, RuntimeError, Session, TaskPacket,
+        ToolExecutor,
     };
     use serde_json::json;
 
@@ -5553,6 +6075,227 @@ mod tests {
         assert!(poisoned.is_err(), "poisoning thread should panic");
 
         let _guard = env_guard();
+    }
+
+    fn bash_output(
+        stdout: &str,
+        stderr: &str,
+        interrupted: bool,
+        structured_content: Option<Vec<serde_json::Value>>,
+    ) -> BashCommandOutput {
+        BashCommandOutput {
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            raw_output_path: None,
+            interrupted,
+            is_image: None,
+            background_task_id: None,
+            backgrounded_by_user: None,
+            assistant_auto_backgrounded: None,
+            dangerously_disable_sandbox: None,
+            return_code_interpretation: None,
+            no_output_expected: None,
+            structured_content,
+            persisted_output_path: None,
+            persisted_output_size: None,
+            sandbox_status: None,
+        }
+    }
+
+    fn powershell_output(stdout: &str, stderr: &str, interrupted: bool) -> PowerShellCommandOutput {
+        PowerShellCommandOutput {
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            interrupted,
+            return_code_interpretation: None,
+            is_image: None,
+            persisted_output_path: None,
+            persisted_output_size: None,
+            background_task_id: None,
+            backgrounded_by_user: None,
+            assistant_auto_backgrounded: None,
+            structured_content: None,
+        }
+    }
+
+    fn shell_model_result<T: serde::Serialize>(
+        output: &T,
+        tool_name: &str,
+    ) -> ModelVisibleToolResult {
+        let serialized = serde_json::to_string_pretty(output).expect("serialize shell output");
+        model_visible_tool_result(tool_name, &serialized, false)
+    }
+
+    #[test]
+    fn model_visible_tool_result_wraps_shell_stdout_and_stderr() {
+        let output = bash_output("\n\nhello\n", "warning\n", false, None);
+        let result = shell_model_result(&output, "bash");
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "hello\nwarning".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_wraps_persisted_output_for_shell_tools() {
+        let mut output = bash_output("\npreview line\n", "", false, None);
+        output.persisted_output_path = Some("C:\\temp\\bash-output.txt".to_string());
+        output.persisted_output_size = Some(4_096);
+
+        let result = shell_model_result(&output, "PowerShell");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert!(text.starts_with("<persisted-output>\n"));
+        assert!(text
+            .contains("Output too large (4KB). Full output saved to: C:\\temp\\bash-output.txt"));
+        assert!(text.contains("Preview (first 2KB):\npreview line\n</persisted-output>"));
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn model_visible_tool_result_preserves_structured_content_blocks() {
+        let output = bash_output(
+            "",
+            "",
+            false,
+            Some(vec![json!("note"), json!({ "ok": true })]),
+        );
+        let result = shell_model_result(&output, "bash");
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![
+                    ToolResultContentBlock::Text {
+                        text: "note".to_string(),
+                    },
+                    ToolResultContentBlock::Json {
+                        value: json!({ "ok": true }),
+                    },
+                ],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_parses_shell_json_prefix_before_hook_feedback() {
+        let serialized = serde_json::to_string_pretty(&bash_output("hello\n", "", false, None))
+            .expect("serialize shell output");
+        let output = format!("{serialized}\n\nHook feedback:\nreview me");
+
+        let result = model_visible_tool_result("bash", &output, false);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "hello\n\nHook feedback:\nreview me".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_falls_back_to_raw_text_when_shell_output_is_not_json() {
+        let result = model_visible_tool_result("bash", "not json", true);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "not json".to_string(),
+                }],
+                is_error: true,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_marks_interrupted_shell_output_as_error() {
+        let output = bash_output("partial", "timeout reached", true, None);
+        let result = shell_model_result(&output, "PowerShell");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert!(text.contains("partial"));
+        assert!(text.contains("timeout reached"));
+        assert!(text.contains("<error>Command was aborted before completion</error>"));
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn model_visible_tool_result_uses_generic_background_message_for_explicit_backgrounding() {
+        let mut output = bash_output("", "", false, None);
+        output.background_task_id = Some("b1234xyz".to_string());
+        output.raw_output_path = Some(
+            "C:\\temp\\.claw\\sessions\\workspace\\session\\tasks\\b1234xyz.output".to_string(),
+        );
+
+        let result = shell_model_result(&output, "bash");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert_eq!(
+            text,
+            "Command running in background with ID: b1234xyz. Output is being written to: C:\\temp\\.claw\\sessions\\workspace\\session\\tasks\\b1234xyz.output"
+        );
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn model_visible_tool_result_derives_powershell_background_output_path_from_task_id() {
+        let mut output = powershell_output("", "", false);
+        output.background_task_id = Some("b1234xyz".to_string());
+
+        let result = shell_model_result(&output, "PowerShell");
+        let expected_path = super::derive_background_output_path("b1234xyz")
+            .expect("background output path should resolve");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert_eq!(
+            text.as_str(),
+            format!(
+                "Command running in background with ID: b1234xyz. Output is being written to: {expected_path}"
+            )
+        );
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn model_visible_tool_result_matches_ts_autobackground_message() {
+        let mut output = powershell_output("", "", false);
+        output.background_task_id = Some("babc1234".to_string());
+        output.assistant_auto_backgrounded = Some(true);
+
+        let result = shell_model_result(&output, "PowerShell");
+        let expected_path = super::derive_background_output_path("babc1234")
+            .expect("background output path should resolve");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert!(text.contains(
+            "Command exceeded the assistant-mode blocking budget (15s) and was moved to the background with ID: babc1234."
+        ));
+        assert!(text.contains("It is still running - you will be notified when it completes."));
+        assert!(text.contains(&format!("Output is being written to: {expected_path}.")));
+        assert!(text.contains(
+            "In assistant mode, delegate long-running work to a subagent or use run_in_background to keep this conversation responsive."
+        ));
     }
 
     fn temp_path(name: &str) -> PathBuf {
@@ -7776,6 +8519,8 @@ mod tests {
         .expect("bash background should succeed");
         let background_output: serde_json::Value = serde_json::from_str(&background).expect("json");
         assert!(background_output["backgroundTaskId"].as_str().is_some());
+        assert!(background_output["rawOutputPath"].as_str().is_some());
+        assert!(background_output["backgroundedByUser"].is_null());
         assert_eq!(background_output["noOutputExpected"], true);
     }
 
@@ -7858,6 +8603,45 @@ mod tests {
             output_json["returnCodeInterpretation"],
             "preflight_blocked:branch_divergence"
         );
+
+        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn powershell_workspace_tests_are_blocked_without_structured_content() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let root = temp_path("powershell-workspace-test-preflight");
+        let original_dir = std::env::current_dir().expect("cwd");
+        init_git_repo(&root);
+        run_git(&root, &["checkout", "-b", "feature/stale-powershell-tests"]);
+        run_git(&root, &["checkout", "main"]);
+        commit_file(
+            &root,
+            "hotfix.txt",
+            "fix from main\n",
+            "fix: unblock powershell workspace tests",
+        );
+        run_git(&root, &["checkout", "feature/stale-powershell-tests"]);
+        std::env::set_current_dir(&root).expect("set cwd");
+
+        let output = execute_tool(
+            "PowerShell",
+            &json!({ "command": "cargo test --workspace --all-targets" }),
+        )
+        .expect("preflight should return structured output");
+        let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+        assert_eq!(
+            output_json["returnCodeInterpretation"],
+            "preflight_blocked:branch_divergence"
+        );
+        assert!(output_json["stderr"]
+            .as_str()
+            .expect("stderr")
+            .contains("branch divergence detected before workspace tests"));
+        assert!(output_json.get("structuredContent").is_none());
 
         std::env::set_current_dir(&original_dir).expect("restore cwd");
         let _ = std::fs::remove_dir_all(root);
@@ -8449,11 +9233,15 @@ printf 'pwsh:%s' "$1"
         let output: serde_json::Value = serde_json::from_str(&result).expect("json");
         assert_eq!(output["stdout"], "pwsh:Write-Output hello");
         assert!(output["stderr"].as_str().expect("stderr").is_empty());
+        assert!(output.get("rawOutputPath").is_none());
+        assert!(output.get("noOutputExpected").is_none());
 
         let background_output: serde_json::Value = serde_json::from_str(&background).expect("json");
         assert!(background_output["backgroundTaskId"].as_str().is_some());
-        assert_eq!(background_output["backgroundedByUser"], true);
-        assert_eq!(background_output["assistantAutoBackgrounded"], false);
+        assert!(background_output.get("rawOutputPath").is_none());
+        assert!(background_output.get("noOutputExpected").is_none());
+        assert!(background_output["backgroundedByUser"].is_null());
+        assert!(background_output["assistantAutoBackgrounded"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

This PR brings the Rust shell tools closer to the original TS behavior for both execution artifacts and model-visible tool results.

- adds a model-visible wrapper layer for `bash` and `PowerShell` tool results instead of exposing raw JSON directly to the model
- stores shell artifacts under session-scoped directories so concurrent agents do not share `.claw/tasks` and `.claw/tool-results`
- aligns shell background task naming, persisted output previews, and background messaging with the TS implementation more closely
- gives `PowerShell` its own output schema and preflight handling so it no longer leaks bash-specific fields or `structuredContent` in the branch-divergence path

## Why

The Rust implementation was still exposing the execution-layer JSON too directly to the model, and shell artifact storage was shared across sessions. That made the behavior diverge from the TS original and created collision risk when multiple agents were active in the same workspace.

## Impact

Agents now see shell results through a TS-style wrapper, while the runtime still keeps structured JSON internally. Shell background logs and persisted large outputs are isolated per session under `.claw/sessions/<workspace>/<session-id>/...`, which makes parallel agent work safer and easier to reason about.

## Root cause

The Rust port had collapsed the execution-layer and model-visible layers together for shell tools, and it was writing shell artifacts to shared workspace-level directories instead of session-scoped paths.

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
