### PR TITLE
[codex] Continue TS parity migration in Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -112,9 +112,11 @@ dependencies = [
 name = "commands"
 version = "0.1.0"
 dependencies = [
+ "api",
  "plugins",
  "runtime",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/crates/commands/Cargo.toml
+++ b/rust/crates/commands/Cargo.toml
@@ -9,6 +9,8 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+api = { path = "../api" }
 plugins = { path = "../plugins" }
 runtime = { path = "../runtime" }
 serde_json.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -5,10 +5,19 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use plugins::{PluginError, PluginManager, PluginSummary};
+use api::{
+    max_tokens_for_model, resolve_model_alias, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, PromptCache, ProviderClient, ProviderKind,
+    ProviderOverride, ToolResultContentBlock,
+};
+use plugins::{
+    PluginError, PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry, PluginSummary,
+};
 use runtime::{
-    compact_session, CompactionConfig, ConfigLoader, ConfigSource, McpOAuthConfig, McpServerConfig,
-    ScopedMcpServerConfig, Session,
+    load_system_prompt, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
+    ConversationMessage, ConversationRuntime, McpOAuthConfig, McpServerConfig, MessageRole,
+    PermissionMode, PermissionPolicy, RuntimeConfig, RuntimeFeatureConfig, RuntimeHookConfig,
+    RuntimeProviderConfig, RuntimeProviderKind, ScopedMcpServerConfig, Session, StaticToolExecutor,
 };
 use serde_json::{json, Value};
 
@@ -56,6 +65,9 @@ pub enum SkillSlashDispatch {
     Local,
     Invoke(String),
 }
+
+const DEFAULT_DATE: &str = "2026-03-31";
+const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
 const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
     SlashCommandSpec {
@@ -3785,12 +3797,295 @@ fn mcp_server_json(name: &str, server: &ScopedMcpServerConfig) -> Value {
         "details": mcp_server_details_json(&server.config),
     })
 }
-#[must_use]
-pub fn handle_slash_command(
+
+struct InitializedPluginRegistry {
+    registry: PluginRegistry,
+}
+
+impl InitializedPluginRegistry {
+    fn new(registry: PluginRegistry) -> Result<Self, String> {
+        registry.initialize().map_err(|error| error.to_string())?;
+        Ok(Self { registry })
+    }
+
+    fn aggregated_hooks(&self) -> Result<PluginHooks, String> {
+        self.registry
+            .aggregated_hooks()
+            .map_err(|error| error.to_string())
+    }
+}
+
+impl Drop for InitializedPluginRegistry {
+    fn drop(&mut self) {
+        let _ = self.registry.shutdown();
+    }
+}
+
+struct CompactApiClient {
+    runtime: tokio::runtime::Runtime,
+    client: ProviderClient,
+    model: String,
+}
+
+impl CompactApiClient {
+    fn new(client: ProviderClient, model: String) -> Result<Self, String> {
+        Ok(Self {
+            runtime: tokio::runtime::Runtime::new().map_err(|error| error.to_string())?,
+            client,
+            model,
+        })
+    }
+}
+
+impl runtime::ApiClient for CompactApiClient {
+    fn stream(
+        &mut self,
+        request: runtime::ApiRequest,
+    ) -> Result<Vec<AssistantEvent>, runtime::RuntimeError> {
+        let message_request = MessageRequest {
+            model: self.model.clone(),
+            max_tokens: max_tokens_for_model(&self.model),
+            messages: convert_compact_messages(&request.messages),
+            system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
+            stream: false,
+            ..Default::default()
+        };
+        let response = self
+            .runtime
+            .block_on(self.client.send_message(&message_request))
+            .map_err(|error| runtime::RuntimeError::new(error.to_string()))?;
+        Ok(message_response_to_assistant_events(response))
+    }
+}
+
+fn message_response_to_assistant_events(response: MessageResponse) -> Vec<AssistantEvent> {
+    let mut events = Vec::new();
+    for block in response.content {
+        match block {
+            OutputContentBlock::Text { text } => events.push(AssistantEvent::TextDelta(text)),
+            OutputContentBlock::ToolUse { id, name, input } => {
+                events.push(AssistantEvent::ToolUse {
+                    id,
+                    name,
+                    input: serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string()),
+                });
+            }
+            OutputContentBlock::Thinking { .. } | OutputContentBlock::RedactedThinking { .. } => {}
+        }
+    }
+    let usage = response.usage.token_usage();
+    if usage.total_tokens() > 0 {
+        events.push(AssistantEvent::Usage(usage));
+    }
+    events.push(AssistantEvent::MessageStop);
+    events
+}
+
+fn convert_compact_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
+    messages
+        .iter()
+        .filter_map(|message| {
+            let role = match message.role {
+                MessageRole::System | MessageRole::User | MessageRole::Tool => "user",
+                MessageRole::Assistant => "assistant",
+            };
+            let content = message
+                .blocks
+                .iter()
+                .map(|block| match block {
+                    runtime::ContentBlock::Text { text } => {
+                        InputContentBlock::Text { text: text.clone() }
+                    }
+                    runtime::ContentBlock::ToolUse { id, name, input } => {
+                        InputContentBlock::ToolUse {
+                            id: id.clone(),
+                            name: name.clone(),
+                            input: serde_json::from_str(input)
+                                .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
+                        }
+                    }
+                    runtime::ContentBlock::ToolResult {
+                        tool_use_id,
+                        output,
+                        is_error,
+                        ..
+                    } => InputContentBlock::ToolResult {
+                        tool_use_id: tool_use_id.clone(),
+                        content: vec![ToolResultContentBlock::Text {
+                            text: output.clone(),
+                        }],
+                        is_error: *is_error,
+                    },
+                })
+                .collect::<Vec<_>>();
+            (!content.is_empty()).then(|| InputMessage {
+                role: role.to_string(),
+                content,
+            })
+        })
+        .collect()
+}
+
+fn resolve_compact_model(config: &RuntimeConfig) -> String {
+    let configured_model = env::var("ANTHROPIC_MODEL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| config.model().map(ToOwned::to_owned))
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    let aliased = config
+        .aliases()
+        .get(configured_model.trim())
+        .cloned()
+        .unwrap_or(configured_model);
+    resolve_model_alias(&aliased).clone()
+}
+
+fn provider_override_from_runtime_config(config: &RuntimeProviderConfig) -> ProviderOverride {
+    ProviderOverride {
+        provider: match config.provider() {
+            RuntimeProviderKind::Anthropic => ProviderKind::Anthropic,
+            RuntimeProviderKind::OpenAi => ProviderKind::OpenAi,
+            RuntimeProviderKind::Xai => ProviderKind::Xai,
+        },
+        base_url: config.base_url().map(ToOwned::to_owned),
+        api_key_env: config.api_key_env().map(ToOwned::to_owned),
+        auth_token_env: config.auth_token_env().map(ToOwned::to_owned),
+    }
+}
+
+fn runtime_hook_config_from_plugin_hooks(hooks: PluginHooks) -> RuntimeHookConfig {
+    RuntimeHookConfig::new(
+        hooks.pre_tool_use,
+        hooks.post_tool_use,
+        hooks.post_tool_use_failure,
+    )
+    .with_pre_compact(hooks.pre_compact)
+    .with_post_compact(hooks.post_compact)
+    .with_session_start(hooks.session_start)
+}
+
+fn resolve_plugin_path(cwd: &Path, config_home: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else if value.starts_with('.') {
+        cwd.join(path)
+    } else {
+        config_home.join(path)
+    }
+}
+
+fn build_plugin_manager(
+    cwd: &Path,
+    loader: &ConfigLoader,
+    runtime_config: &RuntimeConfig,
+) -> PluginManager {
+    let plugin_settings = runtime_config.plugins();
+    let mut plugin_config = PluginManagerConfig::new(loader.config_home().to_path_buf());
+    plugin_config.enabled_plugins = plugin_settings.enabled_plugins().clone();
+    plugin_config.external_dirs = plugin_settings
+        .external_directories()
+        .iter()
+        .map(|path| resolve_plugin_path(cwd, loader.config_home(), path))
+        .collect();
+    plugin_config.install_root = plugin_settings
+        .install_root()
+        .map(|path| resolve_plugin_path(cwd, loader.config_home(), path));
+    plugin_config.registry_path = plugin_settings
+        .registry_path()
+        .map(|path| resolve_plugin_path(cwd, loader.config_home(), path));
+    plugin_config.bundled_root = plugin_settings
+        .bundled_root()
+        .map(|path| resolve_plugin_path(cwd, loader.config_home(), path));
+    PluginManager::new(plugin_config)
+}
+
+fn build_full_compact_feature_config(
+    cwd: &Path,
+    loader: &ConfigLoader,
+    runtime_config: &RuntimeConfig,
+) -> Result<(RuntimeFeatureConfig, InitializedPluginRegistry), String> {
+    let plugin_registry = InitializedPluginRegistry::new(
+        build_plugin_manager(cwd, loader, runtime_config)
+            .plugin_registry()
+            .map_err(|error| error.to_string())?,
+    )?;
+    let plugin_hook_config =
+        runtime_hook_config_from_plugin_hooks(plugin_registry.aggregated_hooks()?);
+    let feature_config = runtime_config
+        .feature_config()
+        .clone()
+        .with_hooks(runtime_config.hooks().merged(&plugin_hook_config));
+    Ok((feature_config, plugin_registry))
+}
+
+fn run_full_compact(
+    session: &Session,
+    compaction: CompactionConfig,
+) -> Result<runtime::CompactionResult, String> {
+    let cwd = env::current_dir().map_err(|error| error.to_string())?;
+    let loader = ConfigLoader::default_for(&cwd);
+    let runtime_config = loader.load().map_err(|error| error.to_string())?;
+    let system_prompt = load_system_prompt(cwd.clone(), DEFAULT_DATE, env::consts::OS, "unknown")
+        .map_err(|error| error.to_string())?;
+    let model = resolve_compact_model(&runtime_config);
+    let provider_override = runtime_config
+        .provider()
+        .map(provider_override_from_runtime_config);
+    let client =
+        ProviderClient::from_model_with_provider_override(&model, provider_override.as_ref())
+            .map_err(|error| error.to_string())?
+            .with_prompt_cache(PromptCache::new(&session.session_id));
+    let compact_client = CompactApiClient::new(client, model)?;
+    let (feature_config, _plugin_registry) =
+        build_full_compact_feature_config(&cwd, &loader, &runtime_config)?;
+    let mut runtime = ConversationRuntime::new_with_features(
+        session.clone(),
+        compact_client,
+        StaticToolExecutor::new(),
+        PermissionPolicy::new(PermissionMode::DangerFullAccess),
+        system_prompt,
+        &feature_config,
+    );
+    runtime
+        .compact(compaction)
+        .map_err(|error| error.to_string())
+}
+
+fn format_compact_result_message(
+    result: &runtime::CompactionResult,
+    fallback_label: &str,
+) -> String {
+    let mut message = if result.removed_message_count == 0 {
+        "Compaction skipped: session is below the compaction threshold.".to_string()
+    } else {
+        format!(
+            "{fallback_label} {} messages.",
+            result.removed_message_count
+        )
+    };
+    if let Some(display) = result
+        .user_display_message
+        .as_deref()
+        .map(str::trim)
+        .filter(|display| !display.is_empty())
+    {
+        message.push('\n');
+        message.push_str(display);
+    }
+    message
+}
+
+pub fn handle_slash_command_with_compactor<F>(
     input: &str,
     session: &Session,
     compaction: CompactionConfig,
-) -> Option<SlashCommandResult> {
+    compact_with_runtime: &mut F,
+) -> Option<SlashCommandResult>
+where
+    F: FnMut(&Session, CompactionConfig) -> Result<runtime::CompactionResult, String>,
+{
     let command = match SlashCommand::parse(input) {
         Ok(Some(command)) => command,
         Ok(None) => return None,
@@ -3803,21 +4098,19 @@ pub fn handle_slash_command(
     };
 
     match command {
-        SlashCommand::Compact => {
-            let result = compact_session(session, compaction);
-            let message = if result.removed_message_count == 0 {
-                "Compaction skipped: session is below the compaction threshold.".to_string()
-            } else {
-                format!(
-                    "Compacted {} messages into a resumable system summary.",
-                    result.removed_message_count
-                )
-            };
-            Some(SlashCommandResult {
-                message,
+        SlashCommand::Compact => match compact_with_runtime(session, compaction) {
+            Ok(result) => Some(SlashCommandResult {
+                message: format_compact_result_message(
+                    &result,
+                    "Compacted session with full compact summary for",
+                ),
                 session: result.compacted_session,
-            })
-        }
+            }),
+            Err(error) => Some(SlashCommandResult {
+                message: format!("Compaction failed: {error}"),
+                session: session.clone(),
+            }),
+        },
         SlashCommand::Help => Some(SlashCommandResult {
             message: render_slash_command_help(),
             session: session.clone(),
@@ -3892,21 +4185,31 @@ pub fn handle_slash_command(
     }
 }
 
+#[must_use]
+pub fn handle_slash_command(
+    input: &str,
+    session: &Session,
+    compaction: CompactionConfig,
+) -> Option<SlashCommandResult> {
+    handle_slash_command_with_compactor(input, session, compaction, &mut run_full_compact)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         classify_skills_slash_command, handle_agents_slash_command_json,
         handle_plugins_slash_command, handle_skills_slash_command_json, handle_slash_command,
-        load_agents_from_roots, load_skills_from_roots, render_agents_report,
-        render_agents_report_json, render_mcp_report_json_for, render_plugins_report,
-        render_skills_report, render_slash_command_help, render_slash_command_help_detail,
-        resolve_skill_path, resume_supported_slash_commands, slash_command_specs,
-        suggest_slash_commands, validate_slash_command_input, DefinitionSource, SkillOrigin,
-        SkillRoot, SkillSlashDispatch, SlashCommand,
+        handle_slash_command_with_compactor, load_agents_from_roots, load_skills_from_roots,
+        render_agents_report, render_agents_report_json, render_mcp_report_json_for,
+        render_plugins_report, render_skills_report, render_slash_command_help,
+        render_slash_command_help_detail, resolve_skill_path, resume_supported_slash_commands,
+        slash_command_specs, suggest_slash_commands, validate_slash_command_input,
+        DefinitionSource, SkillOrigin, SkillRoot, SkillSlashDispatch, SlashCommand,
     };
     use plugins::{PluginKind, PluginManager, PluginManagerConfig, PluginMetadata, PluginSummary};
     use runtime::{
-        CompactionConfig, ConfigLoader, ContentBlock, ConversationMessage, MessageRole, Session,
+        CompactBoundaryMetadata, CompactTrigger, CompactionConfig, CompactionResult, ConfigLoader,
+        ContentBlock, ConversationMessage, MessageRole, Session,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -4670,17 +4973,47 @@ mod tests {
             }]),
         ];
 
-        let result = handle_slash_command(
+        let mut compacted_session = session.clone();
+        compacted_session.messages = vec![
+            ConversationMessage::compact_boundary(CompactBoundaryMetadata {
+                trigger: CompactTrigger::Manual,
+                pre_tokens: 321,
+                user_context: None,
+                messages_summarized: Some(2),
+                pre_compact_discovered_tools: vec!["bash".to_string()],
+                preserved_segment: None,
+            }),
+            ConversationMessage::compact_summary_user_text(
+                "This session is being continued from a previous conversation.\nSummary:\nCarry over context.",
+                true,
+            ),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "recent".to_string(),
+            }]),
+        ];
+
+        let result = handle_slash_command_with_compactor(
             "/compact",
             &session,
             CompactionConfig {
                 preserve_recent_messages: 2,
                 max_estimated_tokens: 1,
             },
+            &mut |input_session, _compaction| {
+                assert_eq!(input_session.messages.len(), 4);
+                Ok(CompactionResult {
+                    summary: "Carry over context.".to_string(),
+                    formatted_summary: "formatted".to_string(),
+                    compacted_session: compacted_session.clone(),
+                    removed_message_count: 2,
+                    user_display_message: Some("post compact note".to_string()),
+                })
+            },
         )
         .expect("slash command should be handled");
 
-        assert!(result.message.contains("Compacted 2 messages"));
+        assert!(result.message.contains("full compact summary"));
+        assert!(result.message.contains("post compact note"));
         assert_eq!(result.session.messages[0].role, MessageRole::System);
     }
 

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -1103,7 +1103,40 @@ fn extract_num_matches(tool_output: &str) -> usize {
     serde_json::from_str::<Value>(tool_output)
         .ok()
         .and_then(|value| value.get("numMatches").and_then(Value::as_u64))
-        .unwrap_or(0) as usize
+        .map(|count| count as usize)
+        .or_else(|| {
+            tool_output.lines().find_map(|line| {
+                let trimmed = line.trim();
+                let remainder = trimmed.strip_prefix("Found ")?;
+                let digit_len = remainder.chars().take_while(char::is_ascii_digit).count();
+                if digit_len == 0 {
+                    return None;
+                }
+
+                let (digits, suffix) = remainder.split_at(digit_len);
+                suffix
+                    .starts_with(" total occurrence")
+                    .then(|| digits.parse::<usize>().ok())
+                    .flatten()
+            })
+        })
+        .or_else(|| {
+            let total = tool_output
+                .lines()
+                .filter_map(|line| {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        return None;
+                    }
+
+                    trimmed
+                        .rsplit_once(':')
+                        .and_then(|(_, count)| count.parse::<usize>().ok())
+                })
+                .sum::<usize>();
+            (total > 0).then_some(total)
+        })
+        .unwrap_or(0)
 }
 
 fn extract_file_path(tool_output: &str) -> String {
@@ -1141,4 +1174,26 @@ fn extract_plugin_message(tool_output: &str) -> String {
                 .map(ToOwned::to_owned)
         })
         .unwrap_or_else(|| tool_output.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_num_matches;
+
+    #[test]
+    fn extract_num_matches_reads_json_output() {
+        assert_eq!(extract_num_matches(r#"{"numMatches":2}"#), 2);
+    }
+
+    #[test]
+    fn extract_num_matches_reads_ts_count_wrapper_summary() {
+        let output = "fixture.txt:2\n\nFound 2 total occurrences across 1 file.";
+        assert_eq!(extract_num_matches(output), 2);
+    }
+
+    #[test]
+    fn extract_num_matches_falls_back_to_count_lines() {
+        let output = "fixture.txt:2\nnested/notes.txt:1";
+        assert_eq!(extract_num_matches(output), 3);
+    }
 }

--- a/rust/crates/plugins/src/hooks.rs
+++ b/rust/crates/plugins/src/hooks.rs
@@ -11,6 +11,9 @@ pub enum HookEvent {
     PreToolUse,
     PostToolUse,
     PostToolUseFailure,
+    PreCompact,
+    PostCompact,
+    SessionStart,
 }
 
 impl HookEvent {
@@ -19,6 +22,9 @@ impl HookEvent {
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
             Self::PostToolUseFailure => "PostToolUseFailure",
+            Self::PreCompact => "PreCompact",
+            Self::PostCompact => "PostCompact",
+            Self::SessionStart => "SessionStart",
         }
     }
 }
@@ -54,6 +60,43 @@ impl HookRunResult {
     pub fn messages(&self) -> &[String] {
         &self.messages
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PreCompactHookResult {
+    new_custom_instructions: Option<String>,
+    user_display_message: Option<String>,
+}
+
+impl PreCompactHookResult {
+    #[must_use]
+    pub fn new_custom_instructions(&self) -> Option<&str> {
+        self.new_custom_instructions.as_deref()
+    }
+
+    #[must_use]
+    pub fn user_display_message(&self) -> Option<&str> {
+        self.user_display_message.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PostCompactHookResult {
+    user_display_message: Option<String>,
+}
+
+impl PostCompactHookResult {
+    #[must_use]
+    pub fn user_display_message(&self) -> Option<&str> {
+        self.user_display_message.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ContextHookCommandResult {
+    command: String,
+    succeeded: bool,
+    output: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -118,6 +161,47 @@ impl HookRunner {
         )
     }
 
+    #[must_use]
+    pub fn run_pre_compact(
+        &self,
+        trigger: &str,
+        custom_instructions: Option<&str>,
+    ) -> PreCompactHookResult {
+        let command_results = Self::run_contextual_commands(
+            HookEvent::PreCompact,
+            &self.hooks.pre_compact,
+            "compact",
+            &hook_pre_compact_payload(trigger, custom_instructions).to_string(),
+            |child| {
+                child.env("HOOK_TRIGGER", trigger);
+                if let Some(custom_instructions) = custom_instructions {
+                    child.env("HOOK_CUSTOM_INSTRUCTIONS", custom_instructions);
+                }
+            },
+        );
+        build_pre_compact_hook_result(&command_results)
+    }
+
+    #[must_use]
+    pub fn run_post_compact(&self, trigger: &str, compact_summary: &str) -> PostCompactHookResult {
+        let command_results = Self::run_contextual_commands(
+            HookEvent::PostCompact,
+            &self.hooks.post_compact,
+            "compact",
+            &hook_post_compact_payload(trigger, compact_summary).to_string(),
+            |child| {
+                child.env("HOOK_TRIGGER", trigger);
+                child.env("HOOK_COMPACT_SUMMARY", compact_summary);
+            },
+        );
+        build_post_compact_hook_result(&command_results)
+    }
+
+    #[must_use]
+    pub fn run_session_start(&self, source: &str, model: Option<&str>) -> HookRunResult {
+        Self::run_session_start_commands(&self.hooks.session_start, source, model)
+    }
+
     fn run_commands(
         event: HookEvent,
         commands: &[String],
@@ -153,6 +237,73 @@ impl HookRunner {
                     messages.push(message.unwrap_or_else(|| {
                         format!("{} hook denied tool `{tool_name}`", event.as_str())
                     }));
+                    return HookRunResult {
+                        denied: true,
+                        failed: false,
+                        messages,
+                    };
+                }
+                HookCommandOutcome::Failed { message } => {
+                    messages.push(message);
+                    return HookRunResult {
+                        denied: false,
+                        failed: true,
+                        messages,
+                    };
+                }
+            }
+        }
+
+        HookRunResult::allow(messages)
+    }
+
+    fn run_contextual_commands<F>(
+        event: HookEvent,
+        commands: &[String],
+        context_name: &str,
+        payload: &str,
+        mut configure_env: F,
+    ) -> Vec<ContextHookCommandResult>
+    where
+        F: FnMut(&mut CommandWithStdin),
+    {
+        commands
+            .iter()
+            .map(|command| {
+                Self::run_contextual_command(
+                    command,
+                    event,
+                    context_name,
+                    payload,
+                    &mut configure_env,
+                )
+            })
+            .collect()
+    }
+
+    fn run_session_start_commands(
+        commands: &[String],
+        source: &str,
+        model: Option<&str>,
+    ) -> HookRunResult {
+        if commands.is_empty() {
+            return HookRunResult::allow(Vec::new());
+        }
+
+        let payload = hook_session_start_payload(source, model).to_string();
+        let mut messages = Vec::new();
+
+        for command in commands {
+            match Self::run_session_start_command(command, source, model, &payload) {
+                HookCommandOutcome::Allow { message } => {
+                    if let Some(message) = message {
+                        messages.push(message);
+                    }
+                }
+                HookCommandOutcome::Deny { message } => {
+                    messages.push(
+                        message.unwrap_or_else(|| format!("SessionStart hook denied `{source}`")),
+                    );
                     return HookRunResult {
                         denied: true,
                         failed: false,
@@ -237,6 +388,137 @@ impl HookRunner {
             },
         }
     }
+
+    fn run_session_start_command(
+        command: &str,
+        source: &str,
+        model: Option<&str>,
+        payload: &str,
+    ) -> HookCommandOutcome {
+        let mut child = match shell_command(command) {
+            Ok(child) => child,
+            Err(error) => {
+                return HookCommandOutcome::Failed {
+                    message: format!(
+                        "SessionStart hook `{command}` failed to start for `{source}`: {error}"
+                    ),
+                };
+            }
+        };
+        child.stdin(std::process::Stdio::piped());
+        child.stdout(std::process::Stdio::piped());
+        child.stderr(std::process::Stdio::piped());
+        child.env("HOOK_EVENT", HookEvent::SessionStart.as_str());
+        child.env("HOOK_SESSION_SOURCE", source);
+        if let Some(model) = model {
+            child.env("HOOK_MODEL", model);
+        }
+
+        match child.output_with_stdin(payload.as_bytes()) {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let message = (!stdout.is_empty()).then_some(stdout);
+                match output.status.code() {
+                    Some(0) => HookCommandOutcome::Allow { message },
+                    Some(2) => HookCommandOutcome::Deny { message },
+                    Some(code) => HookCommandOutcome::Failed {
+                        message: format_hook_warning(
+                            command,
+                            code,
+                            message.as_deref(),
+                            stderr.as_str(),
+                        ),
+                    },
+                    None => HookCommandOutcome::Failed {
+                        message: format!(
+                            "SessionStart hook `{command}` terminated by signal while handling `{source}`"
+                        ),
+                    },
+                }
+            }
+            Err(error) => HookCommandOutcome::Failed {
+                message: format!(
+                    "SessionStart hook `{command}` failed to start for `{source}`: {error}"
+                ),
+            },
+        }
+    }
+
+    fn run_contextual_command<F>(
+        command: &str,
+        event: HookEvent,
+        context_name: &str,
+        payload: &str,
+        configure_env: &mut F,
+    ) -> ContextHookCommandResult
+    where
+        F: FnMut(&mut CommandWithStdin),
+    {
+        let mut child = match shell_command(command) {
+            Ok(child) => child,
+            Err(error) => {
+                return ContextHookCommandResult {
+                    command: command.to_string(),
+                    succeeded: false,
+                    output: format!(
+                        "{} hook `{command}` failed to start for `{context_name}`: {error}",
+                        event.as_str()
+                    ),
+                };
+            }
+        };
+        child.stdin(std::process::Stdio::piped());
+        child.stdout(std::process::Stdio::piped());
+        child.stderr(std::process::Stdio::piped());
+        child.env("HOOK_EVENT", event.as_str());
+        configure_env(&mut child);
+
+        match child.output_with_stdin(payload.as_bytes()) {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let rendered = if stdout.is_empty() {
+                    stderr.clone()
+                } else {
+                    stdout.clone()
+                };
+                match output.status.code() {
+                    Some(0) => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: true,
+                        output: rendered,
+                    },
+                    Some(code) => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: false,
+                        output: format_hook_warning(
+                            command,
+                            code,
+                            (!rendered.is_empty()).then_some(rendered.as_str()),
+                            stderr.as_str(),
+                        ),
+                    },
+                    None => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: false,
+                        output: format!(
+                            "{} hook `{command}` terminated by signal while handling `{context_name}`",
+                            event.as_str()
+                        ),
+                    },
+                }
+            }
+            Err(error) => ContextHookCommandResult {
+                command: command.to_string(),
+                succeeded: false,
+                output: format!(
+                    "{} hook `{command}` failed to start for `{context_name}`: {error}",
+                    event.as_str()
+                ),
+            },
+        }
+    }
 }
 
 enum HookCommandOutcome {
@@ -272,6 +554,30 @@ fn hook_payload(
     }
 }
 
+fn hook_session_start_payload(source: &str, model: Option<&str>) -> serde_json::Value {
+    json!({
+        "hook_event_name": HookEvent::SessionStart.as_str(),
+        "session_source": source,
+        "model": model,
+    })
+}
+
+fn hook_pre_compact_payload(trigger: &str, custom_instructions: Option<&str>) -> serde_json::Value {
+    json!({
+        "hook_event_name": HookEvent::PreCompact.as_str(),
+        "trigger": trigger,
+        "custom_instructions": custom_instructions,
+    })
+}
+
+fn hook_post_compact_payload(trigger: &str, compact_summary: &str) -> serde_json::Value {
+    json!({
+        "hook_event_name": HookEvent::PostCompact.as_str(),
+        "trigger": trigger,
+        "compact_summary": compact_summary,
+    })
+}
+
 fn parse_tool_input(tool_input: &str) -> serde_json::Value {
     serde_json::from_str(tool_input).unwrap_or_else(|_| json!({ "raw": tool_input }))
 }
@@ -286,6 +592,92 @@ fn format_hook_warning(command: &str, code: i32, stdout: Option<&str>, stderr: &
         message.push_str(stderr);
     }
     message
+}
+
+fn build_pre_compact_hook_result(
+    command_results: &[ContextHookCommandResult],
+) -> PreCompactHookResult {
+    if command_results.is_empty() {
+        return PreCompactHookResult::default();
+    }
+
+    let new_custom_instructions = command_results
+        .iter()
+        .filter(|result| result.succeeded)
+        .map(|result| result.output.trim())
+        .filter(|output| !output.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let user_display_message = command_results
+        .iter()
+        .map(|result| {
+            if result.succeeded {
+                if result.output.trim().is_empty() {
+                    format!("PreCompact [{}] completed successfully", result.command)
+                } else {
+                    format!(
+                        "PreCompact [{}] completed successfully: {}",
+                        result.command,
+                        result.output.trim()
+                    )
+                }
+            } else if result.output.trim().is_empty() {
+                format!("PreCompact [{}] failed", result.command)
+            } else {
+                format!(
+                    "PreCompact [{}] failed: {}",
+                    result.command,
+                    result.output.trim()
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    PreCompactHookResult {
+        new_custom_instructions: (!new_custom_instructions.is_empty())
+            .then_some(new_custom_instructions),
+        user_display_message: (!user_display_message.is_empty()).then_some(user_display_message),
+    }
+}
+
+fn build_post_compact_hook_result(
+    command_results: &[ContextHookCommandResult],
+) -> PostCompactHookResult {
+    if command_results.is_empty() {
+        return PostCompactHookResult::default();
+    }
+
+    let user_display_message = command_results
+        .iter()
+        .map(|result| {
+            if result.succeeded {
+                if result.output.trim().is_empty() {
+                    format!("PostCompact [{}] completed successfully", result.command)
+                } else {
+                    format!(
+                        "PostCompact [{}] completed successfully: {}",
+                        result.command,
+                        result.output.trim()
+                    )
+                }
+            } else if result.output.trim().is_empty() {
+                format!("PostCompact [{}] failed", result.command)
+            } else {
+                format!(
+                    "PostCompact [{}] failed: {}",
+                    result.command,
+                    result.output.trim()
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    PostCompactHookResult {
+        user_display_message: (!user_display_message.is_empty()).then_some(user_display_message),
+    }
 }
 
 fn shell_command(command: &str) -> std::io::Result<CommandWithStdin> {
@@ -347,6 +739,16 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    #[derive(Clone, Copy)]
+    struct HookPluginMessages<'a> {
+        pre: &'a str,
+        post: &'a str,
+        failure: &'a str,
+        pre_compact: &'a str,
+        post_compact: &'a str,
+        session: &'a str,
+    }
+
     fn temp_dir(label: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -368,36 +770,51 @@ mod tests {
         let _ = path;
     }
 
-    fn write_hook_plugin(
-        root: &Path,
-        name: &str,
-        pre_message: &str,
-        post_message: &str,
-        failure_message: &str,
-    ) {
+    fn write_hook_plugin(root: &Path, name: &str, messages: HookPluginMessages<'_>) {
         fs::create_dir_all(root.join(".claude-plugin")).expect("manifest dir");
         fs::create_dir_all(root.join("hooks")).expect("hooks dir");
         let pre_hook = hook_script_name("pre");
         let post_hook = hook_script_name("post");
         let pre_path = root.join("hooks").join(&pre_hook);
-        fs::write(&pre_path, hook_script_contents(pre_message)).expect("write pre hook");
+        fs::write(&pre_path, hook_script_contents(messages.pre)).expect("write pre hook");
         make_executable(&pre_path);
 
         let post_path = root.join("hooks").join(&post_hook);
-        fs::write(&post_path, hook_script_contents(post_message)).expect("write post hook");
+        fs::write(&post_path, hook_script_contents(messages.post)).expect("write post hook");
         make_executable(&post_path);
 
         let failure_path = root.join("hooks").join("failure.sh");
         fs::write(
             &failure_path,
-            format!("#!/bin/sh\nprintf '%s\\n' '{failure_message}'\n"),
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", messages.failure),
         )
         .expect("write failure hook");
         make_executable(&failure_path);
+        let pre_compact_path = root.join("hooks").join("pre-compact.sh");
+        fs::write(
+            &pre_compact_path,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", messages.pre_compact),
+        )
+        .expect("write pre-compact hook");
+        make_executable(&pre_compact_path);
+        let post_compact_path = root.join("hooks").join("post-compact.sh");
+        fs::write(
+            &post_compact_path,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", messages.post_compact),
+        )
+        .expect("write post-compact hook");
+        make_executable(&post_compact_path);
+        let session_path = root.join("hooks").join("session.sh");
+        fs::write(
+            &session_path,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", messages.session),
+        )
+        .expect("write session hook");
+        make_executable(&session_path);
         fs::write(
             root.join(".claude-plugin").join("plugin.json"),
             format!(
-                "{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\",\n  \"description\": \"hook plugin\",\n  \"hooks\": {{\n    \"PreToolUse\": [\"./hooks/{pre_hook}\"],\n    \"PostToolUse\": [\"./hooks/{post_hook}\"],\n    \"PostToolUseFailure\": [\"./hooks/failure.sh\"]\n  }}\n}}"
+                "{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\",\n  \"description\": \"hook plugin\",\n  \"hooks\": {{\n    \"PreToolUse\": [\"./hooks/{pre_hook}\"],\n    \"PostToolUse\": [\"./hooks/{post_hook}\"],\n    \"PostToolUseFailure\": [\"./hooks/failure.sh\"],\n    \"PreCompact\": [\"./hooks/pre-compact.sh\"],\n    \"PostCompact\": [\"./hooks/post-compact.sh\"],\n    \"SessionStart\": [\"./hooks/session.sh\"]\n  }}\n}}"
             ),
         )
         .expect("write plugin manifest");
@@ -415,16 +832,26 @@ mod tests {
         write_hook_plugin(
             &first_source_root,
             "first",
-            "plugin pre one",
-            "plugin post one",
-            "plugin failure one",
+            HookPluginMessages {
+                pre: "plugin pre one",
+                post: "plugin post one",
+                failure: "plugin failure one",
+                pre_compact: "plugin pre compact one",
+                post_compact: "plugin post compact one",
+                session: "plugin session one",
+            },
         );
         write_hook_plugin(
             &second_source_root,
             "second",
-            "plugin pre two",
-            "plugin post two",
-            "plugin failure two",
+            HookPluginMessages {
+                pre: "plugin pre two",
+                post: "plugin post two",
+                failure: "plugin failure two",
+                pre_compact: "plugin pre compact two",
+                post_compact: "plugin post compact two",
+                session: "plugin session two",
+            },
         );
 
         let mut manager = PluginManager::new(PluginManagerConfig::new(&config_home));
@@ -461,6 +888,25 @@ mod tests {
                 "plugin failure two".to_string(),
             ])
         );
+        assert_eq!(
+            runner.run_session_start("compact", Some("claude-opus-4-6")),
+            HookRunResult::allow(vec![
+                "plugin session one".to_string(),
+                "plugin session two".to_string(),
+            ])
+        );
+        assert_eq!(
+            runner
+                .run_pre_compact("manual", None)
+                .new_custom_instructions(),
+            Some("plugin pre compact one\n\nplugin pre compact two")
+        );
+        let post_compact = runner.run_post_compact("manual", "summary");
+        let post_compact_display = post_compact
+            .user_display_message()
+            .expect("post-compact display");
+        assert!(post_compact_display.contains("plugin post compact one"));
+        assert!(post_compact_display.contains("plugin post compact two"));
 
         let _ = fs::remove_dir_all(config_home);
         let _ = fs::remove_dir_all(first_source_root);
@@ -477,6 +923,9 @@ mod tests {
             pre_tool_use: vec![shell_echo_and_exit("blocked by plugin", 2)],
             post_tool_use: Vec::new(),
             post_tool_use_failure: Vec::new(),
+            pre_compact: Vec::new(),
+            post_compact: Vec::new(),
+            session_start: Vec::new(),
         });
 
         // when
@@ -500,6 +949,9 @@ mod tests {
             ],
             post_tool_use: Vec::new(),
             post_tool_use_failure: Vec::new(),
+            pre_compact: Vec::new(),
+            post_compact: Vec::new(),
+            session_start: Vec::new(),
         });
 
         // when
@@ -523,9 +975,27 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let root = temp_dir("exec-guard");
-        write_hook_plugin(&root, "exec-check", "pre", "post", "fail");
+        write_hook_plugin(
+            &root,
+            "exec-check",
+            HookPluginMessages {
+                pre: "pre",
+                post: "post",
+                failure: "fail",
+                pre_compact: "pre compact",
+                post_compact: "post compact",
+                session: "session",
+            },
+        );
 
-        for script in ["pre.sh", "post.sh", "failure.sh"] {
+        for script in [
+            "pre.sh",
+            "post.sh",
+            "failure.sh",
+            "pre-compact.sh",
+            "post-compact.sh",
+            "session.sh",
+        ] {
             let path = root.join("hooks").join(script);
             let mode = fs::metadata(&path)
                 .unwrap_or_else(|error| panic!("{script} metadata: {error}"))

--- a/rust/crates/plugins/src/lib.rs
+++ b/rust/crates/plugins/src/lib.rs
@@ -71,6 +71,12 @@ pub struct PluginHooks {
     pub post_tool_use: Vec<String>,
     #[serde(rename = "PostToolUseFailure", default)]
     pub post_tool_use_failure: Vec<String>,
+    #[serde(rename = "PreCompact", default)]
+    pub pre_compact: Vec<String>,
+    #[serde(rename = "PostCompact", default)]
+    pub post_compact: Vec<String>,
+    #[serde(rename = "SessionStart", default)]
+    pub session_start: Vec<String>,
 }
 
 impl PluginHooks {
@@ -79,6 +85,9 @@ impl PluginHooks {
         self.pre_tool_use.is_empty()
             && self.post_tool_use.is_empty()
             && self.post_tool_use_failure.is_empty()
+            && self.pre_compact.is_empty()
+            && self.post_compact.is_empty()
+            && self.session_start.is_empty()
     }
 
     #[must_use]
@@ -93,6 +102,13 @@ impl PluginHooks {
         merged
             .post_tool_use_failure
             .extend(other.post_tool_use_failure.iter().cloned());
+        merged.pre_compact.extend(other.pre_compact.iter().cloned());
+        merged
+            .post_compact
+            .extend(other.post_compact.iter().cloned());
+        merged
+            .session_start
+            .extend(other.session_start.iter().cloned());
         merged
     }
 }
@@ -1897,6 +1913,21 @@ fn resolve_hooks(root: &Path, hooks: &PluginHooks) -> PluginHooks {
             .iter()
             .map(|entry| resolve_hook_entry(root, entry))
             .collect(),
+        pre_compact: hooks
+            .pre_compact
+            .iter()
+            .map(|entry| resolve_hook_entry(root, entry))
+            .collect(),
+        post_compact: hooks
+            .post_compact
+            .iter()
+            .map(|entry| resolve_hook_entry(root, entry))
+            .collect(),
+        session_start: hooks
+            .session_start
+            .iter()
+            .map(|entry| resolve_hook_entry(root, entry))
+            .collect(),
     }
 }
 
@@ -1950,6 +1981,9 @@ fn validate_hook_paths(root: Option<&Path>, hooks: &PluginHooks) -> Result<(), P
         .iter()
         .chain(hooks.post_tool_use.iter())
         .chain(hooks.post_tool_use_failure.iter())
+        .chain(hooks.pre_compact.iter())
+        .chain(hooks.post_compact.iter())
+        .chain(hooks.session_start.iter())
     {
         validate_command_path(root, entry, "hook")?;
     }

--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -15,15 +15,12 @@ use crate::sandbox::{
     build_linux_sandbox_command, resolve_sandbox_status_for_request, FilesystemIsolationMode,
     SandboxConfig, SandboxStatus,
 };
-use crate::tool_session::current_tool_session_storage_root;
+use crate::tool_output::{task_outputs_dir, tool_results_dir};
 #[cfg(windows)]
 use crate::windows_path_to_posix_path;
 use crate::{bash_shell_path, ConfigLoader};
 
 static SHELL_OUTPUT_COUNTER: AtomicU64 = AtomicU64::new(0);
-const CLAW_STATE_DIR: &str = ".claw";
-const TOOL_RESULTS_DIR: &str = "tool-results";
-const TASK_OUTPUTS_DIR: &str = "tasks";
 const MAX_PERSISTED_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
 const SHELL_TASK_ID_ALPHABET: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 
@@ -270,21 +267,9 @@ fn persist_stdout_for_model(cwd: &Path, stdout: &[u8]) -> io::Result<PersistedSh
     })
 }
 
-fn tool_results_dir(cwd: &Path) -> PathBuf {
-    shell_output_root(cwd).join(TOOL_RESULTS_DIR)
-}
-
-fn task_outputs_dir(cwd: &Path) -> PathBuf {
-    shell_output_root(cwd).join(TASK_OUTPUTS_DIR)
-}
-
 #[must_use]
 pub fn shell_task_output_path(cwd: &Path, task_id: &str) -> PathBuf {
     task_outputs_dir(cwd).join(format!("{task_id}.output"))
-}
-
-fn shell_output_root(cwd: &Path) -> PathBuf {
-    current_tool_session_storage_root(cwd).unwrap_or_else(|| cwd.join(CLAW_STATE_DIR))
 }
 
 fn next_shell_task_id() -> String {

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -1,8 +1,105 @@
-use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+
+use crate::session::{
+    AttachmentKind, CompactBoundaryMetadata, CompactPreservedSegment, CompactTrigger, ContentBlock,
+    ConversationMessage, MessageRole, Session,
+};
+
+const NO_TOOLS_PREAMBLE: &str = r"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
+
+- Do NOT use Read, Bash, Grep, Glob, Edit, Write, or any other tool.
+- You already have all the context you need in the conversation above.
+- Tool calls will be rejected and will waste your only turn.
+- Your entire response must be plain text: an <analysis> block followed by a <summary> block.
+
+";
+const NO_TOOLS_TRAILER: &str = "\n\nREMINDER: Do NOT call any tools. Respond with plain text only - an <analysis> block followed by a <summary> block. Tool calls will be rejected and you will fail the task.";
+const DETAILED_ANALYSIS_INSTRUCTION_BASE: &str = r"Before providing your final summary, wrap your analysis in <analysis> tags to organize your thoughts and ensure you've covered all necessary points. In your analysis process:
+
+1. Chronologically analyze each message and section of the conversation. For each section thoroughly identify:
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions, technical concepts, and code patterns
+   - Specific details like:
+     - file names
+     - full code snippets
+     - function signatures
+     - file edits
+   - Errors that you ran into and how you fixed them
+   - Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+2. Double-check for technical accuracy and completeness, addressing each required element thoroughly.";
+const BASE_COMPACT_PROMPT: &str = r"Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
+This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context.
+
+{analysis_instruction}
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: Capture all of the user's explicit requests and intents in detail
+2. Key Technical Concepts: List all important technical concepts, technologies, and frameworks discussed.
+3. Files and Code Sections: Enumerate specific files and code sections examined, modified, or created. Pay special attention to the most recent messages and include full code snippets where applicable and a summary of why each file read or edit is important.
+4. Errors and fixes: List all errors that you ran into, and how you fixed them. Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+5. Problem Solving: Document problems solved and any ongoing troubleshooting efforts.
+6. All user messages: List all user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+7. Pending Tasks: Outline any pending tasks that you have explicitly been asked to work on.
+8. Current Work: Describe in detail precisely what was being worked on immediately before this summary request, paying special attention to the most recent messages from both user and assistant. Include file names and code snippets where applicable.
+9. Optional Next Step: List the next step that you will take that is related to the most recent work you were doing. Ensure that this step is directly in line with the user's most recent explicit requests and the task you were working on immediately before this summary request. If there is a next step, include direct quotes from the most recent conversation showing exactly what task you were working on and where you left off.
+
+Use this exact output structure:
+
+<analysis>
+[your drafting analysis]
+</analysis>
+
+<summary>
+1. Primary Request and Intent:
+   [Detailed description]
+
+2. Key Technical Concepts:
+   - [Concept 1]
+   - [Concept 2]
+
+3. Files and Code Sections:
+   - [File Name 1]
+     - [Why it matters]
+     - [Changes made]
+     - [Important snippet]
+
+4. Errors and fixes:
+   - [Error description]
+     - [How you fixed it]
+     - [Relevant user feedback]
+
+5. Problem Solving:
+   [Description]
+
+6. All user messages:
+   - [Detailed non-tool user message]
+
+7. Pending Tasks:
+   - [Task 1]
+
+8. Current Work:
+   [Precise description of current work]
+
+9. Optional Next Step:
+   [Optional next step]
+</summary>
+
+Please provide your summary based on the conversation so far, following this structure and ensuring precision and thoroughness in your response.
+
+There may be additional summarization instructions provided in the included context. If so, remember to follow them when creating the summary.";
 
 const COMPACT_CONTINUATION_PREAMBLE: &str =
     "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\n";
 const COMPACT_RECENT_MESSAGES_NOTE: &str = "Recent messages are preserved verbatim.";
+const COMPACT_BOUNDARY_TEXT: &str = "Conversation compacted";
 const COMPACT_DIRECT_RESUME_INSTRUCTION: &str = "Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, and do not preface with continuation text.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,6 +123,110 @@ pub struct CompactionResult {
     pub formatted_summary: String,
     pub compacted_session: Session,
     pub removed_message_count: usize,
+    pub user_display_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompactionLayout {
+    LegacyResumableSummary,
+    TsBoundaryAndSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreservedSegmentAnchor {
+    LastSummaryMessage,
+}
+
+struct CompactedMessageOptions<'a> {
+    summary: &'a str,
+    post_compact_context_messages: Vec<ConversationMessage>,
+    hook_result_messages: Vec<ConversationMessage>,
+    preserved_messages: Vec<ConversationMessage>,
+    preserved_segment_anchor: Option<PreservedSegmentAnchor>,
+    suppress_follow_up_questions: bool,
+    layout: CompactionLayout,
+    boundary_trigger: Option<CompactTrigger>,
+    pre_tokens: usize,
+    removed_message_count: usize,
+    source_messages: &'a [ConversationMessage],
+}
+
+pub(crate) struct BuildCompactionResultOptions {
+    pub preserved_messages: Vec<ConversationMessage>,
+    pub hook_result_messages: Vec<ConversationMessage>,
+    pub preserved_segment_anchor: Option<PreservedSegmentAnchor>,
+    pub removed_message_count: usize,
+    pub suppress_follow_up_questions: bool,
+    pub layout: CompactionLayout,
+    pub boundary_trigger: Option<CompactTrigger>,
+    pub user_display_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FullCompactSelection {
+    pub messages_to_summarize: Vec<ConversationMessage>,
+    pub preserved_messages: Vec<ConversationMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompactTodoItem {
+    content: String,
+    #[serde(rename = "activeForm")]
+    active_form: String,
+    status: CompactTodoStatus,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CompactTodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl CompactTodoStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CompactSkillOutput {
+    skill: String,
+    path: String,
+    args: Option<String>,
+    description: Option<String>,
+    prompt: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompactPlanModeOutput {
+    active: bool,
+    managed: bool,
+    message: String,
+    #[serde(rename = "settingsPath")]
+    settings_path: String,
+    #[serde(rename = "statePath")]
+    state_path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CompactAgentOutput {
+    #[serde(rename = "agentId")]
+    agent_id: String,
+    name: String,
+    description: String,
+    status: String,
+    #[serde(rename = "outputFile")]
+    output_file: String,
+    #[serde(rename = "manifestFile")]
+    manifest_file: String,
+    #[serde(rename = "derivedState")]
+    derived_state: String,
 }
 
 #[must_use]
@@ -62,6 +263,26 @@ pub fn format_compact_summary(summary: &str) -> String {
 }
 
 #[must_use]
+/// Builds the TS-style full compact prompt for a text-only summarization turn.
+pub fn get_compact_prompt(custom_instructions: Option<&str>) -> String {
+    let mut prompt = NO_TOOLS_PREAMBLE.to_string();
+    prompt.push_str(
+        &BASE_COMPACT_PROMPT.replace("{analysis_instruction}", DETAILED_ANALYSIS_INSTRUCTION_BASE),
+    );
+
+    if let Some(instructions) = custom_instructions
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        prompt.push_str("\n\nAdditional Instructions:\n");
+        prompt.push_str(instructions);
+    }
+
+    prompt.push_str(NO_TOOLS_TRAILER);
+    prompt
+}
+
+#[must_use]
 pub fn get_compact_continuation_message(
     summary: &str,
     suppress_follow_up_questions: bool,
@@ -86,6 +307,416 @@ pub fn get_compact_continuation_message(
 }
 
 #[must_use]
+pub fn get_compact_user_summary_message(
+    summary: &str,
+    suppress_follow_up_questions: bool,
+    recent_messages_preserved: bool,
+) -> String {
+    let mut base = format!(
+        "{COMPACT_CONTINUATION_PREAMBLE}{}",
+        format_compact_summary(summary)
+    );
+
+    if recent_messages_preserved {
+        base.push_str("\n\n");
+        base.push_str(COMPACT_RECENT_MESSAGES_NOTE);
+    }
+
+    if suppress_follow_up_questions {
+        base.push('\n');
+        base.push_str(COMPACT_DIRECT_RESUME_INSTRUCTION);
+    }
+
+    base
+}
+
+fn build_compacted_messages(options: CompactedMessageOptions<'_>) -> Vec<ConversationMessage> {
+    let CompactedMessageOptions {
+        summary,
+        post_compact_context_messages,
+        hook_result_messages,
+        preserved_messages,
+        preserved_segment_anchor,
+        suppress_follow_up_questions,
+        layout,
+        boundary_trigger,
+        pre_tokens,
+        removed_message_count,
+        source_messages,
+    } = options;
+
+    let recent_messages_preserved = !preserved_messages.is_empty();
+    let mut compacted_messages = match layout {
+        CompactionLayout::LegacyResumableSummary => vec![ConversationMessage::system_text(
+            get_compact_continuation_message(
+                summary,
+                suppress_follow_up_questions,
+                recent_messages_preserved,
+            ),
+        )],
+        CompactionLayout::TsBoundaryAndSummary => vec![
+            build_ts_compact_boundary_message(
+                boundary_trigger.unwrap_or(CompactTrigger::Manual),
+                pre_tokens,
+                removed_message_count,
+                source_messages,
+                &preserved_messages,
+                preserved_segment_anchor,
+            ),
+            ConversationMessage::compact_summary_user_text(
+                get_compact_user_summary_message(
+                    summary,
+                    suppress_follow_up_questions,
+                    recent_messages_preserved,
+                ),
+                !recent_messages_preserved,
+            ),
+        ],
+    };
+    compacted_messages.extend(preserved_messages);
+    compacted_messages.extend(post_compact_context_messages);
+    compacted_messages.extend(hook_result_messages);
+    compacted_messages
+}
+
+fn build_ts_compact_boundary_message(
+    trigger: CompactTrigger,
+    pre_tokens: usize,
+    removed_message_count: usize,
+    source_messages: &[ConversationMessage],
+    preserved_messages: &[ConversationMessage],
+    preserved_segment_anchor: Option<PreservedSegmentAnchor>,
+) -> ConversationMessage {
+    ConversationMessage::compact_boundary(CompactBoundaryMetadata {
+        trigger,
+        pre_tokens,
+        user_context: None,
+        messages_summarized: Some(removed_message_count),
+        pre_compact_discovered_tools: collect_discovered_tools(source_messages),
+        preserved_segment: build_preserved_segment_metadata(
+            source_messages.len(),
+            preserved_messages.len(),
+            preserved_segment_anchor,
+        ),
+    })
+}
+
+fn build_preserved_segment_metadata(
+    source_message_count: usize,
+    preserved_message_count: usize,
+    anchor: Option<PreservedSegmentAnchor>,
+) -> Option<CompactPreservedSegment> {
+    if preserved_message_count == 0 || preserved_message_count > source_message_count {
+        return None;
+    }
+
+    let head_index = source_message_count - preserved_message_count;
+    let tail_index = source_message_count - 1;
+    Some(CompactPreservedSegment {
+        // Rust sessions do not yet persist TS-style message UUID chains. We
+        // still record stable synthetic anchors here so suffix-preserving
+        // compaction metadata is available now and can be upgraded later.
+        head: format!("source-message-{head_index}"),
+        anchor: match anchor.unwrap_or(PreservedSegmentAnchor::LastSummaryMessage) {
+            PreservedSegmentAnchor::LastSummaryMessage => "summary-message".to_string(),
+        },
+        tail: format!("source-message-{tail_index}"),
+    })
+}
+
+/// Rewrites a session into its post-compaction form.
+pub(crate) fn build_compaction_result(
+    session: &Session,
+    summary: String,
+    options: BuildCompactionResultOptions,
+) -> CompactionResult {
+    let BuildCompactionResultOptions {
+        preserved_messages,
+        hook_result_messages,
+        preserved_segment_anchor,
+        removed_message_count,
+        suppress_follow_up_questions,
+        layout,
+        boundary_trigger,
+        user_display_message,
+    } = options;
+    let formatted_summary = format_compact_summary(&summary);
+    let pre_tokens = estimate_session_tokens(session);
+    let post_compact_context_messages = match layout {
+        CompactionLayout::LegacyResumableSummary => Vec::new(),
+        CompactionLayout::TsBoundaryAndSummary => collect_post_compact_context_messages(session),
+    };
+    let compacted_messages = build_compacted_messages(CompactedMessageOptions {
+        summary: &summary,
+        post_compact_context_messages,
+        hook_result_messages,
+        preserved_messages,
+        preserved_segment_anchor,
+        suppress_follow_up_questions,
+        layout,
+        boundary_trigger,
+        pre_tokens,
+        removed_message_count,
+        source_messages: &session.messages,
+    });
+
+    let mut compacted_session = session.clone();
+    compacted_session.messages = compacted_messages;
+    compacted_session.record_compaction(summary.clone(), removed_message_count);
+
+    CompactionResult {
+        summary,
+        formatted_summary,
+        compacted_session,
+        removed_message_count,
+        user_display_message,
+    }
+}
+
+#[must_use]
+pub(crate) fn select_full_compact_messages(
+    session: &Session,
+    preserve_recent_messages: usize,
+) -> FullCompactSelection {
+    if preserve_recent_messages == 0 {
+        return FullCompactSelection {
+            messages_to_summarize: session.messages.clone(),
+            preserved_messages: Vec::new(),
+        };
+    }
+
+    let compacted_prefix_len = compacted_summary_prefix_len(session);
+    let keep_from = session
+        .messages
+        .len()
+        .saturating_sub(preserve_recent_messages)
+        .max(compacted_prefix_len);
+
+    FullCompactSelection {
+        messages_to_summarize: session.messages[..keep_from].to_vec(),
+        preserved_messages: session.messages[keep_from..].to_vec(),
+    }
+}
+
+fn collect_post_compact_context_messages(session: &Session) -> Vec<ConversationMessage> {
+    let mut messages = Vec::new();
+
+    if let Some(running_agents) = create_running_agents_context_message(&session.messages) {
+        messages.push(running_agents);
+    }
+    if let Some(todo_list) = create_todo_context_message(session) {
+        messages.push(todo_list);
+    }
+    if let Some(plan_mode) = create_plan_mode_context_message(&session.messages) {
+        messages.push(plan_mode);
+    }
+    if let Some(skills) = create_invoked_skills_context_message(&session.messages) {
+        messages.push(skills);
+    }
+
+    messages
+}
+
+fn create_running_agents_context_message(
+    messages: &[ConversationMessage],
+) -> Option<ConversationMessage> {
+    let mut latest_agents = BTreeMap::new();
+    for output in successful_tool_outputs(messages, "Agent") {
+        let Some(parsed) = parse_tool_result_json_prefix::<CompactAgentOutput>(output) else {
+            continue;
+        };
+        let refreshed = refresh_agent_manifest(&parsed).unwrap_or(parsed);
+        latest_agents.insert(refreshed.agent_id.clone(), refreshed);
+    }
+
+    let running_agents = latest_agents
+        .into_values()
+        .filter(|agent| agent.status.eq_ignore_ascii_case("running"))
+        .collect::<Vec<_>>();
+    if running_agents.is_empty() {
+        return None;
+    }
+
+    let mut content = String::from(
+        "Background agents are still active after compaction. Avoid spawning duplicate agents unless the user explicitly asks.",
+    );
+    for agent in running_agents {
+        let _ = write!(
+            content,
+            "\n- `{}` (`{}`): {}",
+            agent.name,
+            agent.agent_id,
+            agent.description.trim()
+        );
+        let _ = write!(content, "\n  Status: {}", agent.status);
+        if !agent.derived_state.trim().is_empty() {
+            let _ = write!(content, "\n  Derived state: {}", agent.derived_state.trim());
+        }
+        let _ = write!(content, "\n  Output file: {}", agent.output_file);
+    }
+
+    Some(ConversationMessage::attachment_user_text(
+        content,
+        AttachmentKind::RunningAgents,
+    ))
+}
+
+fn refresh_agent_manifest(agent: &CompactAgentOutput) -> Option<CompactAgentOutput> {
+    let manifest = fs::read_to_string(&agent.manifest_file).ok()?;
+    serde_json::from_str(&manifest).ok()
+}
+
+fn create_todo_context_message(session: &Session) -> Option<ConversationMessage> {
+    let todo_store_path = todo_store_path_for_session(session)?;
+    let contents = fs::read_to_string(&todo_store_path).ok()?;
+    let todos = serde_json::from_str::<Vec<CompactTodoItem>>(&contents).ok()?;
+    if todos.is_empty() {
+        return None;
+    }
+
+    let mut content = format!(
+        "Current TodoWrite task list remains active after compaction.\nSource: {}",
+        todo_store_path.display()
+    );
+    for todo in todos {
+        let _ = write!(
+            content,
+            "\n- [{}] {} (active form: {})",
+            todo.status.label(),
+            todo.content.trim(),
+            todo.active_form.trim()
+        );
+    }
+
+    Some(ConversationMessage::attachment_user_text(
+        content,
+        AttachmentKind::TodoList,
+    ))
+}
+
+fn todo_store_path_for_session(session: &Session) -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CLAWD_TODO_STORE") {
+        return Some(PathBuf::from(path));
+    }
+
+    if let Some(workspace_root) = session.workspace_root() {
+        return Some(workspace_root.join(".clawd-todos.json"));
+    }
+
+    session
+        .persistence_path()
+        .and_then(|_| std::env::current_dir().ok())
+        .map(|cwd| cwd.join(".clawd-todos.json"))
+}
+
+fn create_plan_mode_context_message(
+    messages: &[ConversationMessage],
+) -> Option<ConversationMessage> {
+    let latest_state = messages
+        .iter()
+        .rev()
+        .flat_map(|message| message.blocks.iter().rev())
+        .find_map(|block| match block {
+            ContentBlock::ToolResult {
+                tool_name,
+                output,
+                is_error,
+                ..
+            } if !*is_error && matches!(tool_name.as_str(), "EnterPlanMode" | "ExitPlanMode") => {
+                parse_tool_result_json_prefix::<CompactPlanModeOutput>(output)
+            }
+            ContentBlock::Text { .. }
+            | ContentBlock::ToolUse { .. }
+            | ContentBlock::ToolResult { .. } => None,
+        })?;
+
+    if !latest_state.active {
+        return None;
+    }
+
+    let managed_text = if latest_state.managed {
+        "The override is still managed by EnterPlanMode."
+    } else {
+        "The worktree is still in local plan mode."
+    };
+    Some(ConversationMessage::attachment_user_text(
+        format!(
+            "Plan mode is still active for this worktree after compaction.\n{managed_text}\nLast plan-mode message: {}\nSettings path: {}\nState path: {}\nContinue exploring and planning until the user explicitly approves implementation.",
+            latest_state.message.trim(),
+            latest_state.settings_path,
+            latest_state.state_path
+        ),
+        AttachmentKind::PlanMode,
+    ))
+}
+
+fn create_invoked_skills_context_message(
+    messages: &[ConversationMessage],
+) -> Option<ConversationMessage> {
+    let mut skills = BTreeMap::new();
+    for output in successful_tool_outputs(messages, "Skill") {
+        let Some(parsed) = parse_tool_result_json_prefix::<CompactSkillOutput>(output) else {
+            continue;
+        };
+        skills.insert(parsed.skill.clone(), parsed);
+    }
+
+    if skills.is_empty() {
+        return None;
+    }
+
+    let mut content = String::from("Previously invoked skills remain available after compaction.");
+    for skill in skills.into_values() {
+        let _ = write!(content, "\n\nSkill `{}`", skill.skill);
+        let _ = write!(content, "\nPath: {}", skill.path);
+        if let Some(description) = skill.description.as_deref().map(str::trim) {
+            if !description.is_empty() {
+                let _ = write!(content, "\nDescription: {description}");
+            }
+        }
+        if let Some(args) = skill.args.as_deref().map(str::trim) {
+            if !args.is_empty() {
+                let _ = write!(content, "\nArgs: {args}");
+            }
+        }
+        content.push_str("\nInstructions:\n");
+        content.push_str(skill.prompt.trim());
+    }
+
+    Some(ConversationMessage::attachment_user_text(
+        content,
+        AttachmentKind::InvokedSkills,
+    ))
+}
+
+fn successful_tool_outputs<'a>(
+    messages: &'a [ConversationMessage],
+    tool_name: &'a str,
+) -> impl Iterator<Item = &'a str> + 'a {
+    messages
+        .iter()
+        .flat_map(|message| message.blocks.iter())
+        .filter_map(move |block| match block {
+            ContentBlock::ToolResult {
+                tool_name: block_tool_name,
+                output,
+                is_error,
+                ..
+            } if !*is_error && block_tool_name == tool_name => Some(output.as_str()),
+            ContentBlock::Text { .. }
+            | ContentBlock::ToolUse { .. }
+            | ContentBlock::ToolResult { .. } => None,
+        })
+}
+
+fn parse_tool_result_json_prefix<T: DeserializeOwned>(output: &str) -> Option<T> {
+    let mut deserializer = serde_json::Deserializer::from_str(output.trim_start());
+    T::deserialize(&mut deserializer).ok()
+}
+
+#[must_use]
+/// Local heuristic compaction fallback used when a model-driven full compact
+/// is unavailable.
 pub fn compact_session(session: &Session, config: CompactionConfig) -> CompactionResult {
     if !should_compact(session, config) {
         return CompactionResult {
@@ -93,52 +724,60 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
             formatted_summary: String::new(),
             compacted_session: session.clone(),
             removed_message_count: 0,
+            user_display_message: None,
         };
     }
 
-    let existing_summary = session
-        .messages
-        .first()
-        .and_then(extract_existing_compacted_summary);
-    let compacted_prefix_len = usize::from(existing_summary.is_some());
+    let existing_summary = extract_existing_compacted_summary(&session.messages);
+    let compacted_prefix_len = existing_summary
+        .as_ref()
+        .map_or(0, |(prefix_len, _)| *prefix_len);
     let keep_from = session
         .messages
         .len()
         .saturating_sub(config.preserve_recent_messages);
     let removed = &session.messages[compacted_prefix_len..keep_from];
     let preserved = session.messages[keep_from..].to_vec();
-    let summary =
-        merge_compact_summaries(existing_summary.as_deref(), &summarize_messages(removed));
-    let formatted_summary = format_compact_summary(&summary);
-    let continuation = get_compact_continuation_message(&summary, true, !preserved.is_empty());
-
-    let mut compacted_messages = vec![ConversationMessage {
-        role: MessageRole::System,
-        blocks: vec![ContentBlock::Text { text: continuation }],
-        usage: None,
-    }];
-    compacted_messages.extend(preserved);
-
-    let mut compacted_session = session.clone();
-    compacted_session.messages = compacted_messages;
-    compacted_session.record_compaction(summary.clone(), removed.len());
-
-    CompactionResult {
+    let summary = merge_compact_summaries(
+        existing_summary
+            .as_ref()
+            .map(|(_, summary)| summary.as_str()),
+        &summarize_messages(removed),
+    );
+    build_compaction_result(
+        session,
         summary,
-        formatted_summary,
-        compacted_session,
-        removed_message_count: removed.len(),
-    }
+        BuildCompactionResultOptions {
+            preserved_messages: preserved,
+            hook_result_messages: Vec::new(),
+            preserved_segment_anchor: None,
+            removed_message_count: removed.len(),
+            suppress_follow_up_questions: true,
+            layout: CompactionLayout::LegacyResumableSummary,
+            boundary_trigger: None,
+            user_display_message: None,
+        },
+    )
 }
 
 fn compacted_summary_prefix_len(session: &Session) -> usize {
-    usize::from(
-        session
-            .messages
-            .first()
-            .and_then(extract_existing_compacted_summary)
-            .is_some(),
-    )
+    extract_existing_compacted_summary(&session.messages).map_or(0, |(prefix_len, _)| prefix_len)
+}
+
+fn collect_discovered_tools(messages: &[ConversationMessage]) -> Vec<String> {
+    let mut tool_names = messages
+        .iter()
+        .flat_map(|message| message.blocks.iter())
+        .filter_map(|block| match block {
+            ContentBlock::ToolUse { name, .. } => Some(name.as_str()),
+            ContentBlock::ToolResult { tool_name, .. } => Some(tool_name.as_str()),
+            ContentBlock::Text { .. } => None,
+        })
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    tool_names.sort_unstable();
+    tool_names.dedup();
+    tool_names
 }
 
 fn summarize_messages(messages: &[ConversationMessage]) -> String {
@@ -155,17 +794,7 @@ fn summarize_messages(messages: &[ConversationMessage]) -> String {
         .filter(|message| message.role == MessageRole::Tool)
         .count();
 
-    let mut tool_names = messages
-        .iter()
-        .flat_map(|message| message.blocks.iter())
-        .filter_map(|block| match block {
-            ContentBlock::ToolUse { name, .. } => Some(name.as_str()),
-            ContentBlock::ToolResult { tool_name, .. } => Some(tool_name.as_str()),
-            ContentBlock::Text { .. } => None,
-        })
-        .collect::<Vec<_>>();
-    tool_names.sort_unstable();
-    tool_names.dedup();
+    let tool_names = collect_discovered_tools(messages);
 
     let mut lines = vec![
         "<summary>".to_string(),
@@ -440,7 +1069,20 @@ fn collapse_blank_lines(content: &str) -> String {
     result
 }
 
-fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<String> {
+fn extract_existing_compacted_summary(messages: &[ConversationMessage]) -> Option<(usize, String)> {
+    if let Some(summary) = messages.first().and_then(extract_legacy_compacted_summary) {
+        return Some((1, summary));
+    }
+
+    match (messages.first(), messages.get(1)) {
+        (Some(boundary), Some(summary_message)) if is_compact_boundary_message(boundary) => {
+            extract_full_compact_summary(summary_message).map(|summary| (2, summary))
+        }
+        _ => None,
+    }
+}
+
+fn extract_legacy_compacted_summary(message: &ConversationMessage) -> Option<String> {
     if message.role != MessageRole::System {
         return None;
     }
@@ -454,6 +1096,31 @@ fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<S
         .split_once(&format!("\n{COMPACT_DIRECT_RESUME_INSTRUCTION}"))
         .map_or(summary, |(value, _)| value);
     Some(summary.trim().to_string())
+}
+
+fn extract_full_compact_summary(message: &ConversationMessage) -> Option<String> {
+    if message.role != MessageRole::User {
+        return None;
+    }
+
+    let text = first_text_block(message)?;
+    if !message.is_compact_summary && !text.starts_with(COMPACT_CONTINUATION_PREAMBLE) {
+        return None;
+    }
+    let summary = text.strip_prefix(COMPACT_CONTINUATION_PREAMBLE)?;
+    let summary = summary
+        .split_once(&format!("\n\n{COMPACT_RECENT_MESSAGES_NOTE}"))
+        .map_or(summary, |(value, _)| value);
+    let summary = summary
+        .split_once(&format!("\n{COMPACT_DIRECT_RESUME_INSTRUCTION}"))
+        .map_or(summary, |(value, _)| value);
+    Some(summary.trim().to_string())
+}
+
+fn is_compact_boundary_message(message: &ConversationMessage) -> bool {
+    message.role == MessageRole::System
+        && (message.compact_metadata.is_some()
+            || first_text_block(message).is_some_and(|text| text.trim() == COMPACT_BOUNDARY_TEXT))
 }
 
 fn extract_summary_highlights(summary: &str) -> Vec<String> {
@@ -502,16 +1169,149 @@ fn extract_summary_timeline(summary: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use serde_json::json;
+
     use super::{
-        collect_key_files, compact_session, estimate_session_tokens, format_compact_summary,
-        get_compact_continuation_message, infer_pending_work, should_compact, CompactionConfig,
+        build_compaction_result, collect_key_files, collect_post_compact_context_messages,
+        compact_session, estimate_session_tokens, format_compact_summary,
+        get_compact_continuation_message, get_compact_prompt, get_compact_user_summary_message,
+        infer_pending_work, select_full_compact_messages, should_compact,
+        BuildCompactionResultOptions, CompactionConfig, CompactionLayout, PreservedSegmentAnchor,
     };
-    use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::session::{
+        AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, MessageRole, Session,
+    };
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("runtime-compact-{label}-{nanos}"))
+    }
+
+    fn write_post_compact_todo_fixture(workspace: &std::path::Path) {
+        let todo_path = workspace.join(".clawd-todos.json");
+        fs::write(
+            &todo_path,
+            serde_json::to_string_pretty(&json!([
+                {
+                    "content": "Implement TS full compact parity",
+                    "activeForm": "Implementing TS full compact parity",
+                    "status": "in_progress"
+                },
+                {
+                    "content": "Run cargo test --workspace",
+                    "activeForm": "Running cargo test --workspace",
+                    "status": "pending"
+                }
+            ]))
+            .expect("todo json should serialize"),
+        )
+        .expect("todo file should write");
+    }
+
+    fn write_post_compact_agent_fixture(workspace: &std::path::Path) -> PathBuf {
+        let manifest_dir = workspace.join(".claw").join("agents");
+        fs::create_dir_all(&manifest_dir).expect("agent dir should exist");
+        let manifest_path = manifest_dir.join("agent-compact.json");
+        fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&json!({
+                "agentId": "agent-compact",
+                "name": "planner",
+                "description": "Finish compact parity",
+                "status": "running",
+                "outputFile": workspace.join(".claw").join("agents").join("agent-compact.md").display().to_string(),
+                "manifestFile": manifest_path.display().to_string(),
+                "derivedState": "working"
+            }))
+            .expect("agent json should serialize"),
+        )
+        .expect("agent manifest should write");
+        manifest_path
+    }
+
+    fn build_post_compact_context_session(
+        workspace: &std::path::Path,
+        manifest_path: &std::path::Path,
+    ) -> Session {
+        let mut session = Session::new().with_workspace_root(workspace);
+        session.messages = vec![
+            ConversationMessage::tool_result(
+                "plan-1",
+                "EnterPlanMode",
+                serde_json::to_string_pretty(&json!({
+                    "success": true,
+                    "operation": "enter",
+                    "changed": true,
+                    "active": true,
+                    "managed": true,
+                    "message": "Enabled worktree-local plan mode override.",
+                    "settingsPath": workspace.join(".codex").join("settings.local.json").display().to_string(),
+                    "statePath": workspace.join(".claw").join("plan-mode.json").display().to_string()
+                }))
+                .expect("plan json should serialize"),
+                false,
+            ),
+            ConversationMessage::tool_result(
+                "skill-1",
+                "Skill",
+                serde_json::to_string_pretty(&json!({
+                    "skill": "$compact",
+                    "path": workspace.join(".codex").join("skills").join("compact").join("SKILL.md").display().to_string(),
+                    "args": "full",
+                    "description": "Compact guidance",
+                    "prompt": "Prefer TS full compact parity over local summaries."
+                }))
+                .expect("skill json should serialize"),
+                false,
+            ),
+            ConversationMessage::tool_result(
+                "agent-1",
+                "Agent",
+                serde_json::to_string_pretty(&json!({
+                    "agentId": "agent-compact",
+                    "name": "planner",
+                    "description": "Finish compact parity",
+                    "status": "running",
+                    "outputFile": workspace.join(".claw").join("agents").join("agent-compact.md").display().to_string(),
+                    "manifestFile": manifest_path.display().to_string(),
+                    "derivedState": "working"
+                }))
+                .expect("agent json should serialize"),
+                false,
+            ),
+        ];
+        session
+    }
 
     #[test]
     fn formats_compact_summary_like_upstream() {
         let summary = "<analysis>scratch</analysis>\n<summary>Kept work</summary>";
         assert_eq!(format_compact_summary(summary), "Summary:\nKept work");
+    }
+
+    #[test]
+    fn builds_full_compact_prompt_with_no_tools_guard() {
+        let prompt = get_compact_prompt(Some("Focus on Rust code changes."));
+        assert!(prompt.contains("CRITICAL: Respond with TEXT ONLY."));
+        assert!(prompt.contains("Do NOT call any tools."));
+        assert!(prompt.contains("Primary Request and Intent"));
+        assert!(prompt.contains("Additional Instructions:\nFocus on Rust code changes."));
+    }
+
+    #[test]
+    fn builds_user_facing_summary_message_like_ts_full_compact() {
+        let message =
+            get_compact_user_summary_message("<summary>Carry over context</summary>", true, false);
+        assert!(message.starts_with("This session is being continued from a previous conversation"));
+        assert!(message.contains("Summary:\nCarry over context"));
+        assert!(message.contains("Continue the conversation from where it left off"));
     }
 
     #[test]
@@ -541,6 +1341,12 @@ mod tests {
                     text: "recent".to_string(),
                 }],
                 usage: None,
+                subtype: None,
+                compact_metadata: None,
+                attachment_metadata: None,
+                hook_result_metadata: None,
+                is_compact_summary: false,
+                is_visible_in_transcript_only: false,
             },
         ];
 
@@ -641,7 +1447,36 @@ mod tests {
                     text: get_compact_continuation_message(summary, true, true),
                 }],
                 usage: None,
+                subtype: None,
+                compact_metadata: None,
+                attachment_metadata: None,
+                hook_result_metadata: None,
+                is_compact_summary: false,
+                is_visible_in_transcript_only: false,
             },
+            ConversationMessage::user_text("tiny"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "recent".to_string(),
+            }]),
+        ];
+
+        assert!(!should_compact(
+            &session,
+            CompactionConfig {
+                preserve_recent_messages: 2,
+                max_estimated_tokens: 1,
+            }
+        ));
+    }
+
+    #[test]
+    fn ignores_existing_full_compact_prefix_when_deciding_to_recompact() {
+        let summary =
+            "<summary>Conversation summary:\n- Scope: earlier work preserved.\n</summary>";
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::system_text("Conversation compacted"),
+            ConversationMessage::user_text(get_compact_user_summary_message(summary, true, false)),
             ConversationMessage::user_text("tiny"),
             ConversationMessage::assistant(vec![ContentBlock::Text {
                 text: "recent".to_string(),
@@ -685,5 +1520,198 @@ mod tests {
         ]);
         assert_eq!(pending.len(), 1);
         assert!(pending[0].contains("Next: update tests"));
+    }
+
+    #[test]
+    fn build_compaction_result_can_replace_entire_session_with_summary_only() {
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("first"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "second".to_string(),
+            }]),
+        ];
+
+        let result = build_compaction_result(
+            &session,
+            "<summary>Model-generated summary</summary>".to_string(),
+            BuildCompactionResultOptions {
+                preserved_messages: Vec::new(),
+                hook_result_messages: Vec::new(),
+                preserved_segment_anchor: None,
+                removed_message_count: session.messages.len(),
+                suppress_follow_up_questions: true,
+                layout: CompactionLayout::TsBoundaryAndSummary,
+                boundary_trigger: Some(CompactTrigger::Manual),
+                user_display_message: None,
+            },
+        );
+
+        assert_eq!(result.removed_message_count, 2);
+        assert_eq!(result.compacted_session.messages.len(), 2);
+        assert!(matches!(
+            &result.compacted_session.messages[0].blocks[0],
+            ContentBlock::Text { text } if text == "Conversation compacted"
+        ));
+        assert!(matches!(
+            result.compacted_session.messages[0].compact_metadata.as_ref(),
+            Some(metadata)
+                if metadata.trigger == CompactTrigger::Manual
+                    && metadata.messages_summarized == Some(2)
+        ));
+        assert!(matches!(
+            &result.compacted_session.messages[1].blocks[0],
+            ContentBlock::Text { text }
+                if text.contains("Summary:\nModel-generated summary")
+                    && !text.contains("Recent messages are preserved verbatim.")
+        ));
+        assert!(result.compacted_session.messages[1].is_compact_summary);
+        assert!(result.compacted_session.messages[1].is_visible_in_transcript_only);
+    }
+
+    #[test]
+    fn build_compaction_result_records_preserved_segment_for_suffix_preserving_layout() {
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("first"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "second".to_string(),
+            }]),
+            ConversationMessage::user_text("keep me"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "and me".to_string(),
+            }]),
+        ];
+
+        let preserved_messages = session.messages[2..].to_vec();
+        let result = build_compaction_result(
+            &session,
+            "<summary>Model-generated summary</summary>".to_string(),
+            BuildCompactionResultOptions {
+                preserved_messages,
+                hook_result_messages: Vec::new(),
+                preserved_segment_anchor: Some(PreservedSegmentAnchor::LastSummaryMessage),
+                removed_message_count: 2,
+                suppress_follow_up_questions: true,
+                layout: CompactionLayout::TsBoundaryAndSummary,
+                boundary_trigger: Some(CompactTrigger::Manual),
+                user_display_message: None,
+            },
+        );
+
+        assert_eq!(result.compacted_session.messages.len(), 4);
+        assert!(matches!(
+            result.compacted_session.messages[0].compact_metadata.as_ref(),
+            Some(metadata)
+                if metadata.preserved_segment.as_ref().is_some_and(|segment|
+                    segment.head == "source-message-2"
+                        && segment.anchor == "summary-message"
+                        && segment.tail == "source-message-3"
+                )
+        ));
+        assert!(matches!(
+            &result.compacted_session.messages[1].blocks[0],
+            ContentBlock::Text { text } if text.contains("Recent messages are preserved verbatim.")
+        ));
+        assert!(result.compacted_session.messages[1].is_compact_summary);
+        assert!(!result.compacted_session.messages[1].is_visible_in_transcript_only);
+        assert!(matches!(
+            &result.compacted_session.messages[2].blocks[0],
+            ContentBlock::Text { text } if text == "keep me"
+        ));
+    }
+
+    #[test]
+    fn select_full_compact_messages_keeps_recent_tail_without_reusing_compact_prefix() {
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::compact_boundary(crate::session::CompactBoundaryMetadata {
+                trigger: CompactTrigger::Manual,
+                pre_tokens: 42,
+                user_context: None,
+                messages_summarized: Some(2),
+                pre_compact_discovered_tools: Vec::new(),
+                preserved_segment: None,
+            }),
+            ConversationMessage::user_text(get_compact_user_summary_message(
+                "<summary>Older work</summary>",
+                true,
+                false,
+            )),
+            ConversationMessage::user_text("recent one"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "recent two".to_string(),
+            }]),
+            ConversationMessage::user_text("recent three"),
+        ];
+
+        let selection = select_full_compact_messages(&session, 2);
+        assert_eq!(selection.messages_to_summarize.len(), 3);
+        assert_eq!(selection.preserved_messages.len(), 2);
+        assert!(matches!(
+            &selection.preserved_messages[0].blocks[0],
+            ContentBlock::Text { text } if text == "recent two"
+        ));
+        assert!(matches!(
+            &selection.preserved_messages[1].blocks[0],
+            ContentBlock::Text { text } if text == "recent three"
+        ));
+    }
+
+    #[test]
+    fn collects_post_compact_context_messages_from_runtime_state() {
+        let workspace = temp_dir("post-compact-context");
+        fs::create_dir_all(&workspace).expect("workspace should exist");
+        write_post_compact_todo_fixture(&workspace);
+        let manifest_path = write_post_compact_agent_fixture(&workspace);
+        let session = build_post_compact_context_session(&workspace, &manifest_path);
+
+        let messages = collect_post_compact_context_messages(&session);
+        assert_eq!(messages.len(), 4);
+
+        let rendered = messages
+            .iter()
+            .filter_map(|message| match &message.blocks[0] {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            messages[0]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::RunningAgents)
+        );
+        assert_eq!(
+            messages[1]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::TodoList)
+        );
+        assert_eq!(
+            messages[2]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::PlanMode)
+        );
+        assert_eq!(
+            messages[3]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::InvokedSkills)
+        );
+        assert!(rendered[0].contains("Background agents are still active after compaction"));
+        assert!(rendered[0].contains("agent-compact"));
+        assert!(rendered[1].contains("Current TodoWrite task list remains active"));
+        assert!(rendered[1].contains("Implement TS full compact parity"));
+        assert!(rendered[2].contains("Plan mode is still active for this worktree"));
+        assert!(rendered[3].contains("Previously invoked skills remain available"));
+        assert!(rendered[3].contains("Prefer TS full compact parity over local summaries."));
+
+        fs::remove_dir_all(&workspace).expect("workspace cleanup should succeed");
     }
 }

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -354,24 +354,26 @@ fn build_compacted_messages(options: CompactedMessageOptions<'_>) -> Vec<Convers
                 recent_messages_preserved,
             ),
         )],
-        CompactionLayout::TsBoundaryAndSummary => vec![
-            build_ts_compact_boundary_message(
-                boundary_trigger.unwrap_or(CompactTrigger::Manual),
-                pre_tokens,
-                removed_message_count,
-                source_messages,
-                &preserved_messages,
-                preserved_segment_anchor,
-            ),
-            ConversationMessage::compact_summary_user_text(
+        CompactionLayout::TsBoundaryAndSummary => {
+            let summary_message = ConversationMessage::compact_summary_user_text(
                 get_compact_user_summary_message(
                     summary,
                     suppress_follow_up_questions,
                     recent_messages_preserved,
                 ),
                 !recent_messages_preserved,
-            ),
-        ],
+            );
+            let boundary_message = build_ts_compact_boundary_message(
+                boundary_trigger.unwrap_or(CompactTrigger::Manual),
+                pre_tokens,
+                removed_message_count,
+                source_messages,
+                &preserved_messages,
+                preserved_segment_anchor,
+                Some(summary_message.uuid.as_str()),
+            );
+            vec![boundary_message, summary_message]
+        }
     };
     compacted_messages.extend(preserved_messages);
     compacted_messages.extend(post_compact_context_messages);
@@ -386,6 +388,7 @@ fn build_ts_compact_boundary_message(
     source_messages: &[ConversationMessage],
     preserved_messages: &[ConversationMessage],
     preserved_segment_anchor: Option<PreservedSegmentAnchor>,
+    summary_message_uuid: Option<&str>,
 ) -> ConversationMessage {
     ConversationMessage::compact_boundary(CompactBoundaryMetadata {
         trigger,
@@ -394,33 +397,28 @@ fn build_ts_compact_boundary_message(
         messages_summarized: Some(removed_message_count),
         pre_compact_discovered_tools: collect_discovered_tools(source_messages),
         preserved_segment: build_preserved_segment_metadata(
-            source_messages.len(),
-            preserved_messages.len(),
+            preserved_messages,
             preserved_segment_anchor,
+            summary_message_uuid,
         ),
     })
 }
 
 fn build_preserved_segment_metadata(
-    source_message_count: usize,
-    preserved_message_count: usize,
+    preserved_messages: &[ConversationMessage],
     anchor: Option<PreservedSegmentAnchor>,
+    summary_message_uuid: Option<&str>,
 ) -> Option<CompactPreservedSegment> {
-    if preserved_message_count == 0 || preserved_message_count > source_message_count {
+    if preserved_messages.is_empty() {
         return None;
     }
-
-    let head_index = source_message_count - preserved_message_count;
-    let tail_index = source_message_count - 1;
+    let anchor_uuid = match anchor.unwrap_or(PreservedSegmentAnchor::LastSummaryMessage) {
+        PreservedSegmentAnchor::LastSummaryMessage => summary_message_uuid?,
+    };
     Some(CompactPreservedSegment {
-        // Rust sessions do not yet persist TS-style message UUID chains. We
-        // still record stable synthetic anchors here so suffix-preserving
-        // compaction metadata is available now and can be upgraded later.
-        head: format!("source-message-{head_index}"),
-        anchor: match anchor.unwrap_or(PreservedSegmentAnchor::LastSummaryMessage) {
-            PreservedSegmentAnchor::LastSummaryMessage => "summary-message".to_string(),
-        },
-        tail: format!("source-message-{tail_index}"),
+        head: preserved_messages.first()?.uuid.clone(),
+        anchor: anchor_uuid.to_string(),
+        tail: preserved_messages.last()?.uuid.clone(),
     })
 }
 
@@ -1335,19 +1333,9 @@ mod tests {
                 text: "two ".repeat(200),
             }]),
             ConversationMessage::tool_result("1", "bash", "ok ".repeat(200), false),
-            ConversationMessage {
-                role: MessageRole::Assistant,
-                blocks: vec![ContentBlock::Text {
-                    text: "recent".to_string(),
-                }],
-                usage: None,
-                subtype: None,
-                compact_metadata: None,
-                attachment_metadata: None,
-                hook_result_metadata: None,
-                is_compact_summary: false,
-                is_visible_in_transcript_only: false,
-            },
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "recent".to_string(),
+            }]),
         ];
 
         let result = compact_session(
@@ -1441,19 +1429,7 @@ mod tests {
         let summary = "<summary>Conversation summary:\n- Scope: earlier work preserved.\n- Key timeline:\n  - user: large preserved context\n</summary>";
         let mut session = Session::new();
         session.messages = vec![
-            ConversationMessage {
-                role: MessageRole::System,
-                blocks: vec![ContentBlock::Text {
-                    text: get_compact_continuation_message(summary, true, true),
-                }],
-                usage: None,
-                subtype: None,
-                compact_metadata: None,
-                attachment_metadata: None,
-                hook_result_metadata: None,
-                is_compact_summary: false,
-                is_visible_in_transcript_only: false,
-            },
+            ConversationMessage::system_text(get_compact_continuation_message(summary, true, true)),
             ConversationMessage::user_text("tiny"),
             ConversationMessage::assistant(vec![ContentBlock::Text {
                 text: "recent".to_string(),
@@ -1583,6 +1559,8 @@ mod tests {
             }]),
         ];
 
+        let expected_head_uuid = session.messages[2].uuid.clone();
+        let expected_tail_uuid = session.messages[3].uuid.clone();
         let preserved_messages = session.messages[2..].to_vec();
         let result = build_compaction_result(
             &session,
@@ -1600,13 +1578,14 @@ mod tests {
         );
 
         assert_eq!(result.compacted_session.messages.len(), 4);
+        let summary_uuid = result.compacted_session.messages[1].uuid.clone();
         assert!(matches!(
             result.compacted_session.messages[0].compact_metadata.as_ref(),
             Some(metadata)
                 if metadata.preserved_segment.as_ref().is_some_and(|segment|
-                    segment.head == "source-message-2"
-                        && segment.anchor == "summary-message"
-                        && segment.tail == "source-message-3"
+                    segment.head == expected_head_uuid
+                        && segment.anchor == summary_uuid
+                        && segment.tail == expected_tail_uuid
                 )
         ));
         assert!(matches!(

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -90,6 +90,9 @@ pub struct RuntimeHookConfig {
     pre_tool_use: Vec<String>,
     post_tool_use: Vec<String>,
     post_tool_use_failure: Vec<String>,
+    pre_compact: Vec<String>,
+    post_compact: Vec<String>,
+    session_start: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -598,7 +601,28 @@ impl RuntimeHookConfig {
             pre_tool_use,
             post_tool_use,
             post_tool_use_failure,
+            pre_compact: Vec::new(),
+            post_compact: Vec::new(),
+            session_start: Vec::new(),
         }
+    }
+
+    #[must_use]
+    pub fn with_pre_compact(mut self, pre_compact: Vec<String>) -> Self {
+        self.pre_compact = pre_compact;
+        self
+    }
+
+    #[must_use]
+    pub fn with_post_compact(mut self, post_compact: Vec<String>) -> Self {
+        self.post_compact = post_compact;
+        self
+    }
+
+    #[must_use]
+    pub fn with_session_start(mut self, session_start: Vec<String>) -> Self {
+        self.session_start = session_start;
+        self
     }
 
     #[must_use]
@@ -609,6 +633,21 @@ impl RuntimeHookConfig {
     #[must_use]
     pub fn post_tool_use(&self) -> &[String] {
         &self.post_tool_use
+    }
+
+    #[must_use]
+    pub fn pre_compact(&self) -> &[String] {
+        &self.pre_compact
+    }
+
+    #[must_use]
+    pub fn post_compact(&self) -> &[String] {
+        &self.post_compact
+    }
+
+    #[must_use]
+    pub fn session_start(&self) -> &[String] {
+        &self.session_start
     }
 
     #[must_use]
@@ -625,6 +664,9 @@ impl RuntimeHookConfig {
             &mut self.post_tool_use_failure,
             other.post_tool_use_failure(),
         );
+        extend_unique(&mut self.pre_compact, other.pre_compact());
+        extend_unique(&mut self.post_compact, other.post_compact());
+        extend_unique(&mut self.session_start, other.session_start());
     }
 
     #[must_use]
@@ -832,12 +874,14 @@ fn parse_optional_hooks_config_object(
         return Ok(RuntimeHookConfig::default());
     };
     let hooks = expect_object(hooks_value, context)?;
-    Ok(RuntimeHookConfig {
-        pre_tool_use: optional_string_array(hooks, "PreToolUse", context)?.unwrap_or_default(),
-        post_tool_use: optional_string_array(hooks, "PostToolUse", context)?.unwrap_or_default(),
-        post_tool_use_failure: optional_string_array(hooks, "PostToolUseFailure", context)?
-            .unwrap_or_default(),
-    })
+    Ok(RuntimeHookConfig::new(
+        optional_string_array(hooks, "PreToolUse", context)?.unwrap_or_default(),
+        optional_string_array(hooks, "PostToolUse", context)?.unwrap_or_default(),
+        optional_string_array(hooks, "PostToolUseFailure", context)?.unwrap_or_default(),
+    )
+    .with_pre_compact(optional_string_array(hooks, "PreCompact", context)?.unwrap_or_default())
+    .with_post_compact(optional_string_array(hooks, "PostCompact", context)?.unwrap_or_default())
+    .with_session_start(optional_string_array(hooks, "SessionStart", context)?.unwrap_or_default()))
 }
 
 fn validate_optional_hooks_config(
@@ -1357,7 +1401,7 @@ mod tests {
         .expect("write user compat config");
         fs::write(
             home.join("settings.json"),
-            r#"{"model":"sonnet","env":{"A2":"1"},"hooks":{"PreToolUse":["base"]},"permissions":{"defaultMode":"plan","allow":["Read"],"deny":["Bash(rm -rf)"]}}"#,
+            r#"{"model":"sonnet","env":{"A2":"1"},"hooks":{"PreToolUse":["base"],"PreCompact":["compact-base"],"SessionStart":["session-base"]},"permissions":{"defaultMode":"plan","allow":["Read"],"deny":["Bash(rm -rf)"]}}"#,
         )
         .expect("write user settings");
         fs::write(
@@ -1367,7 +1411,7 @@ mod tests {
         .expect("write project compat config");
         fs::write(
             cwd.join(".claw").join("settings.json"),
-            r#"{"env":{"C":"3"},"hooks":{"PostToolUse":["project"],"PostToolUseFailure":["project-failure"]},"permissions":{"ask":["Edit"]},"mcpServers":{"project":{"command":"uvx","args":["project"]}}}"#,
+            r#"{"env":{"C":"3"},"hooks":{"PostToolUse":["project"],"PostToolUseFailure":["project-failure"],"PostCompact":["project-post-compact"]},"permissions":{"ask":["Edit"]},"mcpServers":{"project":{"command":"uvx","args":["project"]}}}"#,
         )
         .expect("write project settings");
         fs::write(
@@ -1416,6 +1460,15 @@ mod tests {
         assert_eq!(
             loaded.hooks().post_tool_use_failure(),
             &["project-failure".to_string()]
+        );
+        assert_eq!(loaded.hooks().pre_compact(), &["compact-base".to_string()]);
+        assert_eq!(
+            loaded.hooks().post_compact(),
+            &["project-post-compact".to_string()]
+        );
+        assert_eq!(
+            loaded.hooks().session_start(),
+            &["session-base".to_string()]
         );
         assert_eq!(loaded.permission_rules().allow(), &["Read".to_string()]);
         assert_eq!(
@@ -2019,6 +2072,28 @@ mod tests {
         assert_eq!(
             merged.post_tool_use_failure(),
             &["failure-a".to_string(), "failure-b".to_string()]
+        );
+        assert_eq!(merged.pre_compact(), &[] as &[String]);
+        assert_eq!(merged.post_compact(), &[] as &[String]);
+        assert_eq!(merged.session_start(), &[] as &[String]);
+
+        let merged_with_compact_hooks = merged.merged(
+            &RuntimeHookConfig::default()
+                .with_pre_compact(vec!["pre-compact-a".to_string()])
+                .with_post_compact(vec!["post-compact-a".to_string()])
+                .with_session_start(vec!["session-a".to_string()]),
+        );
+        assert_eq!(
+            merged_with_compact_hooks.pre_compact(),
+            &["pre-compact-a".to_string()]
+        );
+        assert_eq!(
+            merged_with_compact_hooks.post_compact(),
+            &["post-compact-a".to_string()]
+        );
+        assert_eq!(
+            merged_with_compact_hooks.session_start(),
+            &["session-a".to_string()]
         );
     }
 

--- a/rust/crates/runtime/src/config_validate.rs
+++ b/rust/crates/runtime/src/config_validate.rs
@@ -224,6 +224,18 @@ const HOOKS_FIELDS: &[FieldSpec] = &[
         name: "PostToolUseFailure",
         expected: FieldType::StringArray,
     },
+    FieldSpec {
+        name: "PreCompact",
+        expected: FieldType::StringArray,
+    },
+    FieldSpec {
+        name: "PostCompact",
+        expected: FieldType::StringArray,
+    },
+    FieldSpec {
+        name: "SessionStart",
+        expected: FieldType::StringArray,
+    },
 ];
 
 const PERMISSIONS_FIELDS: &[FieldSpec] = &[

--- a/rust/crates/runtime/src/context.rs
+++ b/rust/crates/runtime/src/context.rs
@@ -171,6 +171,12 @@ mod tests {
                     text: "Summary:\nEarlier context".to_string(),
                 }],
                 usage: None,
+                subtype: None,
+                compact_metadata: None,
+                attachment_metadata: None,
+                hook_result_metadata: None,
+                is_compact_summary: false,
+                is_visible_in_transcript_only: false,
             },
             ConversationMessage::user_text("Please inspect src/main.rs"),
             ConversationMessage::assistant(vec![

--- a/rust/crates/runtime/src/context.rs
+++ b/rust/crates/runtime/src/context.rs
@@ -159,25 +159,13 @@ fn estimate_text_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::analyze_context_usage;
-    use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::session::{ContentBlock, ConversationMessage, Session};
 
     #[test]
     fn analyzes_system_prompt_sections_and_message_categories() {
         let mut session = Session::new();
         session.messages = vec![
-            ConversationMessage {
-                role: MessageRole::System,
-                blocks: vec![ContentBlock::Text {
-                    text: "Summary:\nEarlier context".to_string(),
-                }],
-                usage: None,
-                subtype: None,
-                compact_metadata: None,
-                attachment_metadata: None,
-                hook_result_metadata: None,
-                is_compact_summary: false,
-                is_visible_in_transcript_only: false,
-            },
+            ConversationMessage::system_text("Summary:\nEarlier context"),
             ConversationMessage::user_text("Please inspect src/main.rs"),
             ConversationMessage::assistant(vec![
                 ContentBlock::Text {

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -1565,6 +1565,7 @@ mod tests {
             result.compacted_session.messages[3].role,
             MessageRole::Assistant
         );
+        let summary_uuid = result.compacted_session.messages[1].uuid.clone();
         assert!(matches!(
             result.compacted_session.messages[0].compact_metadata.as_ref(),
             Some(metadata)
@@ -1572,7 +1573,7 @@ mod tests {
                     && metadata
                         .preserved_segment
                         .as_ref()
-                        .is_some_and(|segment| segment.anchor == "summary-message")
+                        .is_some_and(|segment| segment.anchor == summary_uuid)
         ));
         assert_eq!(
             result.compacted_session.session_id,

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -1713,11 +1713,15 @@ mod tests {
             }
         }
 
+        if !windows_bash_smoke_ok() {
+            return;
+        }
+
         let requests = Rc::new(RefCell::new(Vec::new()));
         let feature_config = RuntimeFeatureConfig::default().with_hooks(
             RuntimeHookConfig::default()
-                .with_pre_compact(vec![r"printf 'preserve failing test output'".to_string()])
-                .with_post_compact(vec![r"printf 'post compact note'".to_string()]),
+                .with_pre_compact(vec![shell_snippet("printf 'preserve failing test output'")])
+                .with_post_compact(vec![shell_snippet("printf 'post compact note'")]),
         );
         let mut runtime = ConversationRuntime::new_with_features(
             Session::new(),

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -5,14 +5,18 @@ use serde_json::{Map, Value};
 use telemetry::SessionTracer;
 
 use crate::compact::{
-    compact_session, estimate_session_tokens, CompactionConfig, CompactionResult,
+    build_compaction_result, compact_session, estimate_session_tokens, get_compact_prompt,
+    select_full_compact_messages, should_compact, BuildCompactionResultOptions, CompactionConfig,
+    CompactionLayout, CompactionResult, PreservedSegmentAnchor,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{HookAbortSignal, HookProgressReporter, HookRunResult, HookRunner};
 use crate::permissions::{
     PermissionContext, PermissionOutcome, PermissionPolicy, PermissionPrompter,
 };
-use crate::session::{ContentBlock, ConversationMessage, Session};
+use crate::session::{
+    AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent, Session,
+};
 use crate::tool_session::with_tool_session_context;
 use crate::usage::{TokenUsage, UsageTracker};
 
@@ -23,6 +27,28 @@ const AUTO_COMPACTION_THRESHOLD_ENV_VAR: &str = "CLAUDE_CODE_AUTO_COMPACT_INPUT_
 pub struct ApiRequest {
     pub system_prompt: Vec<String>,
     pub messages: Vec<ConversationMessage>,
+    /// Full compact uses a text-only request and must not expose tool schemas.
+    pub allow_tools: bool,
+}
+
+impl ApiRequest {
+    #[must_use]
+    pub fn conversation(system_prompt: Vec<String>, messages: Vec<ConversationMessage>) -> Self {
+        Self {
+            system_prompt,
+            messages,
+            allow_tools: true,
+        }
+    }
+
+    #[must_use]
+    pub fn text_only(system_prompt: Vec<String>, messages: Vec<ConversationMessage>) -> Self {
+        Self {
+            system_prompt,
+            messages,
+            allow_tools: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -283,6 +309,30 @@ where
         }
     }
 
+    fn run_session_start_hook_messages(
+        &mut self,
+        source: &str,
+        model: Option<&str>,
+    ) -> Vec<ConversationMessage> {
+        let result = if let Some(reporter) = self.hook_progress_reporter.as_mut() {
+            self.hook_runner.run_session_start_with_context(
+                source,
+                model,
+                Some(&self.hook_abort_signal),
+                Some(reporter.as_mut()),
+            )
+        } else {
+            self.hook_runner.run_session_start_with_context(
+                source,
+                model,
+                Some(&self.hook_abort_signal),
+                None,
+            )
+        };
+
+        session_start_hook_messages(source, &result)
+    }
+
     #[allow(clippy::too_many_lines)]
     pub fn run_turn(
         &mut self,
@@ -310,10 +360,8 @@ where
                 return Err(error);
             }
 
-            let request = ApiRequest {
-                system_prompt: self.system_prompt.clone(),
-                messages: self.session.messages.clone(),
-            };
+            let request =
+                ApiRequest::conversation(self.system_prompt.clone(), self.session.messages.clone());
             let events = match with_tool_session_context(
                 &self.session.session_id,
                 self.session.persistence_path(),
@@ -482,9 +530,81 @@ where
         Ok(summary)
     }
 
-    #[must_use]
-    pub fn compact(&self, config: CompactionConfig) -> CompactionResult {
-        compact_session(&self.session, config)
+    pub fn compact(&mut self, config: CompactionConfig) -> Result<CompactionResult, RuntimeError> {
+        if !should_compact(&self.session, config) {
+            return Ok(compact_session(&self.session, config));
+        }
+
+        self.run_full_compact(
+            true,
+            CompactTrigger::Manual,
+            config.preserve_recent_messages,
+        )
+    }
+
+    /// Runs a TS-style full compact summary turn and rewrites the session to a
+    /// boundary + summary layout with post-compact context messages.
+    fn run_full_compact(
+        &mut self,
+        suppress_follow_up_questions: bool,
+        trigger: CompactTrigger,
+        preserve_recent_messages: usize,
+    ) -> Result<CompactionResult, RuntimeError> {
+        let selection = select_full_compact_messages(&self.session, preserve_recent_messages);
+        let removed_message_count = selection.messages_to_summarize.len();
+        let pre_compact = self.hook_runner.run_pre_compact(trigger, None);
+        let summary = self.execute_full_compact_summary_request(
+            &selection.messages_to_summarize,
+            pre_compact.new_custom_instructions(),
+        )?;
+        let hook_result_messages = self.run_session_start_hook_messages("compact", None);
+        let post_compact = self.hook_runner.run_post_compact(trigger, &summary);
+        Ok(build_compaction_result(
+            &self.session,
+            summary,
+            BuildCompactionResultOptions {
+                preserved_messages: selection.preserved_messages,
+                hook_result_messages,
+                preserved_segment_anchor: if preserve_recent_messages == 0 {
+                    None
+                } else {
+                    Some(PreservedSegmentAnchor::LastSummaryMessage)
+                },
+                removed_message_count,
+                suppress_follow_up_questions,
+                layout: CompactionLayout::TsBoundaryAndSummary,
+                boundary_trigger: Some(trigger),
+                user_display_message: combine_optional_display_messages(&[
+                    pre_compact.user_display_message(),
+                    post_compact.user_display_message(),
+                ]),
+            },
+        ))
+    }
+
+    fn execute_full_compact_summary_request(
+        &mut self,
+        source_messages: &[ConversationMessage],
+        custom_instructions: Option<&str>,
+    ) -> Result<String, RuntimeError> {
+        let mut messages = source_messages.to_vec();
+        messages.push(ConversationMessage::user_text(get_compact_prompt(
+            custom_instructions,
+        )));
+        let request = ApiRequest::text_only(self.system_prompt.clone(), messages);
+        let events = with_tool_session_context(
+            &self.session.session_id,
+            self.session.persistence_path(),
+            || self.api_client.stream(request),
+        )?;
+        let (assistant_message, usage, _) = build_assistant_message(events)?;
+        if let Some(usage) = usage {
+            self.usage_tracker.record(usage);
+        }
+
+        assistant_text(&assistant_message).ok_or_else(|| {
+            RuntimeError::new("full compaction failed to produce a text summary response")
+        })
     }
 
     #[must_use]
@@ -523,13 +643,7 @@ where
             return None;
         }
 
-        let result = compact_session(
-            &self.session,
-            CompactionConfig {
-                max_estimated_tokens: 0,
-                ..CompactionConfig::default()
-            },
-        );
+        let result = self.run_full_compact(true, CompactTrigger::Auto, 0).ok()?;
 
         if result.removed_message_count == 0 {
             return None;
@@ -715,6 +829,21 @@ fn build_assistant_message(
     ))
 }
 
+fn assistant_text(message: &ConversationMessage) -> Option<String> {
+    let text = message
+        .blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+        })
+        .collect::<String>()
+        .trim()
+        .to_string();
+
+    (!text.is_empty()).then_some(text)
+}
+
 fn flush_text_block(text: &mut String, blocks: &mut Vec<ContentBlock>) {
     if !text.is_empty() {
         blocks.push(ContentBlock::Text {
@@ -747,6 +876,32 @@ fn merge_hook_feedback(messages: &[String], output: String, is_error: bool) -> S
     };
     sections.push(format!("{label}:\n{}", messages.join("\n")));
     sections.join("\n\n")
+}
+
+fn combine_optional_display_messages(messages: &[Option<&str>]) -> Option<String> {
+    let combined = messages
+        .iter()
+        .flatten()
+        .map(|message| message.trim())
+        .filter(|message| !message.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!combined.is_empty()).then_some(combined)
+}
+
+fn session_start_hook_messages(source: &str, result: &HookRunResult) -> Vec<ConversationMessage> {
+    result
+        .messages()
+        .iter()
+        .map(|message| {
+            ConversationMessage::hook_result_user_text(
+                format!("SessionStart hook ({source}) output:\n{}", message.trim()),
+                Some(AttachmentKind::HookAdditionalContext),
+                HookResultEvent::SessionStart,
+                source,
+            )
+        })
+        .collect()
 }
 
 type ToolHandler = Box<dyn FnMut(&str) -> Result<String, ToolError>>;
@@ -795,15 +950,19 @@ mod tests {
         PermissionRequest,
     };
     use crate::prompt::{ProjectContext, SystemPromptBuilder};
-    use crate::session::{ContentBlock, MessageRole, Session};
+    use crate::session::{
+        AttachmentKind, CompactTrigger, ContentBlock, HookResultEvent, MessageRole, Session,
+    };
     use crate::usage::TokenUsage;
     use crate::ToolError;
     #[cfg(windows)]
     use crate::{bash_shell_path, set_shell_if_windows};
+    use std::cell::RefCell;
     use std::fs;
     use std::path::PathBuf;
     #[cfg(windows)]
     use std::process::Command;
+    use std::rc::Rc;
     use std::sync::Arc;
     #[cfg(windows)]
     use std::sync::OnceLock;
@@ -1349,22 +1508,37 @@ mod tests {
 
     #[test]
     fn compacts_session_after_turns() {
-        struct SimpleApi;
+        #[derive(Clone)]
+        struct SimpleApi {
+            requests: Rc<RefCell<Vec<ApiRequest>>>,
+        }
+
         impl ApiClient for SimpleApi {
-            fn stream(
-                &mut self,
-                _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
-                    AssistantEvent::TextDelta("done".to_string()),
-                    AssistantEvent::MessageStop,
-                ])
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.requests.borrow_mut().push(request.clone());
+                if request.allow_tools {
+                    Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ])
+                } else {
+                    Ok(vec![
+                        AssistantEvent::TextDelta(
+                            "<analysis>draft</analysis><summary>Compacted from model</summary>"
+                                .to_string(),
+                        ),
+                        AssistantEvent::MessageStop,
+                    ])
+                }
             }
         }
 
+        let requests = Rc::new(RefCell::new(Vec::new()));
         let mut runtime = ConversationRuntime::new(
             Session::new(),
-            SimpleApi,
+            SimpleApi {
+                requests: requests.clone(),
+            },
             StaticToolExecutor::new(),
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
             vec!["system".to_string()],
@@ -1373,20 +1547,216 @@ mod tests {
         runtime.run_turn("b", None).expect("turn b");
         runtime.run_turn("c", None).expect("turn c");
 
-        let result = runtime.compact(CompactionConfig {
-            preserve_recent_messages: 2,
-            max_estimated_tokens: 1,
-        });
-        assert!(result.summary.contains("Conversation summary"));
+        let result = runtime
+            .compact(CompactionConfig {
+                preserve_recent_messages: 2,
+                max_estimated_tokens: 1,
+            })
+            .expect("compact should succeed");
+        assert!(result.summary.contains("Compacted from model"));
         assert_eq!(
             result.compacted_session.messages[0].role,
             MessageRole::System
         );
+        assert_eq!(result.compacted_session.messages.len(), 4);
+        assert_eq!(result.compacted_session.messages[1].role, MessageRole::User);
+        assert_eq!(result.compacted_session.messages[2].role, MessageRole::User);
+        assert_eq!(
+            result.compacted_session.messages[3].role,
+            MessageRole::Assistant
+        );
+        assert!(matches!(
+            result.compacted_session.messages[0].compact_metadata.as_ref(),
+            Some(metadata)
+                if metadata.trigger == CompactTrigger::Manual
+                    && metadata
+                        .preserved_segment
+                        .as_ref()
+                        .is_some_and(|segment| segment.anchor == "summary-message")
+        ));
         assert_eq!(
             result.compacted_session.session_id,
             runtime.session().session_id
         );
         assert!(result.compacted_session.compaction.is_some());
+
+        let requests = requests.borrow();
+        let compact_request = requests.last().expect("compact request should exist");
+        assert!(!compact_request.allow_tools);
+        let compact_prompt = compact_request
+            .messages
+            .last()
+            .and_then(|message| message.blocks.first())
+            .and_then(|block| match block {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+            })
+            .expect("compact request should end with a text prompt");
+        assert!(compact_prompt.contains("Your task is to create a detailed summary"));
+        assert_eq!(compact_request.messages.len(), 5);
+        assert!(matches!(
+            &compact_request.messages[0].blocks[0],
+            ContentBlock::Text { text } if text == "a"
+        ));
+        assert!(matches!(
+            &compact_request.messages[2].blocks[0],
+            ContentBlock::Text { text } if text == "b"
+        ));
+        assert!(
+            compact_request.messages.iter().all(|message| {
+                message
+                    .blocks
+                    .iter()
+                    .all(|block| !matches!(block, ContentBlock::Text { text } if text == "c"))
+            }),
+            "preserved tail should be excluded from the summary request"
+        );
+    }
+
+    #[test]
+    fn compact_appends_session_start_hook_messages_after_summary() {
+        #[derive(Clone)]
+        struct SimpleApi;
+
+        impl ApiClient for SimpleApi {
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                if request.allow_tools {
+                    Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ])
+                } else {
+                    Ok(vec![
+                        AssistantEvent::TextDelta(
+                            "<analysis>draft</analysis><summary>Compacted from model</summary>"
+                                .to_string(),
+                        ),
+                        AssistantEvent::MessageStop,
+                    ])
+                }
+            }
+        }
+
+        let feature_config = RuntimeFeatureConfig::default().with_hooks(
+            RuntimeHookConfig::default()
+                .with_session_start(vec!["printf 'hook says keep compact context'".to_string()]),
+        );
+        let mut runtime = ConversationRuntime::new_with_features(
+            Session::new(),
+            SimpleApi,
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+            &feature_config,
+        );
+        runtime.run_turn("a", None).expect("turn a");
+        runtime.run_turn("b", None).expect("turn b");
+
+        let result = runtime
+            .compact(CompactionConfig {
+                preserve_recent_messages: 1,
+                max_estimated_tokens: 1,
+            })
+            .expect("compact should succeed");
+
+        assert_eq!(result.compacted_session.messages.len(), 4);
+        assert_eq!(
+            result.compacted_session.messages[2].role,
+            MessageRole::Assistant
+        );
+        assert_eq!(
+            result.compacted_session.messages[3]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::HookAdditionalContext)
+        );
+        let hook_metadata = result.compacted_session.messages[3]
+            .hook_result_metadata
+            .as_ref()
+            .expect("hook result metadata");
+        assert_eq!(hook_metadata.event, HookResultEvent::SessionStart);
+        assert_eq!(hook_metadata.source, "compact");
+        assert!(matches!(
+            &result.compacted_session.messages[3].blocks[0],
+            ContentBlock::Text { text }
+                if text.contains("SessionStart hook (compact) output:")
+                    && text.contains("hook says keep compact context")
+        ));
+    }
+
+    #[test]
+    fn compact_applies_pre_and_post_compact_hooks() {
+        #[derive(Clone)]
+        struct RecordingApi {
+            requests: Rc<RefCell<Vec<ApiRequest>>>,
+        }
+
+        impl ApiClient for RecordingApi {
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.requests.borrow_mut().push(request.clone());
+                if request.allow_tools {
+                    Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ])
+                } else {
+                    Ok(vec![
+                        AssistantEvent::TextDelta(
+                            "<analysis>draft</analysis><summary>Compacted from model</summary>"
+                                .to_string(),
+                        ),
+                        AssistantEvent::MessageStop,
+                    ])
+                }
+            }
+        }
+
+        let requests = Rc::new(RefCell::new(Vec::new()));
+        let feature_config = RuntimeFeatureConfig::default().with_hooks(
+            RuntimeHookConfig::default()
+                .with_pre_compact(vec![r"printf 'preserve failing test output'".to_string()])
+                .with_post_compact(vec![r"printf 'post compact note'".to_string()]),
+        );
+        let mut runtime = ConversationRuntime::new_with_features(
+            Session::new(),
+            RecordingApi {
+                requests: requests.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+            &feature_config,
+        );
+        runtime.run_turn("a", None).expect("turn a");
+        runtime.run_turn("b", None).expect("turn b");
+
+        let result = runtime
+            .compact(CompactionConfig {
+                preserve_recent_messages: 0,
+                max_estimated_tokens: 1,
+            })
+            .expect("compact should succeed");
+
+        let requests = requests.borrow();
+        let compact_request = requests.last().expect("compact request should exist");
+        let compact_prompt = compact_request
+            .messages
+            .last()
+            .and_then(|message| message.blocks.first())
+            .and_then(|block| match block {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+            })
+            .expect("compact request should end with a text prompt");
+        assert!(compact_prompt.contains("Additional Instructions:"));
+        assert!(compact_prompt.contains("preserve failing test output"));
+        assert_eq!(
+            result.user_display_message.as_deref(),
+            Some(
+                "PreCompact [printf 'preserve failing test output'] completed successfully: preserve failing test output\nPostCompact [printf 'post compact note'] completed successfully: post compact note"
+            )
+        );
     }
 
     #[test]
@@ -1497,25 +1867,38 @@ mod tests {
 
     #[test]
     fn auto_compacts_when_cumulative_input_threshold_is_crossed() {
-        struct SimpleApi;
+        #[derive(Clone)]
+        struct SimpleApi {
+            requests: Rc<RefCell<Vec<ApiRequest>>>,
+        }
+
         impl ApiClient for SimpleApi {
-            fn stream(
-                &mut self,
-                _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
-                    AssistantEvent::TextDelta("done".to_string()),
-                    AssistantEvent::Usage(TokenUsage {
-                        input_tokens: 120_000,
-                        output_tokens: 4,
-                        cache_creation_input_tokens: 0,
-                        cache_read_input_tokens: 0,
-                    }),
-                    AssistantEvent::MessageStop,
-                ])
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.requests.borrow_mut().push(request.clone());
+                if request.allow_tools {
+                    Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::Usage(TokenUsage {
+                            input_tokens: 120_000,
+                            output_tokens: 4,
+                            cache_creation_input_tokens: 0,
+                            cache_read_input_tokens: 0,
+                        }),
+                        AssistantEvent::MessageStop,
+                    ])
+                } else {
+                    Ok(vec![
+                        AssistantEvent::TextDelta(
+                            "<analysis>draft</analysis><summary>Auto compacted</summary>"
+                                .to_string(),
+                        ),
+                        AssistantEvent::MessageStop,
+                    ])
+                }
             }
         }
 
+        let requests = Rc::new(RefCell::new(Vec::new()));
         let mut session = Session::new();
         session.messages = vec![
             crate::session::ConversationMessage::user_text("one"),
@@ -1530,7 +1913,9 @@ mod tests {
 
         let mut runtime = ConversationRuntime::new(
             session,
-            SimpleApi,
+            SimpleApi {
+                requests: requests.clone(),
+            },
             StaticToolExecutor::new(),
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
             vec!["system".to_string()],
@@ -1544,10 +1929,24 @@ mod tests {
         assert_eq!(
             summary.auto_compaction,
             Some(AutoCompactionEvent {
-                removed_message_count: 2,
+                removed_message_count: 6,
             })
         );
         assert_eq!(runtime.session().messages[0].role, MessageRole::System);
+        assert_eq!(runtime.session().messages.len(), 2);
+        assert_eq!(runtime.session().messages[1].role, MessageRole::User);
+        assert!(matches!(
+            runtime.session().messages[0].compact_metadata.as_ref(),
+            Some(metadata) if metadata.trigger == CompactTrigger::Auto
+        ));
+        let requests = requests.borrow();
+        assert_eq!(
+            requests.len(),
+            2,
+            "expected turn request and compact request"
+        );
+        assert!(requests[0].allow_tools);
+        assert!(!requests[1].allow_tools);
     }
 
     #[test]

--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use glob::Pattern;
-use regex::RegexBuilder;
+use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
@@ -286,10 +286,11 @@ pub fn edit_file(
 
 pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOutput> {
     let started = Instant::now();
+    let cwd = std::env::current_dir()?;
     let base_dir = path
         .map(normalize_path)
         .transpose()?
-        .unwrap_or(std::env::current_dir()?);
+        .unwrap_or_else(|| cwd.clone());
     let search_pattern = if Path::new(pattern).is_absolute() {
         pattern.to_owned()
     } else {
@@ -316,7 +317,7 @@ pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOu
     let filenames = matches
         .into_iter()
         .take(100)
-        .map(|path| path.to_string_lossy().into_owned())
+        .map(|path| relative_display_path(&path, &cwd))
         .collect::<Vec<_>>();
 
     Ok(GlobSearchOutput {
@@ -328,25 +329,16 @@ pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOu
 }
 
 pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
+    let cwd = std::env::current_dir()?;
     let base_path = input
         .path
         .as_deref()
         .map(normalize_path)
         .transpose()?
-        .unwrap_or(std::env::current_dir()?);
+        .unwrap_or_else(|| cwd.clone());
 
-    let regex = RegexBuilder::new(&input.pattern)
-        .case_insensitive(input.case_insensitive.unwrap_or(false))
-        .dot_matches_new_line(input.multiline.unwrap_or(false))
-        .build()
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
-
-    let glob_filter = input
-        .glob
-        .as_deref()
-        .map(Pattern::new)
-        .transpose()
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let regex = build_grep_regex(input)?;
+    let glob_filter = build_grep_glob_filter(input)?;
     let file_type = input.file_type.as_deref();
     let output_mode = input
         .output_mode
@@ -354,9 +346,9 @@ pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
         .unwrap_or_else(|| String::from("files_with_matches"));
     let context = input.context.or(input.context_short).unwrap_or(0);
 
-    let mut filenames = Vec::new();
+    let mut matched_files = Vec::new();
     let mut content_lines = Vec::new();
-    let mut total_matches = 0usize;
+    let mut count_entries = Vec::new();
 
     for file_path in collect_search_files(&base_path)? {
         if !matches_optional_filters(&file_path, glob_filter.as_ref(), file_type) {
@@ -370,70 +362,51 @@ pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
         if output_mode == "count" {
             let count = regex.find_iter(&file_contents).count();
             if count > 0 {
-                filenames.push(file_path.to_string_lossy().into_owned());
-                total_matches += count;
+                count_entries.push((file_path, count));
             }
             continue;
         }
 
         let lines: Vec<&str> = file_contents.lines().collect();
-        let mut matched_lines = Vec::new();
-        for (index, line) in lines.iter().enumerate() {
-            if regex.is_match(line) {
-                total_matches += 1;
-                matched_lines.push(index);
-            }
-        }
+        let matched_lines = matching_line_indices(&lines, &regex);
 
         if matched_lines.is_empty() {
             continue;
         }
 
-        filenames.push(file_path.to_string_lossy().into_owned());
+        matched_files.push(file_path.clone());
         if output_mode == "content" {
-            for index in matched_lines {
-                let start = index.saturating_sub(input.before.unwrap_or(context));
-                let end = (index + input.after.unwrap_or(context) + 1).min(lines.len());
-                for (current, line) in lines.iter().enumerate().take(end).skip(start) {
-                    let prefix = if input.line_numbers.unwrap_or(true) {
-                        format!("{}:{}:", file_path.to_string_lossy(), current + 1)
-                    } else {
-                        format!("{}:", file_path.to_string_lossy())
-                    };
-                    content_lines.push(format!("{prefix}{line}"));
-                }
-            }
+            append_content_matches(
+                &mut content_lines,
+                &file_path,
+                &cwd,
+                &lines,
+                &matched_lines,
+                input,
+                context,
+            );
         }
     }
 
-    let (filenames, applied_limit, applied_offset) =
-        apply_limit(filenames, input.head_limit, input.offset);
-    let content_output = if output_mode == "content" {
-        let (lines, limit, offset) = apply_limit(content_lines, input.head_limit, input.offset);
-        return Ok(GrepSearchOutput {
-            mode: Some(output_mode),
-            num_files: filenames.len(),
-            filenames,
-            num_lines: Some(lines.len()),
-            content: Some(lines.join("\n")),
-            num_matches: None,
-            applied_limit: limit,
-            applied_offset: offset,
-        });
-    } else {
-        None
-    };
+    if output_mode == "content" {
+        return Ok(build_grep_content_output(content_lines, input, output_mode));
+    }
 
-    Ok(GrepSearchOutput {
-        mode: Some(output_mode.clone()),
-        num_files: filenames.len(),
-        filenames,
-        content: content_output,
-        num_lines: None,
-        num_matches: (output_mode == "count").then_some(total_matches),
-        applied_limit,
-        applied_offset,
-    })
+    if output_mode == "count" {
+        return Ok(build_grep_count_output(
+            count_entries,
+            &cwd,
+            input,
+            output_mode,
+        ));
+    }
+
+    Ok(build_grep_files_output(
+        matched_files,
+        &cwd,
+        input,
+        output_mode,
+    ))
 }
 
 fn collect_search_files(base_path: &Path) -> io::Result<Vec<PathBuf>> {
@@ -473,6 +446,130 @@ fn matches_optional_filters(
     true
 }
 
+fn build_grep_regex(input: &GrepSearchInput) -> io::Result<Regex> {
+    RegexBuilder::new(&input.pattern)
+        .case_insensitive(input.case_insensitive.unwrap_or(false))
+        .dot_matches_new_line(input.multiline.unwrap_or(false))
+        .build()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))
+}
+
+fn build_grep_glob_filter(input: &GrepSearchInput) -> io::Result<Option<Pattern>> {
+    input
+        .glob
+        .as_deref()
+        .map(Pattern::new)
+        .transpose()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))
+}
+
+fn matching_line_indices(lines: &[&str], regex: &Regex) -> Vec<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| regex.is_match(line).then_some(index))
+        .collect()
+}
+
+fn append_content_matches(
+    content_lines: &mut Vec<String>,
+    file_path: &Path,
+    cwd: &Path,
+    lines: &[&str],
+    matched_lines: &[usize],
+    input: &GrepSearchInput,
+    context: usize,
+) {
+    let display_path = relative_display_path(file_path, cwd);
+    for index in matched_lines {
+        let start = index.saturating_sub(input.before.unwrap_or(context));
+        let end = (index + input.after.unwrap_or(context) + 1).min(lines.len());
+        for (current, line) in lines.iter().enumerate().take(end).skip(start) {
+            let prefix = if input.line_numbers.unwrap_or(true) {
+                format!("{display_path}:{}:", current + 1)
+            } else {
+                format!("{display_path}:")
+            };
+            content_lines.push(format!("{prefix}{line}"));
+        }
+    }
+}
+
+fn build_grep_content_output(
+    content_lines: Vec<String>,
+    input: &GrepSearchInput,
+    output_mode: String,
+) -> GrepSearchOutput {
+    let (lines, applied_limit, applied_offset) =
+        apply_limit(content_lines, input.head_limit, input.offset);
+    GrepSearchOutput {
+        mode: Some(output_mode),
+        num_files: 0,
+        filenames: Vec::new(),
+        num_lines: Some(lines.len()),
+        content: Some(lines.join("\n")),
+        num_matches: None,
+        applied_limit,
+        applied_offset,
+    }
+}
+
+fn build_grep_count_output(
+    count_entries: Vec<(PathBuf, usize)>,
+    cwd: &Path,
+    input: &GrepSearchInput,
+    output_mode: String,
+) -> GrepSearchOutput {
+    let count_lines = count_entries
+        .into_iter()
+        .map(|(path, count)| format!("{}:{count}", relative_display_path(&path, cwd)))
+        .collect::<Vec<_>>();
+    let (lines, applied_limit, applied_offset) =
+        apply_limit(count_lines, input.head_limit, input.offset);
+    let total_matches = lines
+        .iter()
+        .filter_map(|line| line.rsplit_once(':'))
+        .filter_map(|(_, count)| count.parse::<usize>().ok())
+        .sum::<usize>();
+
+    GrepSearchOutput {
+        mode: Some(output_mode),
+        num_files: lines.len(),
+        filenames: Vec::new(),
+        content: Some(lines.join("\n")),
+        num_lines: None,
+        num_matches: Some(total_matches),
+        applied_limit,
+        applied_offset,
+    }
+}
+
+fn build_grep_files_output(
+    mut matched_files: Vec<PathBuf>,
+    cwd: &Path,
+    input: &GrepSearchInput,
+    output_mode: String,
+) -> GrepSearchOutput {
+    sort_paths_by_modified_desc(&mut matched_files);
+    let relative_matches = matched_files
+        .into_iter()
+        .map(|path| relative_display_path(&path, cwd))
+        .collect::<Vec<_>>();
+    let (filenames, applied_limit, applied_offset) =
+        apply_limit(relative_matches, input.head_limit, input.offset);
+
+    GrepSearchOutput {
+        mode: Some(output_mode),
+        num_files: filenames.len(),
+        filenames,
+        content: None,
+        num_lines: None,
+        num_matches: None,
+        applied_limit,
+        applied_offset,
+    }
+}
+
 fn apply_limit<T>(
     items: Vec<T>,
     limit: Option<usize>,
@@ -492,6 +589,84 @@ fn apply_limit<T>(
         truncated.then_some(explicit_limit),
         (offset_value > 0).then_some(offset_value),
     )
+}
+
+fn sort_paths_by_modified_desc(paths: &mut [PathBuf]) {
+    paths.sort_by(|left, right| {
+        let left_modified = fs::metadata(left)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        let right_modified = fs::metadata(right)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        right_modified.cmp(&left_modified).then_with(|| {
+            let left_display = left.to_string_lossy();
+            let right_display = right.to_string_lossy();
+            left_display.as_ref().cmp(right_display.as_ref())
+        })
+    });
+}
+
+fn relative_display_path(path: &Path, cwd: &Path) -> String {
+    let normalized_path = normalize_display_path(path);
+    let normalized_cwd = normalize_display_path(cwd);
+    diff_paths(&normalized_path, &normalized_cwd)
+        .unwrap_or(normalized_path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn normalize_display_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let raw = path.to_string_lossy();
+        if let Some(stripped) = raw.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{stripped}"));
+        }
+        if let Some(stripped) = raw.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+
+    path.to_path_buf()
+}
+
+fn diff_paths(path: &Path, base: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let path_components = path.components().collect::<Vec<_>>();
+    let base_components = base.components().collect::<Vec<_>>();
+
+    match (path_components.first(), base_components.first()) {
+        (Some(Component::Prefix(path_prefix)), Some(Component::Prefix(base_prefix)))
+            if path_prefix.kind() != base_prefix.kind() =>
+        {
+            return None;
+        }
+        (Some(Component::RootDir), Some(Component::Prefix(_)))
+        | (Some(Component::Prefix(_)), Some(Component::RootDir)) => return None,
+        _ => {}
+    }
+
+    let common_prefix_len = path_components
+        .iter()
+        .zip(base_components.iter())
+        .take_while(|(left, right)| left == right)
+        .count();
+
+    let mut relative = PathBuf::new();
+    for _ in common_prefix_len..base_components.len() {
+        relative.push("..");
+    }
+    for component in &path_components[common_prefix_len..] {
+        relative.push(component.as_os_str());
+    }
+
+    if relative.as_os_str().is_empty() {
+        Some(PathBuf::from("."))
+    } else {
+        Some(relative)
+    }
 }
 
 fn make_patch(original: &str, updated: &str) -> Vec<StructuredPatchHunk> {

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -13,6 +13,7 @@ use serde_json::{json, Value};
 use crate::bash_shell_path;
 use crate::config::{RuntimeFeatureConfig, RuntimeHookConfig};
 use crate::permissions::PermissionOverride;
+use crate::session::CompactTrigger;
 
 pub type HookPermissionDecision = PermissionOverride;
 
@@ -21,6 +22,9 @@ pub enum HookEvent {
     PreToolUse,
     PostToolUse,
     PostToolUseFailure,
+    PreCompact,
+    PostCompact,
+    SessionStart,
 }
 
 impl HookEvent {
@@ -30,6 +34,9 @@ impl HookEvent {
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
             Self::PostToolUseFailure => "PostToolUseFailure",
+            Self::PreCompact => "PreCompact",
+            Self::PostCompact => "PostCompact",
+            Self::SessionStart => "SessionStart",
         }
     }
 }
@@ -147,6 +154,44 @@ impl HookRunResult {
     pub fn updated_input_json(&self) -> Option<&str> {
         self.updated_input()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PreCompactHookResult {
+    new_custom_instructions: Option<String>,
+    user_display_message: Option<String>,
+}
+
+impl PreCompactHookResult {
+    #[must_use]
+    pub fn new_custom_instructions(&self) -> Option<&str> {
+        self.new_custom_instructions.as_deref()
+    }
+
+    #[must_use]
+    pub fn user_display_message(&self) -> Option<&str> {
+        self.user_display_message.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PostCompactHookResult {
+    user_display_message: Option<String>,
+}
+
+impl PostCompactHookResult {
+    #[must_use]
+    pub fn user_display_message(&self) -> Option<&str> {
+        self.user_display_message.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ContextHookCommandResult {
+    command: String,
+    succeeded: bool,
+    cancelled: bool,
+    output: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -305,6 +350,232 @@ impl HookRunner {
             abort_signal,
             None,
         )
+    }
+
+    #[must_use]
+    pub fn run_pre_compact(
+        &self,
+        trigger: CompactTrigger,
+        custom_instructions: Option<&str>,
+    ) -> PreCompactHookResult {
+        self.run_pre_compact_with_context(trigger, custom_instructions, None, None)
+    }
+
+    #[must_use]
+    pub fn run_pre_compact_with_context(
+        &self,
+        trigger: CompactTrigger,
+        custom_instructions: Option<&str>,
+        abort_signal: Option<&HookAbortSignal>,
+        reporter: Option<&mut dyn HookProgressReporter>,
+    ) -> PreCompactHookResult {
+        let payload = hook_pre_compact_payload(trigger, custom_instructions).to_string();
+        let command_results = Self::run_contextual_commands(
+            HookEvent::PreCompact,
+            self.config.pre_compact(),
+            "compact",
+            &payload,
+            abort_signal,
+            reporter,
+            |child| {
+                child.env("HOOK_TRIGGER", trigger.as_str());
+                if let Some(custom_instructions) = custom_instructions {
+                    child.env("HOOK_CUSTOM_INSTRUCTIONS", custom_instructions);
+                }
+            },
+        );
+
+        build_pre_compact_hook_result(&command_results)
+    }
+
+    #[must_use]
+    pub fn run_post_compact(
+        &self,
+        trigger: CompactTrigger,
+        compact_summary: &str,
+    ) -> PostCompactHookResult {
+        self.run_post_compact_with_context(trigger, compact_summary, None, None)
+    }
+
+    #[must_use]
+    pub fn run_post_compact_with_context(
+        &self,
+        trigger: CompactTrigger,
+        compact_summary: &str,
+        abort_signal: Option<&HookAbortSignal>,
+        reporter: Option<&mut dyn HookProgressReporter>,
+    ) -> PostCompactHookResult {
+        let payload = hook_post_compact_payload(trigger, compact_summary).to_string();
+        let command_results = Self::run_contextual_commands(
+            HookEvent::PostCompact,
+            self.config.post_compact(),
+            "compact",
+            &payload,
+            abort_signal,
+            reporter,
+            |child| {
+                child.env("HOOK_TRIGGER", trigger.as_str());
+                child.env("HOOK_COMPACT_SUMMARY", compact_summary);
+            },
+        );
+
+        build_post_compact_hook_result(&command_results)
+    }
+
+    #[must_use]
+    pub fn run_session_start(&self, source: &str, model: Option<&str>) -> HookRunResult {
+        self.run_session_start_with_context(source, model, None, None)
+    }
+
+    #[must_use]
+    pub fn run_session_start_with_context(
+        &self,
+        source: &str,
+        model: Option<&str>,
+        abort_signal: Option<&HookAbortSignal>,
+        mut reporter: Option<&mut dyn HookProgressReporter>,
+    ) -> HookRunResult {
+        let commands = self.config.session_start();
+        if commands.is_empty() {
+            return HookRunResult::allow(Vec::new());
+        }
+
+        if abort_signal.is_some_and(HookAbortSignal::is_aborted) {
+            return HookRunResult {
+                denied: false,
+                failed: false,
+                cancelled: true,
+                messages: vec![String::from("SessionStart hook cancelled before execution")],
+                permission_override: None,
+                permission_reason: None,
+                updated_input: None,
+            };
+        }
+
+        let payload = hook_session_start_payload(source, model).to_string();
+        let mut result = HookRunResult::allow(Vec::new());
+
+        for command in commands {
+            if let Some(reporter) = reporter.as_deref_mut() {
+                reporter.on_event(&HookProgressEvent::Started {
+                    event: HookEvent::SessionStart,
+                    tool_name: source.to_string(),
+                    command: command.clone(),
+                });
+            }
+
+            match Self::run_session_start_command(command, source, model, &payload, abort_signal) {
+                HookCommandOutcome::Allow { parsed } => {
+                    if let Some(reporter) = reporter.as_deref_mut() {
+                        reporter.on_event(&HookProgressEvent::Completed {
+                            event: HookEvent::SessionStart,
+                            tool_name: source.to_string(),
+                            command: command.clone(),
+                        });
+                    }
+                    merge_parsed_hook_output(&mut result, parsed);
+                }
+                HookCommandOutcome::Deny { parsed } => {
+                    if let Some(reporter) = reporter.as_deref_mut() {
+                        reporter.on_event(&HookProgressEvent::Completed {
+                            event: HookEvent::SessionStart,
+                            tool_name: source.to_string(),
+                            command: command.clone(),
+                        });
+                    }
+                    merge_parsed_hook_output(&mut result, parsed);
+                    result.denied = true;
+                    return result;
+                }
+                HookCommandOutcome::Failed { parsed } => {
+                    if let Some(reporter) = reporter.as_deref_mut() {
+                        reporter.on_event(&HookProgressEvent::Completed {
+                            event: HookEvent::SessionStart,
+                            tool_name: source.to_string(),
+                            command: command.clone(),
+                        });
+                    }
+                    merge_parsed_hook_output(&mut result, parsed);
+                    result.failed = true;
+                    return result;
+                }
+                HookCommandOutcome::Cancelled { message } => {
+                    if let Some(reporter) = reporter.as_deref_mut() {
+                        reporter.on_event(&HookProgressEvent::Cancelled {
+                            event: HookEvent::SessionStart,
+                            tool_name: source.to_string(),
+                            command: command.clone(),
+                        });
+                    }
+                    result.cancelled = true;
+                    result.messages.push(message);
+                    return result;
+                }
+            }
+        }
+
+        result
+    }
+
+    fn run_contextual_commands<F>(
+        event: HookEvent,
+        commands: &[String],
+        context_name: &str,
+        payload: &str,
+        abort_signal: Option<&HookAbortSignal>,
+        mut reporter: Option<&mut dyn HookProgressReporter>,
+        mut configure_env: F,
+    ) -> Vec<ContextHookCommandResult>
+    where
+        F: FnMut(&mut CommandWithStdin),
+    {
+        let mut results = Vec::new();
+        for command in commands {
+            if abort_signal.is_some_and(HookAbortSignal::is_aborted) {
+                results.push(ContextHookCommandResult {
+                    command: command.clone(),
+                    succeeded: false,
+                    cancelled: true,
+                    output: format!("{} hook cancelled before execution", event.as_str()),
+                });
+                break;
+            }
+
+            if let Some(reporter) = reporter.as_deref_mut() {
+                reporter.on_event(&HookProgressEvent::Started {
+                    event,
+                    tool_name: context_name.to_string(),
+                    command: command.clone(),
+                });
+            }
+
+            let result = Self::run_contextual_command(
+                command,
+                event,
+                context_name,
+                payload,
+                abort_signal,
+                &mut configure_env,
+            );
+            if let Some(reporter) = reporter.as_deref_mut() {
+                let event = if result.cancelled {
+                    HookProgressEvent::Cancelled {
+                        event,
+                        tool_name: context_name.to_string(),
+                        command: command.clone(),
+                    }
+                } else {
+                    HookProgressEvent::Completed {
+                        event,
+                        tool_name: context_name.to_string(),
+                        command: command.clone(),
+                    }
+                };
+                reporter.on_event(&event);
+            }
+            results.push(result);
+        }
+        results
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -503,6 +774,175 @@ impl HookRunner {
             },
         }
     }
+
+    fn run_session_start_command(
+        command: &str,
+        source: &str,
+        model: Option<&str>,
+        payload: &str,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> HookCommandOutcome {
+        let mut child = match shell_command(command) {
+            Ok(child) => child,
+            Err(error) => {
+                return HookCommandOutcome::Failed {
+                    parsed: ParsedHookOutput {
+                        messages: vec![format!(
+                            "SessionStart hook `{command}` failed to start for `{source}`: {error}"
+                        )],
+                        ..ParsedHookOutput::default()
+                    },
+                };
+            }
+        };
+        child.stdin(Stdio::piped());
+        child.stdout(Stdio::piped());
+        child.stderr(Stdio::piped());
+        child.env("HOOK_EVENT", HookEvent::SessionStart.as_str());
+        child.env("HOOK_SESSION_SOURCE", source);
+        if let Some(model) = model {
+            child.env("HOOK_MODEL", model);
+        }
+
+        match child.output_with_stdin(payload.as_bytes(), abort_signal) {
+            Ok(CommandExecution::Finished(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let parsed = parse_hook_output(&stdout);
+                let primary_message = parsed.primary_message().map(ToOwned::to_owned);
+                match output.status.code() {
+                    Some(0) => {
+                        if parsed.deny {
+                            HookCommandOutcome::Deny { parsed }
+                        } else {
+                            HookCommandOutcome::Allow { parsed }
+                        }
+                    }
+                    Some(2) => HookCommandOutcome::Deny {
+                        parsed: parsed.with_fallback_message(format!(
+                            "SessionStart hook denied `{source}`"
+                        )),
+                    },
+                    Some(code) => HookCommandOutcome::Failed {
+                        parsed: parsed.with_fallback_message(format_hook_failure(
+                            command,
+                            code,
+                            primary_message.as_deref(),
+                            stderr.as_str(),
+                        )),
+                    },
+                    None => HookCommandOutcome::Failed {
+                        parsed: parsed.with_fallback_message(format!(
+                            "SessionStart hook `{command}` terminated by signal while handling `{source}`"
+                        )),
+                    },
+                }
+            }
+            Ok(CommandExecution::Cancelled) => HookCommandOutcome::Cancelled {
+                message: format!(
+                    "SessionStart hook `{command}` cancelled while handling `{source}`"
+                ),
+            },
+            Err(error) => HookCommandOutcome::Failed {
+                parsed: ParsedHookOutput {
+                    messages: vec![format!(
+                        "SessionStart hook `{command}` failed to start for `{source}`: {error}"
+                    )],
+                    ..ParsedHookOutput::default()
+                },
+            },
+        }
+    }
+
+    fn run_contextual_command<F>(
+        command: &str,
+        event: HookEvent,
+        context_name: &str,
+        payload: &str,
+        abort_signal: Option<&HookAbortSignal>,
+        configure_env: &mut F,
+    ) -> ContextHookCommandResult
+    where
+        F: FnMut(&mut CommandWithStdin),
+    {
+        let mut child = match shell_command(command) {
+            Ok(child) => child,
+            Err(error) => {
+                return ContextHookCommandResult {
+                    command: command.to_string(),
+                    succeeded: false,
+                    cancelled: false,
+                    output: format!(
+                        "{} hook `{command}` failed to start for `{context_name}`: {error}",
+                        event.as_str()
+                    ),
+                };
+            }
+        };
+        child.stdin(Stdio::piped());
+        child.stdout(Stdio::piped());
+        child.stderr(Stdio::piped());
+        child.env("HOOK_EVENT", event.as_str());
+        configure_env(&mut child);
+
+        match child.output_with_stdin(payload.as_bytes(), abort_signal) {
+            Ok(CommandExecution::Finished(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let rendered = if stdout.is_empty() {
+                    stderr.clone()
+                } else {
+                    stdout.clone()
+                };
+                match output.status.code() {
+                    Some(0) => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: true,
+                        cancelled: false,
+                        output: rendered,
+                    },
+                    Some(code) => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: false,
+                        cancelled: false,
+                        output: format_hook_failure(
+                            command,
+                            code,
+                            (!rendered.is_empty()).then_some(rendered.as_str()),
+                            stderr.as_str(),
+                        ),
+                    },
+                    None => ContextHookCommandResult {
+                        command: command.to_string(),
+                        succeeded: false,
+                        cancelled: false,
+                        output: format!(
+                            "{} hook `{command}` terminated by signal while handling `{context_name}`",
+                            event.as_str()
+                        ),
+                    },
+                }
+            }
+            Ok(CommandExecution::Cancelled) => ContextHookCommandResult {
+                command: command.to_string(),
+                succeeded: false,
+                cancelled: true,
+                output: format!(
+                    "{} hook `{command}` cancelled while handling `{context_name}`",
+                    event.as_str()
+                ),
+            },
+            Err(error) => ContextHookCommandResult {
+                command: command.to_string(),
+                succeeded: false,
+                cancelled: false,
+                output: format!(
+                    "{} hook `{command}` failed to start for `{context_name}`: {error}",
+                    event.as_str()
+                ),
+            },
+        }
+    }
 }
 
 enum HookCommandOutcome {
@@ -544,6 +984,92 @@ fn merge_parsed_hook_output(target: &mut HookRunResult, parsed: ParsedHookOutput
     }
     if parsed.updated_input.is_some() {
         target.updated_input = parsed.updated_input;
+    }
+}
+
+fn build_pre_compact_hook_result(
+    command_results: &[ContextHookCommandResult],
+) -> PreCompactHookResult {
+    if command_results.is_empty() {
+        return PreCompactHookResult::default();
+    }
+
+    let new_custom_instructions = command_results
+        .iter()
+        .filter(|result| result.succeeded)
+        .map(|result| result.output.trim())
+        .filter(|output| !output.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let user_display_message = command_results
+        .iter()
+        .map(|result| {
+            if result.succeeded {
+                if result.output.trim().is_empty() {
+                    format!("PreCompact [{}] completed successfully", result.command)
+                } else {
+                    format!(
+                        "PreCompact [{}] completed successfully: {}",
+                        result.command,
+                        result.output.trim()
+                    )
+                }
+            } else if result.output.trim().is_empty() {
+                format!("PreCompact [{}] failed", result.command)
+            } else {
+                format!(
+                    "PreCompact [{}] failed: {}",
+                    result.command,
+                    result.output.trim()
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    PreCompactHookResult {
+        new_custom_instructions: (!new_custom_instructions.is_empty())
+            .then_some(new_custom_instructions),
+        user_display_message: (!user_display_message.is_empty()).then_some(user_display_message),
+    }
+}
+
+fn build_post_compact_hook_result(
+    command_results: &[ContextHookCommandResult],
+) -> PostCompactHookResult {
+    if command_results.is_empty() {
+        return PostCompactHookResult::default();
+    }
+
+    let user_display_message = command_results
+        .iter()
+        .map(|result| {
+            if result.succeeded {
+                if result.output.trim().is_empty() {
+                    format!("PostCompact [{}] completed successfully", result.command)
+                } else {
+                    format!(
+                        "PostCompact [{}] completed successfully: {}",
+                        result.command,
+                        result.output.trim()
+                    )
+                }
+            } else if result.output.trim().is_empty() {
+                format!("PostCompact [{}] failed", result.command)
+            } else {
+                format!(
+                    "PostCompact [{}] failed: {}",
+                    result.command,
+                    result.output.trim()
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    PostCompactHookResult {
+        user_display_message: (!user_display_message.is_empty()).then_some(user_display_message),
     }
 }
 
@@ -628,6 +1154,30 @@ fn hook_payload(
             "tool_result_is_error": is_error,
         }),
     }
+}
+
+fn hook_session_start_payload(source: &str, model: Option<&str>) -> Value {
+    json!({
+        "hook_event_name": HookEvent::SessionStart.as_str(),
+        "session_source": source,
+        "model": model,
+    })
+}
+
+fn hook_pre_compact_payload(trigger: CompactTrigger, custom_instructions: Option<&str>) -> Value {
+    json!({
+        "hook_event_name": HookEvent::PreCompact.as_str(),
+        "trigger": trigger.as_str(),
+        "custom_instructions": custom_instructions,
+    })
+}
+
+fn hook_post_compact_payload(trigger: CompactTrigger, compact_summary: &str) -> Value {
+    json!({
+        "hook_event_name": HookEvent::PostCompact.as_str(),
+        "trigger": trigger.as_str(),
+        "compact_summary": compact_summary,
+    })
 }
 
 fn parse_tool_input(tool_input: &str) -> Value {
@@ -730,6 +1280,7 @@ mod tests {
     };
     use crate::config::{RuntimeFeatureConfig, RuntimeHookConfig};
     use crate::permissions::PermissionOverride;
+    use crate::session::CompactTrigger;
     #[cfg(windows)]
     use crate::{bash_shell_path, set_shell_if_windows};
 
@@ -868,6 +1419,60 @@ mod tests {
         // then
         assert!(!result.is_denied());
         assert_eq!(result.messages(), &["failure hook ran".to_string()]);
+    }
+
+    #[test]
+    fn runs_session_start_hooks_with_compact_source_context() {
+        if !windows_bash_smoke_ok() {
+            return;
+        }
+        let runner =
+            HookRunner::new(
+                RuntimeHookConfig::default().with_session_start(vec![shell_snippet(
+                    r#"printf '%s|%s' "$HOOK_SESSION_SOURCE" "$HOOK_MODEL""#,
+                )]),
+            );
+
+        let result = runner.run_session_start("compact", Some("claude-opus-4-6"));
+
+        assert_eq!(
+            result,
+            HookRunResult::allow(vec!["compact|claude-opus-4-6".to_string()])
+        );
+    }
+
+    #[test]
+    fn runs_pre_and_post_compact_hooks_without_blocking_compaction() {
+        if !windows_bash_smoke_ok() {
+            return;
+        }
+        let runner = HookRunner::new(
+            RuntimeHookConfig::default()
+                .with_pre_compact(vec![
+                    shell_snippet(r#"printf '%s|%s' "$HOOK_TRIGGER" "$HOOK_CUSTOM_INSTRUCTIONS""#),
+                    shell_snippet("printf 'broken pre'; exit 1"),
+                ])
+                .with_post_compact(vec![shell_snippet(
+                    r#"printf '%s|%s' "$HOOK_TRIGGER" "$HOOK_COMPACT_SUMMARY""#,
+                )]),
+        );
+
+        let pre_result = runner.run_pre_compact(CompactTrigger::Manual, Some("keep latest logs"));
+        assert_eq!(
+            pre_result.new_custom_instructions(),
+            Some("manual|keep latest logs")
+        );
+        let pre_display = pre_result
+            .user_display_message()
+            .expect("pre-compact display message");
+        assert!(pre_display.contains("manual|keep latest logs"));
+        assert!(pre_display.contains("broken pre"));
+
+        let post_result = runner.run_post_compact(CompactTrigger::Auto, "summary body");
+        let post_display = post_result
+            .user_display_message()
+            .expect("post-compact display message");
+        assert!(post_display.contains("auto|summary body"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -40,6 +40,7 @@ pub mod summary_compression;
 pub mod task_packet;
 pub mod task_registry;
 pub mod team_cron_registry;
+mod tool_output;
 mod tool_session;
 #[cfg(test)]
 mod trust_resolver;
@@ -173,6 +174,7 @@ pub use stale_branch::{
     StaleBranchPolicy,
 };
 pub use task_packet::{validate_packet, TaskPacket, TaskPacketValidationError, ValidatedPacket};
+pub use tool_output::{tool_output_root, tool_result_path, tool_results_dir};
 #[cfg(test)]
 pub use trust_resolver::{TrustConfig, TrustDecision, TrustEvent, TrustPolicy, TrustResolver};
 pub use usage::{

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -158,8 +158,10 @@ pub use sandbox::{
     SandboxRequest, SandboxStatus,
 };
 pub use session::{
-    ContentBlock, ConversationMessage, MessageRole, Session, SessionCompaction, SessionError,
-    SessionFork, SessionPromptEntry,
+    AttachmentKind, AttachmentMetadata, CompactBoundaryMetadata, CompactPreservedSegment,
+    CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent, HookResultMetadata,
+    MessageRole, Session, SessionCompaction, SessionError, SessionFork, SessionPromptEntry,
+    SystemMessageSubtype,
 };
 pub use sse::{IncrementalSseParser, SseEvent};
 pub use stale_base::{

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -41,11 +41,70 @@ pub enum ContentBlock {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemMessageSubtype {
+    CompactBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachmentKind {
+    RunningAgents,
+    TodoList,
+    PlanMode,
+    InvokedSkills,
+    HookAdditionalContext,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactTrigger {
+    Manual,
+    Auto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactPreservedSegment {
+    pub head: String,
+    pub anchor: String,
+    pub tail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactBoundaryMetadata {
+    pub trigger: CompactTrigger,
+    pub pre_tokens: usize,
+    pub user_context: Option<String>,
+    pub messages_summarized: Option<usize>,
+    pub pre_compact_discovered_tools: Vec<String>,
+    pub preserved_segment: Option<CompactPreservedSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentMetadata {
+    pub kind: AttachmentKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookResultEvent {
+    SessionStart,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookResultMetadata {
+    pub event: HookResultEvent,
+    pub source: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConversationMessage {
     pub role: MessageRole,
     pub blocks: Vec<ContentBlock>,
     pub usage: Option<TokenUsage>,
+    pub subtype: Option<SystemMessageSubtype>,
+    pub compact_metadata: Option<CompactBoundaryMetadata>,
+    pub attachment_metadata: Option<AttachmentMetadata>,
+    pub hook_result_metadata: Option<HookResultMetadata>,
+    pub is_compact_summary: bool,
+    pub is_visible_in_transcript_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -591,12 +650,92 @@ impl Default for Session {
 
 impl ConversationMessage {
     #[must_use]
+    pub fn system_text(text: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::System,
+            blocks: vec![ContentBlock::Text { text: text.into() }],
+            usage: None,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
+        }
+    }
+
+    #[must_use]
+    pub fn compact_boundary(metadata: CompactBoundaryMetadata) -> Self {
+        Self {
+            role: MessageRole::System,
+            blocks: vec![ContentBlock::Text {
+                text: "Conversation compacted".to_string(),
+            }],
+            usage: None,
+            subtype: Some(SystemMessageSubtype::CompactBoundary),
+            compact_metadata: Some(metadata),
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
+        }
+    }
+
+    #[must_use]
     pub fn user_text(text: impl Into<String>) -> Self {
+        Self::user_text_with_metadata(text, None, None, false, false)
+    }
+
+    #[must_use]
+    pub fn attachment_user_text(text: impl Into<String>, kind: AttachmentKind) -> Self {
+        Self::user_text_with_metadata(text, Some(AttachmentMetadata { kind }), None, false, false)
+    }
+
+    #[must_use]
+    pub fn hook_result_user_text(
+        text: impl Into<String>,
+        attachment_kind: Option<AttachmentKind>,
+        event: HookResultEvent,
+        source: impl Into<String>,
+    ) -> Self {
+        Self::user_text_with_metadata(
+            text,
+            attachment_kind.map(|kind| AttachmentMetadata { kind }),
+            Some(HookResultMetadata {
+                event,
+                source: source.into(),
+            }),
+            false,
+            false,
+        )
+    }
+
+    fn user_text_with_metadata(
+        text: impl Into<String>,
+        attachment_metadata: Option<AttachmentMetadata>,
+        hook_result_metadata: Option<HookResultMetadata>,
+        is_compact_summary: bool,
+        is_visible_in_transcript_only: bool,
+    ) -> Self {
         Self {
             role: MessageRole::User,
             blocks: vec![ContentBlock::Text { text: text.into() }],
             usage: None,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata,
+            hook_result_metadata,
+            is_compact_summary,
+            is_visible_in_transcript_only,
         }
+    }
+
+    #[must_use]
+    pub fn compact_summary_user_text(
+        text: impl Into<String>,
+        is_visible_in_transcript_only: bool,
+    ) -> Self {
+        Self::user_text_with_metadata(text, None, None, true, is_visible_in_transcript_only)
     }
 
     #[must_use]
@@ -605,6 +744,12 @@ impl ConversationMessage {
             role: MessageRole::Assistant,
             blocks,
             usage: None,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
         }
     }
 
@@ -614,6 +759,12 @@ impl ConversationMessage {
             role: MessageRole::Assistant,
             blocks,
             usage,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
         }
     }
 
@@ -633,6 +784,12 @@ impl ConversationMessage {
                 is_error,
             }],
             usage: None,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
         }
     }
 
@@ -657,6 +814,41 @@ impl ConversationMessage {
         );
         if let Some(usage) = self.usage {
             object.insert("usage".to_string(), usage_to_json(usage));
+        }
+        if let Some(subtype) = &self.subtype {
+            object.insert(
+                "subtype".to_string(),
+                JsonValue::String(subtype.as_str().to_string()),
+            );
+        }
+        if let Some(compact_metadata) = &self.compact_metadata {
+            object.insert(
+                "compact_metadata".to_string(),
+                compact_metadata
+                    .to_json()
+                    .expect("compact metadata to serialize"),
+            );
+        }
+        if let Some(attachment_metadata) = &self.attachment_metadata {
+            object.insert(
+                "attachment_metadata".to_string(),
+                attachment_metadata.to_json(),
+            );
+        }
+        if let Some(hook_result_metadata) = &self.hook_result_metadata {
+            object.insert(
+                "hook_result_metadata".to_string(),
+                hook_result_metadata.to_json(),
+            );
+        }
+        if self.is_compact_summary {
+            object.insert("is_compact_summary".to_string(), JsonValue::Bool(true));
+        }
+        if self.is_visible_in_transcript_only {
+            object.insert(
+                "is_visible_in_transcript_only".to_string(),
+                JsonValue::Bool(true),
+            );
         }
         JsonValue::Object(object)
     }
@@ -688,10 +880,70 @@ impl ConversationMessage {
             .map(ContentBlock::from_json)
             .collect::<Result<Vec<_>, _>>()?;
         let usage = object.get("usage").map(usage_from_json).transpose()?;
+        let subtype = object
+            .get("subtype")
+            .map(SystemMessageSubtype::from_json)
+            .transpose()?;
+        let compact_metadata = object
+            .get("compact_metadata")
+            .map(CompactBoundaryMetadata::from_json)
+            .transpose()?;
+        let attachment_metadata = object
+            .get("attachment_metadata")
+            .map(AttachmentMetadata::from_json)
+            .transpose()?;
+        let hook_result_metadata = object
+            .get("hook_result_metadata")
+            .map(HookResultMetadata::from_json)
+            .transpose()?;
+        let is_compact_summary = object
+            .get("is_compact_summary")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        let is_visible_in_transcript_only = object
+            .get("is_visible_in_transcript_only")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        if subtype.is_some() && role != MessageRole::System {
+            return Err(SessionError::Format(
+                "message subtype is only supported on system messages".to_string(),
+            ));
+        }
+        if compact_metadata.is_some() && subtype != Some(SystemMessageSubtype::CompactBoundary) {
+            return Err(SessionError::Format(
+                "compact_metadata requires subtype=compact_boundary".to_string(),
+            ));
+        }
+        if attachment_metadata.is_some() && role != MessageRole::User {
+            return Err(SessionError::Format(
+                "attachment_metadata is only supported on user messages".to_string(),
+            ));
+        }
+        if hook_result_metadata.is_some() && role != MessageRole::User {
+            return Err(SessionError::Format(
+                "hook_result_metadata is only supported on user messages".to_string(),
+            ));
+        }
+        if is_compact_summary && role != MessageRole::User {
+            return Err(SessionError::Format(
+                "is_compact_summary is only supported on user messages".to_string(),
+            ));
+        }
+        if is_compact_summary && (attachment_metadata.is_some() || hook_result_metadata.is_some()) {
+            return Err(SessionError::Format(
+                "compact summary messages cannot also be attachments or hook results".to_string(),
+            ));
+        }
         Ok(Self {
             role,
             blocks,
             usage,
+            subtype,
+            compact_metadata,
+            attachment_metadata,
+            hook_result_metadata,
+            is_compact_summary,
+            is_visible_in_transcript_only,
         })
     }
 }
@@ -769,6 +1021,266 @@ impl ContentBlock {
                 "unsupported block type: {other}"
             ))),
         }
+    }
+}
+
+impl SystemMessageSubtype {
+    #[must_use]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CompactBoundary => "compact_boundary",
+        }
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        match value
+            .as_str()
+            .ok_or_else(|| SessionError::Format("subtype must be a string".to_string()))?
+        {
+            "compact_boundary" => Ok(Self::CompactBoundary),
+            other => Err(SessionError::Format(format!(
+                "unsupported message subtype: {other}"
+            ))),
+        }
+    }
+}
+
+impl AttachmentKind {
+    #[must_use]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RunningAgents => "running_agents",
+            Self::TodoList => "todo_list",
+            Self::PlanMode => "plan_mode",
+            Self::InvokedSkills => "invoked_skills",
+            Self::HookAdditionalContext => "hook_additional_context",
+        }
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        match value
+            .as_str()
+            .ok_or_else(|| SessionError::Format("attachment kind must be a string".to_string()))?
+        {
+            "running_agents" => Ok(Self::RunningAgents),
+            "todo_list" => Ok(Self::TodoList),
+            "plan_mode" => Ok(Self::PlanMode),
+            "invoked_skills" => Ok(Self::InvokedSkills),
+            "hook_additional_context" => Ok(Self::HookAdditionalContext),
+            other => Err(SessionError::Format(format!(
+                "unsupported attachment kind: {other}"
+            ))),
+        }
+    }
+}
+
+impl CompactTrigger {
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Auto => "auto",
+        }
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        match value
+            .as_str()
+            .ok_or_else(|| SessionError::Format("compact trigger must be a string".to_string()))?
+        {
+            "manual" => Ok(Self::Manual),
+            "auto" => Ok(Self::Auto),
+            other => Err(SessionError::Format(format!(
+                "unsupported compact trigger: {other}"
+            ))),
+        }
+    }
+}
+
+impl AttachmentMetadata {
+    fn to_json(&self) -> JsonValue {
+        let mut object = BTreeMap::new();
+        object.insert(
+            "kind".to_string(),
+            JsonValue::String(self.kind.as_str().to_string()),
+        );
+        JsonValue::Object(object)
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        let object = value.as_object().ok_or_else(|| {
+            SessionError::Format("attachment_metadata must be an object".to_string())
+        })?;
+        Ok(Self {
+            kind: AttachmentKind::from_json(
+                object
+                    .get("kind")
+                    .ok_or_else(|| SessionError::Format("missing kind".to_string()))?,
+            )?,
+        })
+    }
+}
+
+impl HookResultEvent {
+    #[must_use]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionStart => "session_start",
+        }
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        match value
+            .as_str()
+            .ok_or_else(|| SessionError::Format("hook event must be a string".to_string()))?
+        {
+            "session_start" => Ok(Self::SessionStart),
+            other => Err(SessionError::Format(format!(
+                "unsupported hook event: {other}"
+            ))),
+        }
+    }
+}
+
+impl HookResultMetadata {
+    fn to_json(&self) -> JsonValue {
+        let mut object = BTreeMap::new();
+        object.insert(
+            "event".to_string(),
+            JsonValue::String(self.event.as_str().to_string()),
+        );
+        object.insert("source".to_string(), JsonValue::String(self.source.clone()));
+        JsonValue::Object(object)
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        let object = value.as_object().ok_or_else(|| {
+            SessionError::Format("hook_result_metadata must be an object".to_string())
+        })?;
+        Ok(Self {
+            event: HookResultEvent::from_json(
+                object
+                    .get("event")
+                    .ok_or_else(|| SessionError::Format("missing event".to_string()))?,
+            )?,
+            source: required_string(object, "source")?,
+        })
+    }
+}
+
+impl CompactPreservedSegment {
+    fn to_json(&self) -> JsonValue {
+        let mut object = BTreeMap::new();
+        object.insert(
+            "head_uuid".to_string(),
+            JsonValue::String(self.head.clone()),
+        );
+        object.insert(
+            "anchor_uuid".to_string(),
+            JsonValue::String(self.anchor.clone()),
+        );
+        object.insert(
+            "tail_uuid".to_string(),
+            JsonValue::String(self.tail.clone()),
+        );
+        JsonValue::Object(object)
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        let object = value.as_object().ok_or_else(|| {
+            SessionError::Format("preserved_segment must be an object".to_string())
+        })?;
+        Ok(Self {
+            head: required_string(object, "head_uuid")?,
+            anchor: required_string(object, "anchor_uuid")?,
+            tail: required_string(object, "tail_uuid")?,
+        })
+    }
+}
+
+impl CompactBoundaryMetadata {
+    fn to_json(&self) -> Result<JsonValue, SessionError> {
+        let mut object = BTreeMap::new();
+        object.insert(
+            "trigger".to_string(),
+            JsonValue::String(self.trigger.as_str().to_string()),
+        );
+        object.insert(
+            "pre_tokens".to_string(),
+            JsonValue::Number(i64_from_usize(self.pre_tokens, "pre_tokens")?),
+        );
+        if let Some(user_context) = &self.user_context {
+            object.insert(
+                "user_context".to_string(),
+                JsonValue::String(user_context.clone()),
+            );
+        }
+        if let Some(messages_summarized) = self.messages_summarized {
+            object.insert(
+                "messages_summarized".to_string(),
+                JsonValue::Number(i64_from_usize(messages_summarized, "messages_summarized")?),
+            );
+        }
+        if !self.pre_compact_discovered_tools.is_empty() {
+            object.insert(
+                "pre_compact_discovered_tools".to_string(),
+                JsonValue::Array(
+                    self.pre_compact_discovered_tools
+                        .iter()
+                        .cloned()
+                        .map(JsonValue::String)
+                        .collect(),
+                ),
+            );
+        }
+        if let Some(preserved_segment) = &self.preserved_segment {
+            object.insert("preserved_segment".to_string(), preserved_segment.to_json());
+        }
+        Ok(JsonValue::Object(object))
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        let object = value.as_object().ok_or_else(|| {
+            SessionError::Format("compact_metadata must be an object".to_string())
+        })?;
+        let pre_compact_discovered_tools = object
+            .get("pre_compact_discovered_tools")
+            .and_then(JsonValue::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| {
+                        value.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                            SessionError::Format(
+                                "pre_compact_discovered_tools must be strings".to_string(),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        Ok(Self {
+            trigger: CompactTrigger::from_json(
+                object
+                    .get("trigger")
+                    .ok_or_else(|| SessionError::Format("missing trigger".to_string()))?,
+            )?,
+            pre_tokens: required_usize(object, "pre_tokens")?,
+            user_context: object
+                .get("user_context")
+                .and_then(JsonValue::as_str)
+                .map(ToOwned::to_owned),
+            messages_summarized: object
+                .get("messages_summarized")
+                .map(|_| required_usize(object, "messages_summarized"))
+                .transpose()?,
+            pre_compact_discovered_tools,
+            preserved_segment: object
+                .get("preserved_segment")
+                .map(CompactPreservedSegment::from_json)
+                .transpose()?,
+        })
     }
 }
 
@@ -1111,8 +1623,10 @@ fn cleanup_rotated_logs(path: &Path) -> Result<(), SessionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_rotated_logs, current_time_millis, rotate_session_file_if_needed, ContentBlock,
-        ConversationMessage, MessageRole, Session, SessionFork,
+        cleanup_rotated_logs, current_time_millis, rotate_session_file_if_needed, AttachmentKind,
+        CompactBoundaryMetadata, CompactPreservedSegment, CompactTrigger, ContentBlock,
+        ConversationMessage, HookResultEvent, MessageRole, Session, SessionFork,
+        SystemMessageSubtype,
     };
     use crate::json::JsonValue;
     use crate::usage::TokenUsage;
@@ -1243,6 +1757,115 @@ mod tests {
         assert_eq!(compaction.count, 1);
         assert_eq!(compaction.removed_message_count, 4);
         assert!(compaction.summary.contains("summarized"));
+    }
+
+    #[test]
+    fn persists_compact_boundary_message_metadata() {
+        let path = temp_session_path("compact-boundary");
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::compact_boundary(CompactBoundaryMetadata {
+                trigger: CompactTrigger::Auto,
+                pre_tokens: 1234,
+                user_context: Some("preserve recent diagnostics".to_string()),
+                messages_summarized: Some(8),
+                pre_compact_discovered_tools: vec!["bash".to_string(), "read_file".to_string()],
+                preserved_segment: Some(CompactPreservedSegment {
+                    head: "source-message-8".to_string(),
+                    anchor: "summary-message".to_string(),
+                    tail: "source-message-11".to_string(),
+                }),
+            }),
+            ConversationMessage::user_text("Summary:\ncarried work"),
+        ];
+        session.save_to_path(&path).expect("session should save");
+
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        assert_eq!(
+            restored.messages[0].subtype,
+            Some(SystemMessageSubtype::CompactBoundary)
+        );
+        let metadata = restored.messages[0]
+            .compact_metadata
+            .as_ref()
+            .expect("compact boundary metadata");
+        assert_eq!(metadata.trigger, CompactTrigger::Auto);
+        assert_eq!(metadata.pre_tokens, 1234);
+        assert_eq!(metadata.messages_summarized, Some(8));
+        assert_eq!(
+            metadata.pre_compact_discovered_tools,
+            vec!["bash".to_string(), "read_file".to_string()]
+        );
+        assert_eq!(
+            metadata.preserved_segment.as_ref().map(|segment| (
+                segment.head.as_str(),
+                segment.anchor.as_str(),
+                segment.tail.as_str()
+            )),
+            Some(("source-message-8", "summary-message", "source-message-11"))
+        );
+    }
+
+    #[test]
+    fn persists_compact_summary_message_flags() {
+        let path = temp_session_path("compact-summary");
+        let mut session = Session::new();
+        session.messages = vec![ConversationMessage::compact_summary_user_text(
+            "Summary:\ncarry over context",
+            true,
+        )];
+        session.save_to_path(&path).expect("session should save");
+
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        assert!(restored.messages[0].is_compact_summary);
+        assert!(restored.messages[0].is_visible_in_transcript_only);
+    }
+
+    #[test]
+    fn persists_attachment_and_hook_result_metadata() {
+        let path = temp_session_path("attachment-hook");
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::attachment_user_text(
+                "Previously invoked skills remain available after compaction.",
+                AttachmentKind::InvokedSkills,
+            ),
+            ConversationMessage::hook_result_user_text(
+                "SessionStart hook (compact) output:\nPreserve diagnostics",
+                Some(AttachmentKind::HookAdditionalContext),
+                HookResultEvent::SessionStart,
+                "compact",
+            ),
+        ];
+        session.save_to_path(&path).expect("session should save");
+
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        assert_eq!(
+            restored.messages[0]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::InvokedSkills)
+        );
+        assert_eq!(
+            restored.messages[1]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::HookAdditionalContext)
+        );
+        let hook_metadata = restored.messages[1]
+            .hook_result_metadata
+            .as_ref()
+            .expect("hook result metadata");
+        assert_eq!(hook_metadata.event, HookResultEvent::SessionStart);
+        assert_eq!(hook_metadata.source, "compact");
     }
 
     #[test]
@@ -1393,6 +2016,49 @@ mod tests {
 
         // then
         assert!(error.to_string().contains("unsupported block type"));
+    }
+
+    #[test]
+    fn rejects_attachment_metadata_on_non_user_messages() {
+        let message = JsonValue::Object(
+            [
+                (
+                    "role".to_string(),
+                    JsonValue::String("assistant".to_string()),
+                ),
+                (
+                    "blocks".to_string(),
+                    JsonValue::Array(vec![JsonValue::Object(
+                        [
+                            ("type".to_string(), JsonValue::String("text".to_string())),
+                            ("text".to_string(), JsonValue::String("hello".to_string())),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )]),
+                ),
+                (
+                    "attachment_metadata".to_string(),
+                    JsonValue::Object(
+                        [(
+                            "kind".to_string(),
+                            JsonValue::String("invoked_skills".to_string()),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let error = ConversationMessage::from_json(&message)
+            .expect_err("assistant messages should reject attachment metadata");
+
+        assert!(error
+            .to_string()
+            .contains("attachment_metadata is only supported on user messages"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -8,11 +8,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::json::{JsonError, JsonValue};
 use crate::usage::TokenUsage;
+use getrandom::getrandom;
 
 const SESSION_VERSION: u32 = 1;
 const ROTATE_AFTER_BYTES: u64 = 256 * 1024;
 const MAX_ROTATED_FILES: usize = 3;
 static SESSION_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+static MESSAGE_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 static LAST_TIMESTAMP_MS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +98,7 @@ pub struct HookResultMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConversationMessage {
+    pub uuid: String,
     pub role: MessageRole,
     pub blocks: Vec<ContentBlock>,
     pub usage: Option<TokenUsage>,
@@ -649,36 +652,62 @@ impl Default for Session {
 }
 
 impl ConversationMessage {
-    #[must_use]
-    pub fn system_text(text: impl Into<String>) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        role: MessageRole,
+        blocks: Vec<ContentBlock>,
+        usage: Option<TokenUsage>,
+        subtype: Option<SystemMessageSubtype>,
+        compact_metadata: Option<CompactBoundaryMetadata>,
+        attachment_metadata: Option<AttachmentMetadata>,
+        hook_result_metadata: Option<HookResultMetadata>,
+        is_compact_summary: bool,
+        is_visible_in_transcript_only: bool,
+    ) -> Self {
         Self {
-            role: MessageRole::System,
-            blocks: vec![ContentBlock::Text { text: text.into() }],
-            usage: None,
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
+            uuid: generate_message_uuid(),
+            role,
+            blocks,
+            usage,
+            subtype,
+            compact_metadata,
+            attachment_metadata,
+            hook_result_metadata,
+            is_compact_summary,
+            is_visible_in_transcript_only,
         }
     }
 
     #[must_use]
+    pub fn system_text(text: impl Into<String>) -> Self {
+        Self::new(
+            MessageRole::System,
+            vec![ContentBlock::Text { text: text.into() }],
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )
+    }
+
+    #[must_use]
     pub fn compact_boundary(metadata: CompactBoundaryMetadata) -> Self {
-        Self {
-            role: MessageRole::System,
-            blocks: vec![ContentBlock::Text {
+        Self::new(
+            MessageRole::System,
+            vec![ContentBlock::Text {
                 text: "Conversation compacted".to_string(),
             }],
-            usage: None,
-            subtype: Some(SystemMessageSubtype::CompactBoundary),
-            compact_metadata: Some(metadata),
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }
+            None,
+            Some(SystemMessageSubtype::CompactBoundary),
+            Some(metadata),
+            None,
+            None,
+            false,
+            false,
+        )
     }
 
     #[must_use]
@@ -717,17 +746,17 @@ impl ConversationMessage {
         is_compact_summary: bool,
         is_visible_in_transcript_only: bool,
     ) -> Self {
-        Self {
-            role: MessageRole::User,
-            blocks: vec![ContentBlock::Text { text: text.into() }],
-            usage: None,
-            subtype: None,
-            compact_metadata: None,
+        Self::new(
+            MessageRole::User,
+            vec![ContentBlock::Text { text: text.into() }],
+            None,
+            None,
+            None,
             attachment_metadata,
             hook_result_metadata,
             is_compact_summary,
             is_visible_in_transcript_only,
-        }
+        )
     }
 
     #[must_use]
@@ -740,32 +769,32 @@ impl ConversationMessage {
 
     #[must_use]
     pub fn assistant(blocks: Vec<ContentBlock>) -> Self {
-        Self {
-            role: MessageRole::Assistant,
+        Self::new(
+            MessageRole::Assistant,
             blocks,
-            usage: None,
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )
     }
 
     #[must_use]
     pub fn assistant_with_usage(blocks: Vec<ContentBlock>, usage: Option<TokenUsage>) -> Self {
-        Self {
-            role: MessageRole::Assistant,
+        Self::new(
+            MessageRole::Assistant,
             blocks,
             usage,
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )
     }
 
     #[must_use]
@@ -775,27 +804,28 @@ impl ConversationMessage {
         output: impl Into<String>,
         is_error: bool,
     ) -> Self {
-        Self {
-            role: MessageRole::Tool,
-            blocks: vec![ContentBlock::ToolResult {
+        Self::new(
+            MessageRole::Tool,
+            vec![ContentBlock::ToolResult {
                 tool_use_id: tool_use_id.into(),
                 tool_name: tool_name.into(),
                 output: output.into(),
                 is_error,
             }],
-            usage: None,
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )
     }
 
     #[must_use]
     pub fn to_json(&self) -> JsonValue {
         let mut object = BTreeMap::new();
+        object.insert("uuid".to_string(), JsonValue::String(self.uuid.clone()));
         object.insert(
             "role".to_string(),
             JsonValue::String(
@@ -853,10 +883,25 @@ impl ConversationMessage {
         JsonValue::Object(object)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
         let object = value
             .as_object()
             .ok_or_else(|| SessionError::Format("message must be an object".to_string()))?;
+        let uuid = match object.get("uuid") {
+            Some(value) => {
+                let uuid = value.as_str().ok_or_else(|| {
+                    SessionError::Format("message uuid must be a string".to_string())
+                })?;
+                if uuid.trim().is_empty() {
+                    return Err(SessionError::Format(
+                        "message uuid cannot be empty".to_string(),
+                    ));
+                }
+                uuid.to_string()
+            }
+            None => generate_message_uuid(),
+        };
         let role = match object
             .get("role")
             .and_then(JsonValue::as_str)
@@ -935,6 +980,7 @@ impl ConversationMessage {
             ));
         }
         Ok(Self {
+            uuid,
             role,
             blocks,
             usage,
@@ -1540,6 +1586,38 @@ fn generate_session_id() -> String {
     format!("session-{millis}-{counter}")
 }
 
+fn generate_message_uuid() -> String {
+    let mut bytes = [0_u8; 16];
+    if getrandom(&mut bytes).is_err() {
+        let millis = current_time_millis();
+        let counter = MESSAGE_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        bytes[..8].copy_from_slice(&millis.to_be_bytes());
+        bytes[8..].copy_from_slice(&counter.to_be_bytes());
+    }
+    // RFC 4122 variant + version 4 bits.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )
+}
+
 fn write_atomic(path: &Path, contents: &str) -> Result<(), SessionError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -1698,7 +1776,27 @@ mod tests {
                 ("version".to_string(), JsonValue::Number(1)),
                 (
                     "messages".to_string(),
-                    JsonValue::Array(vec![ConversationMessage::user_text("legacy").to_json()]),
+                    JsonValue::Array(vec![JsonValue::Object(
+                        [
+                            ("role".to_string(), JsonValue::String("user".to_string())),
+                            (
+                                "blocks".to_string(),
+                                JsonValue::Array(vec![JsonValue::Object(
+                                    [
+                                        ("type".to_string(), JsonValue::String("text".to_string())),
+                                        (
+                                            "text".to_string(),
+                                            JsonValue::String("legacy".to_string()),
+                                        ),
+                                    ]
+                                    .into_iter()
+                                    .collect(),
+                                )]),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )]),
                 ),
             ]
             .into_iter()
@@ -1710,11 +1808,36 @@ mod tests {
         fs::remove_file(&path).expect("temp file should be removable");
 
         assert_eq!(restored.messages.len(), 1);
-        assert_eq!(
-            restored.messages[0],
-            ConversationMessage::user_text("legacy")
-        );
+        assert_eq!(restored.messages[0].role, MessageRole::User);
+        assert!(matches!(
+            restored.messages[0].blocks.as_slice(),
+            [ContentBlock::Text { text }] if text == "legacy"
+        ));
+        assert!(!restored.messages[0].uuid.is_empty());
         assert!(!restored.session_id.is_empty());
+    }
+
+    #[test]
+    fn loads_legacy_session_jsonl_without_message_uuids() {
+        let path = temp_session_path("legacy-jsonl");
+        let legacy = [
+            r#"{"type":"session_meta","version":1,"session_id":"legacy-jsonl","created_at_ms":1,"updated_at_ms":2}"#,
+            r#"{"type":"message","message":{"role":"user","blocks":[{"type":"text","text":"legacy jsonl"}]}}"#,
+        ]
+        .join("\n");
+        fs::write(&path, format!("{legacy}\n")).expect("legacy jsonl should write");
+
+        let restored = Session::load_from_path(&path).expect("legacy jsonl should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        assert_eq!(restored.messages.len(), 1);
+        assert_eq!(restored.messages[0].role, MessageRole::User);
+        assert!(matches!(
+            restored.messages[0].blocks.as_slice(),
+            [ContentBlock::Text { text }] if text == "legacy jsonl"
+        ));
+        assert!(!restored.messages[0].uuid.is_empty());
+        assert_eq!(restored.session_id, "legacy-jsonl");
     }
 
     #[test]
@@ -1737,7 +1860,12 @@ mod tests {
         fs::remove_file(&path).expect("temp file should be removable");
 
         assert_eq!(restored.messages.len(), 2);
-        assert_eq!(restored.messages[0], ConversationMessage::user_text("hi"));
+        assert_eq!(restored.messages[0].role, MessageRole::User);
+        assert!(matches!(
+            restored.messages[0].blocks.as_slice(),
+            [ContentBlock::Text { text }] if text == "hi"
+        ));
+        assert!(!restored.messages[0].uuid.is_empty());
     }
 
     #[test]
@@ -1771,9 +1899,9 @@ mod tests {
                 messages_summarized: Some(8),
                 pre_compact_discovered_tools: vec!["bash".to_string(), "read_file".to_string()],
                 preserved_segment: Some(CompactPreservedSegment {
-                    head: "source-message-8".to_string(),
-                    anchor: "summary-message".to_string(),
-                    tail: "source-message-11".to_string(),
+                    head: "message-head-uuid".to_string(),
+                    anchor: "summary-message-uuid".to_string(),
+                    tail: "message-tail-uuid".to_string(),
                 }),
             }),
             ConversationMessage::user_text("Summary:\ncarried work"),
@@ -1804,7 +1932,11 @@ mod tests {
                 segment.anchor.as_str(),
                 segment.tail.as_str()
             )),
-            Some(("source-message-8", "summary-message", "source-message-11"))
+            Some((
+                "message-head-uuid",
+                "summary-message-uuid",
+                "message-tail-uuid"
+            ))
         );
     }
 

--- a/rust/crates/runtime/src/tool_output.rs
+++ b/rust/crates/runtime/src/tool_output.rs
@@ -1,0 +1,115 @@
+use std::path::{Path, PathBuf};
+
+use crate::tool_session::current_tool_session_storage_root;
+
+const CLAW_STATE_DIR: &str = ".claw";
+const TOOL_RESULTS_DIR: &str = "tool-results";
+const TASK_OUTPUTS_DIR: &str = "tasks";
+
+#[must_use]
+pub fn tool_output_root(cwd: &Path) -> PathBuf {
+    current_tool_session_storage_root(cwd).unwrap_or_else(|| cwd.join(CLAW_STATE_DIR))
+}
+
+#[must_use]
+pub fn tool_results_dir(cwd: &Path) -> PathBuf {
+    tool_output_root(cwd).join(TOOL_RESULTS_DIR)
+}
+
+#[must_use]
+pub fn task_outputs_dir(cwd: &Path) -> PathBuf {
+    tool_output_root(cwd).join(TASK_OUTPUTS_DIR)
+}
+
+#[must_use]
+pub fn tool_result_path(cwd: &Path, tool_use_id: &str, extension: &str) -> PathBuf {
+    let extension = extension.trim_start_matches('.');
+    let safe_id = sanitize_tool_result_identifier(tool_use_id);
+    tool_results_dir(cwd).join(format!("{safe_id}.{extension}"))
+}
+
+fn sanitize_tool_result_identifier(tool_use_id: &str) -> String {
+    let sanitized = tool_use_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    if sanitized.is_empty() {
+        String::from("tool-result")
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{task_outputs_dir, tool_result_path, tool_results_dir};
+    use crate::tool_session::with_tool_session_context;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("runtime-tool-output-{unique}-{name}"))
+    }
+
+    #[test]
+    fn session_scoped_directories_live_under_session_root() {
+        let cwd = temp_dir("session-root");
+        let persistence_path = cwd
+            .join(".claw")
+            .join("sessions")
+            .join("workspace-hash")
+            .join("session-123.jsonl");
+        fs::create_dir_all(
+            persistence_path
+                .parent()
+                .expect("persistence path should have a parent"),
+        )
+        .expect("create session dir");
+
+        let (results_dir, tasks_dir) =
+            with_tool_session_context("session-123", Some(&persistence_path), || {
+                (tool_results_dir(&cwd), task_outputs_dir(&cwd))
+            });
+
+        assert_eq!(
+            results_dir,
+            cwd.join(".claw")
+                .join("sessions")
+                .join("workspace-hash")
+                .join("session-123")
+                .join("tool-results")
+        );
+        assert_eq!(
+            tasks_dir,
+            cwd.join(".claw")
+                .join("sessions")
+                .join("workspace-hash")
+                .join("session-123")
+                .join("tasks")
+        );
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn tool_result_path_sanitizes_tool_use_identifier() {
+        let cwd = temp_dir("sanitize-id");
+        let path = tool_result_path(&cwd, "call/with spaces", "txt");
+        assert!(
+            path.ends_with("call_with_spaces.txt"),
+            "unexpected tool result path: {path:?}"
+        );
+    }
+}

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -211,7 +211,7 @@ impl UsageTracker {
 #[cfg(test)]
 mod tests {
     use super::{format_usd, pricing_for_model, TokenUsage, UsageTracker};
-    use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::session::{ContentBlock, ConversationMessage, Session};
 
     #[test]
     fn tracks_true_cumulative_usage() {
@@ -287,24 +287,17 @@ mod tests {
     #[test]
     fn reconstructs_usage_from_session_messages() {
         let mut session = Session::new();
-        session.messages = vec![ConversationMessage {
-            role: MessageRole::Assistant,
-            blocks: vec![ContentBlock::Text {
+        session.messages = vec![ConversationMessage::assistant_with_usage(
+            vec![ContentBlock::Text {
                 text: "done".to_string(),
             }],
-            usage: Some(TokenUsage {
+            Some(TokenUsage {
                 input_tokens: 5,
                 output_tokens: 2,
                 cache_creation_input_tokens: 1,
                 cache_read_input_tokens: 0,
             }),
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }];
+        )];
 
         let tracker = UsageTracker::from_session(&session);
         assert_eq!(tracker.turns(), 1);

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -298,6 +298,12 @@ mod tests {
                 cache_creation_input_tokens: 1,
                 cache_read_input_tokens: 0,
             }),
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
         }];
 
         let tracker = UsageTracker::from_session(&session);

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -2829,6 +2829,58 @@ fn run_resume_command(
     session: &Session,
     command: &SlashCommand,
 ) -> Result<ResumeCommandOutcome, Box<dyn std::error::Error>> {
+    run_resume_command_with_compactor(session_path, session, command, &mut run_resume_full_compact)
+}
+
+fn run_resume_full_compact(
+    session: &Session,
+) -> Result<runtime::CompactionResult, Box<dyn std::error::Error>> {
+    let system_prompt = build_system_prompt()?;
+    let resolved_model = resolve_repl_model(DEFAULT_MODEL.to_string());
+    let mut runtime = build_runtime(
+        session.clone(),
+        &session.session_id,
+        resolved_model,
+        system_prompt,
+        true,
+        false,
+        None,
+        default_permission_mode(),
+        None,
+    )?;
+    Ok(runtime.compact(CompactionConfig {
+        max_estimated_tokens: 0,
+        ..CompactionConfig::default()
+    })?)
+}
+
+fn format_resume_compact_message(
+    removed: usize,
+    kept: usize,
+    skipped: bool,
+    user_display_message: Option<&str>,
+) -> String {
+    let mut message = format_compact_report(removed, kept, skipped);
+    if let Some(user_display_message) = user_display_message
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+    {
+        message.push('\n');
+        message.push_str(user_display_message);
+    }
+    message
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_resume_command_with_compactor<F>(
+    session_path: &Path,
+    session: &Session,
+    command: &SlashCommand,
+    compact_with_runtime: &mut F,
+) -> Result<ResumeCommandOutcome, Box<dyn std::error::Error>>
+where
+    F: FnMut(&Session) -> Result<runtime::CompactionResult, Box<dyn std::error::Error>>,
+{
     match command {
         SlashCommand::Help => Ok(ResumeCommandOutcome {
             session: session.clone(),
@@ -2836,20 +2888,19 @@ fn run_resume_command(
             json: None,
         }),
         SlashCommand::Compact => {
-            let result = runtime::compact_session(
-                session,
-                CompactionConfig {
-                    max_estimated_tokens: 0,
-                    ..CompactionConfig::default()
-                },
-            );
+            let result = compact_with_runtime(session)?;
             let removed = result.removed_message_count;
             let kept = result.compacted_session.messages.len();
             let skipped = removed == 0;
             result.compacted_session.save_to_path(session_path)?;
             Ok(ResumeCommandOutcome {
                 session: result.compacted_session,
-                message: Some(format_compact_report(removed, kept, skipped)),
+                message: Some(format_resume_compact_message(
+                    removed,
+                    kept,
+                    skipped,
+                    result.user_display_message.as_deref(),
+                )),
                 json: None,
             })
         }
@@ -4550,7 +4601,7 @@ impl LiveCli {
     }
 
     fn compact(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let result = self.runtime.compact(CompactionConfig::default());
+        let result = self.runtime.compact(CompactionConfig::default())?;
         let removed = result.removed_message_count;
         let kept = result.compacted_session.messages.len();
         let skipped = removed == 0;
@@ -4568,6 +4619,9 @@ impl LiveCli {
         self.replace_runtime(runtime)?;
         self.persist_session()?;
         println!("{}", format_compact_report(removed, kept, skipped));
+        if let Some(message) = result.user_display_message.as_deref() {
+            println!("{message}");
+        }
         Ok(())
     }
 
@@ -5510,9 +5564,14 @@ fn collect_hook_list_entries(
         &mut entries,
         "config",
         true,
-        runtime_config.hooks().pre_tool_use(),
-        runtime_config.hooks().post_tool_use(),
-        runtime_config.hooks().post_tool_use_failure(),
+        HookCommandSets {
+            pre_tool_use: runtime_config.hooks().pre_tool_use(),
+            post_tool_use: runtime_config.hooks().post_tool_use(),
+            post_tool_use_failure: runtime_config.hooks().post_tool_use_failure(),
+            pre_compact: runtime_config.hooks().pre_compact(),
+            post_compact: runtime_config.hooks().post_compact(),
+            session_start: runtime_config.hooks().session_start(),
+        },
     );
 
     let plugin_manager = build_plugin_manager(cwd, loader, runtime_config);
@@ -5522,31 +5581,71 @@ fn collect_hook_list_entries(
             &mut entries,
             &format!("plugin:{}", plugin.metadata().id),
             plugin.is_enabled(),
-            &plugin.hooks().pre_tool_use,
-            &plugin.hooks().post_tool_use,
-            &plugin.hooks().post_tool_use_failure,
+            HookCommandSets {
+                pre_tool_use: &plugin.hooks().pre_tool_use,
+                post_tool_use: &plugin.hooks().post_tool_use,
+                post_tool_use_failure: &plugin.hooks().post_tool_use_failure,
+                pre_compact: &plugin.hooks().pre_compact,
+                post_compact: &plugin.hooks().post_compact,
+                session_start: &plugin.hooks().session_start,
+            },
         );
     }
 
     Ok(entries)
 }
 
+#[derive(Clone, Copy)]
+struct HookCommandSets<'a> {
+    pre_tool_use: &'a [String],
+    post_tool_use: &'a [String],
+    post_tool_use_failure: &'a [String],
+    pre_compact: &'a [String],
+    post_compact: &'a [String],
+    session_start: &'a [String],
+}
+
 fn extend_hook_list_entries(
     entries: &mut Vec<HookListEntry>,
     source: &str,
     enabled: bool,
-    pre_tool_use: &[String],
-    post_tool_use: &[String],
-    post_tool_use_failure: &[String],
+    commands: HookCommandSets<'_>,
 ) {
-    append_hook_list_entries(entries, source, enabled, "PreToolUse", pre_tool_use);
-    append_hook_list_entries(entries, source, enabled, "PostToolUse", post_tool_use);
+    append_hook_list_entries(
+        entries,
+        source,
+        enabled,
+        "PreToolUse",
+        commands.pre_tool_use,
+    );
+    append_hook_list_entries(
+        entries,
+        source,
+        enabled,
+        "PostToolUse",
+        commands.post_tool_use,
+    );
     append_hook_list_entries(
         entries,
         source,
         enabled,
         "PostToolUseFailure",
-        post_tool_use_failure,
+        commands.post_tool_use_failure,
+    );
+    append_hook_list_entries(entries, source, enabled, "PreCompact", commands.pre_compact);
+    append_hook_list_entries(
+        entries,
+        source,
+        enabled,
+        "PostCompact",
+        commands.post_compact,
+    );
+    append_hook_list_entries(
+        entries,
+        source,
+        enabled,
+        "SessionStart",
+        commands.session_start,
     );
 }
 
@@ -6587,6 +6686,9 @@ fn runtime_hook_config_from_plugin_hooks(hooks: PluginHooks) -> runtime::Runtime
         hooks.post_tool_use,
         hooks.post_tool_use_failure,
     )
+    .with_pre_compact(hooks.pre_compact)
+    .with_post_compact(hooks.post_compact)
+    .with_session_start(hooks.session_start)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7202,15 +7304,15 @@ impl ApiClient for AnthropicRuntimeClient {
             progress_reporter.mark_model_phase();
         }
         let is_post_tool = request_ends_with_tool_result(&request);
+        let allow_tools = self.enable_tools && request.allow_tools;
         let message_request = MessageRequest {
             model: self.model.clone(),
             max_tokens: max_tokens_for_model(&self.model),
             messages: convert_messages(&request.messages),
             system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
-            tools: self
-                .enable_tools
+            tools: allow_tools
                 .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref())),
-            tool_choice: self.enable_tools.then_some(ToolChoice::Auto),
+            tool_choice: allow_tools.then_some(ToolChoice::Auto),
             stream: true,
             ..Default::default()
         };
@@ -8583,7 +8685,8 @@ mod tests {
         render_memory_report, render_merged_runtime_config_json, render_prompt_history_report,
         render_repl_help, render_resume_usage, render_session_markdown, resolve_model_alias,
         resolve_model_alias_with_config, resolve_repl_model, resolve_session_reference,
-        response_to_events, resume_supported_slash_commands, run_resume_command, short_tool_id,
+        response_to_events, resume_supported_slash_commands, run_resume_command,
+        run_resume_command_with_compactor, short_tool_id,
         slash_command_completion_candidates_with_sessions, status_context, status_json_value,
         summarize_tool_payload_for_markdown, validate_no_args, write_mcp_server_fixture, CliAction,
         CliOutputFormat, CliPermissionPrompter, CliToolExecutor, GitBranchFreshness,
@@ -9918,6 +10021,12 @@ mod tests {
                     is_error: false,
                 }],
                 usage: None,
+                subtype: None,
+                compact_metadata: None,
+                attachment_metadata: None,
+                hook_result_metadata: None,
+                is_compact_summary: false,
+                is_visible_in_transcript_only: false,
             },
         ];
 
@@ -9958,6 +10067,12 @@ mod tests {
                 is_error: true,
             }],
             usage: None,
+            subtype: None,
+            compact_metadata: None,
+            attachment_metadata: None,
+            hook_result_metadata: None,
+            is_compact_summary: false,
+            is_visible_in_transcript_only: false,
         }];
 
         // when
@@ -11163,6 +11278,73 @@ UU conflicted.rs",
     }
 
     #[test]
+    fn resume_compact_uses_runtime_compactor_and_persists_result() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("root dir");
+        let session_path = root.join("session.jsonl");
+        let mut original = Session::new();
+        original
+            .push_user_text("Preserve compact context")
+            .expect("session should append");
+        original
+            .save_to_path(&session_path)
+            .expect("session should save");
+
+        let session = Session::load_from_path(&session_path).expect("session should load");
+        let mut compacted_session = session.clone();
+        compacted_session.messages = vec![
+            ConversationMessage::compact_boundary(runtime::CompactBoundaryMetadata {
+                trigger: runtime::CompactTrigger::Manual,
+                pre_tokens: 42,
+                user_context: None,
+                messages_summarized: Some(1),
+                pre_compact_discovered_tools: Vec::new(),
+                preserved_segment: None,
+            }),
+            ConversationMessage::compact_summary_user_text(
+                "This session is being continued from a previous conversation.\nSummary:\nCarry over prior work.",
+                true,
+            ),
+            ConversationMessage::attachment_user_text(
+                "Previously invoked skills remain available after compaction.",
+                runtime::AttachmentKind::InvokedSkills,
+            ),
+        ];
+        compacted_session.record_compaction("Carry over prior work.", 1);
+
+        let mut compactor_called = false;
+        let outcome = run_resume_command_with_compactor(
+            &session_path,
+            &session,
+            &SlashCommand::Compact,
+            &mut |input_session| {
+                compactor_called = true;
+                assert_eq!(input_session.messages.len(), 1);
+                Ok(runtime::CompactionResult {
+                    summary: "Carry over prior work.".to_string(),
+                    formatted_summary: "formatted".to_string(),
+                    compacted_session: compacted_session.clone(),
+                    removed_message_count: 1,
+                    user_display_message: Some("pre compact note\npost compact note".to_string()),
+                })
+            },
+        )
+        .expect("resume compact should succeed");
+
+        let restored = Session::load_from_path(&session_path).expect("session should reload");
+        assert!(compactor_called);
+        assert_eq!(outcome.session, compacted_session);
+        assert_eq!(restored, compacted_session);
+        let message = outcome.message.expect("resume compact report should exist");
+        assert!(message.contains("Result           compacted"));
+        assert!(message.contains("Messages removed 1"));
+        assert!(message.contains("pre compact note"));
+        assert!(message.contains("post compact note"));
+
+        remove_dir_all_with_retry(&root);
+    }
+
+    #[test]
     fn branch_delete_removes_only_merged_unprotected_local_branches() {
         let _guard = cwd_lock()
             .lock()
@@ -11479,6 +11661,12 @@ UU conflicted.rs",
                     is_error: false,
                 }],
                 usage: None,
+                subtype: None,
+                compact_metadata: None,
+                attachment_metadata: None,
+                hook_result_metadata: None,
+                is_compact_summary: false,
+                is_visible_in_transcript_only: false,
             },
         ];
 

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -10012,22 +10012,12 @@ mod tests {
                     input: r#"{"command":"ls -la"}"#.to_string(),
                 },
             ]),
-            ConversationMessage {
-                role: MessageRole::Tool,
-                blocks: vec![ContentBlock::ToolResult {
-                    tool_use_id: "toolu_abcdefghijklmnop".to_string(),
-                    tool_name: "bash".to_string(),
-                    output: "total 8\ndrwxr-xr-x  2 user staff   64 Apr  7 12:00 .".to_string(),
-                    is_error: false,
-                }],
-                usage: None,
-                subtype: None,
-                compact_metadata: None,
-                attachment_metadata: None,
-                hook_result_metadata: None,
-                is_compact_summary: false,
-                is_visible_in_transcript_only: false,
-            },
+            ConversationMessage::tool_result(
+                "toolu_abcdefghijklmnop",
+                "bash",
+                "total 8\ndrwxr-xr-x  2 user staff   64 Apr  7 12:00 .",
+                false,
+            ),
         ];
 
         // when
@@ -10058,22 +10048,12 @@ mod tests {
         // given
         let mut session = Session::new();
         session.session_id = "errs".to_string();
-        session.messages = vec![ConversationMessage {
-            role: MessageRole::Tool,
-            blocks: vec![ContentBlock::ToolResult {
-                tool_use_id: "short".to_string(),
-                tool_name: "read_file".to_string(),
-                output: "   ".to_string(),
-                is_error: true,
-            }],
-            usage: None,
-            subtype: None,
-            compact_metadata: None,
-            attachment_metadata: None,
-            hook_result_metadata: None,
-            is_compact_summary: false,
-            is_visible_in_transcript_only: false,
-        }];
+        session.messages = vec![ConversationMessage::tool_result(
+            "short",
+            "read_file",
+            "   ",
+            true,
+        )];
 
         // when
         let markdown =
@@ -11652,22 +11632,7 @@ UU conflicted.rs",
                 name: "bash".to_string(),
                 input: "{\"command\":\"pwd\"}".to_string(),
             }]),
-            ConversationMessage {
-                role: MessageRole::Tool,
-                blocks: vec![ContentBlock::ToolResult {
-                    tool_use_id: "tool-1".to_string(),
-                    tool_name: "bash".to_string(),
-                    output: "ok".to_string(),
-                    is_error: false,
-                }],
-                usage: None,
-                subtype: None,
-                compact_metadata: None,
-                attachment_metadata: None,
-                hook_result_metadata: None,
-                is_compact_summary: false,
-                is_visible_in_transcript_only: false,
-            },
+            ConversationMessage::tool_result("tool-1", "bash", "ok", false),
         ];
 
         let converted = super::convert_messages(&messages);

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -6279,12 +6279,14 @@ mod tests {
         ProviderRuntimeClient, SubagentToolExecutor,
     };
     use api::{OutputContentBlock, ToolResultContentBlock};
+    #[cfg(windows)]
+    use runtime::{bash_shell_path, set_shell_if_windows};
     use runtime::{
         permission_enforcer::PermissionEnforcer, ApiRequest, AssistantEvent, BashCommandOutput,
         ConversationRuntime, PermissionMode, PermissionPolicy, RuntimeError, Session, TaskPacket,
         ToolExecutor,
     };
-    use runtime::{tool_result_path, GlobSearchOutput, GrepSearchOutput, ProviderFallbackConfig};
+    use runtime::{GlobSearchOutput, GrepSearchOutput, ProviderFallbackConfig};
     use serde_json::json;
 
     fn env_lock() -> &'static Mutex<()> {
@@ -6296,6 +6298,33 @@ mod tests {
         env_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn windows_bash_smoke_ok() -> bool {
+        #[cfg(windows)]
+        {
+            static OK: OnceLock<bool> = OnceLock::new();
+            *OK.get_or_init(|| {
+                if set_shell_if_windows().is_err() {
+                    return false;
+                }
+                let Ok(shell_path) = bash_shell_path() else {
+                    return false;
+                };
+                Command::new(shell_path)
+                    .args(["-lc", "printf ok"])
+                    .output()
+                    .is_ok_and(|output| {
+                        output.status.success()
+                            && String::from_utf8_lossy(&output.stdout).trim() == "ok"
+                    })
+            })
+        }
+
+        #[cfg(not(windows))]
+        {
+            true
+        }
     }
 
     #[test]
@@ -6658,8 +6687,8 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let root = temp_path("grep-wrapper-persist");
+        let restore_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         fs::create_dir_all(&root).expect("create root");
-        let original_dir = std::env::current_dir().expect("cwd");
         std::env::set_current_dir(&root).expect("set cwd");
 
         let content = "alpha\n".repeat(4_100);
@@ -6681,13 +6710,18 @@ mod tests {
             &serialized,
             false,
         );
-        let persisted_path = tool_result_path(&root, "tool:grep/1", "txt");
 
         let ToolResultContentBlock::Text { text } = &result.content[0] else {
             panic!("expected text block");
         };
         assert!(text.starts_with("<persisted-output>\n"));
-        assert!(text.contains(persisted_path.to_string_lossy().as_ref()));
+        let persisted_path = text
+            .lines()
+            .find_map(|line| {
+                line.split_once("Full output saved to: ")
+                    .map(|(_, path)| PathBuf::from(path))
+            })
+            .expect("persisted output path should be present in wrapper text");
         assert!(persisted_path.exists(), "persisted output should exist");
         assert_eq!(
             fs::read_to_string(&persisted_path).expect("read persisted output"),
@@ -6695,7 +6729,7 @@ mod tests {
         );
         assert!(!result.is_error);
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        std::env::set_current_dir(&restore_dir).expect("restore cwd");
         let _ = fs::remove_dir_all(root);
     }
 
@@ -8888,14 +8922,36 @@ mod tests {
 
     #[test]
     fn bash_tool_reports_success_exit_failure_timeout_and_background() {
-        let success = execute_tool("bash", &json!({ "command": "printf 'hello'" }))
-            .expect("bash should succeed");
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        #[cfg(windows)]
+        if !windows_bash_smoke_ok() {
+            return;
+        }
+        #[cfg(windows)]
+        set_shell_if_windows().expect("set shell");
+
+        let success = execute_tool(
+            "bash",
+            &json!({
+                "command": "printf 'hello'",
+                "dangerouslyDisableSandbox": true
+            }),
+        )
+        .expect("bash should succeed");
         let success_output: serde_json::Value = serde_json::from_str(&success).expect("json");
         assert_eq!(success_output["stdout"], "hello");
         assert_eq!(success_output["interrupted"], false);
 
-        let failure = execute_tool("bash", &json!({ "command": "printf 'oops' >&2; exit 7" }))
-            .expect("bash failure should still return structured output");
+        let failure = execute_tool(
+            "bash",
+            &json!({
+                "command": "printf 'oops' >&2; exit 7",
+                "dangerouslyDisableSandbox": true
+            }),
+        )
+        .expect("bash failure should still return structured output");
         let failure_output: serde_json::Value = serde_json::from_str(&failure).expect("json");
         assert_eq!(failure_output["returnCodeInterpretation"], "exit_code:7");
         assert!(failure_output["stderr"]
@@ -8903,8 +8959,15 @@ mod tests {
             .expect("stderr")
             .contains("oops"));
 
-        let timeout = execute_tool("bash", &json!({ "command": "sleep 1", "timeout": 10 }))
-            .expect("bash timeout should return output");
+        let timeout = execute_tool(
+            "bash",
+            &json!({
+                "command": "sleep 1",
+                "timeout": 10,
+                "dangerouslyDisableSandbox": true
+            }),
+        )
+        .expect("bash timeout should return output");
         let timeout_output: serde_json::Value = serde_json::from_str(&timeout).expect("json");
         assert_eq!(timeout_output["interrupted"], true);
         assert_eq!(timeout_output["returnCodeInterpretation"], "timeout");
@@ -8915,7 +8978,11 @@ mod tests {
 
         let background = execute_tool(
             "bash",
-            &json!({ "command": "sleep 1", "run_in_background": true }),
+            &json!({
+                "command": "sleep 1",
+                "run_in_background": true,
+                "dangerouslyDisableSandbox": true
+            }),
         )
         .expect("bash background should succeed");
         let background_output: serde_json::Value = serde_json::from_str(&background).expect("json");
@@ -9780,9 +9847,21 @@ printf 'pwsh:%s' "$1"
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        #[cfg(windows)]
+        if !windows_bash_smoke_ok() {
+            return;
+        }
+        #[cfg(windows)]
+        set_shell_if_windows().expect("set shell");
         let registry = super::GlobalToolRegistry::builtin();
         let result = registry
-            .execute("bash", &json!({ "command": "printf 'ok'" }))
+            .execute(
+                "bash",
+                &json!({
+                    "command": "printf 'ok'",
+                    "dangerouslyDisableSandbox": true
+                }),
+            )
             .expect("bash should succeed without enforcer");
         let output: serde_json::Value = serde_json::from_str(&result).expect("json");
         assert_eq!(output["stdout"], "ok");

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -9218,9 +9218,22 @@ mod tests {
         assert_eq!(grep_count_output["numMatches"], 3);
         assert_eq!(grep_count_output["filenames"], json!([]));
         let grep_count_content = grep_count_output["content"].as_str().expect("content");
-        assert_eq!(
-            grep_count_content.replace('\\', "/"),
-            "nested/lib.rs:2\nnested/notes.txt:1"
+        let grep_count_lines = grep_count_content
+            .lines()
+            .map(|line| line.replace('\\', "/"))
+            .collect::<Vec<_>>();
+        assert_eq!(grep_count_lines.len(), 2);
+        assert!(
+            grep_count_lines
+                .iter()
+                .any(|line| line.ends_with("nested/lib.rs:2")),
+            "unexpected grep count lines: {grep_count_lines:?}"
+        );
+        assert!(
+            grep_count_lines
+                .iter()
+                .any(|line| line.ends_with("nested/notes.txt:1")),
+            "unexpected grep count lines: {grep_count_lines:?}"
         );
 
         let grep_error = execute_tool(

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -22,13 +24,15 @@ use runtime::{
     summary_compression::compress_summary_text,
     task_registry::TaskRegistry,
     team_cron_registry::{CronRegistry, TeamRegistry},
+    tool_result_path,
     worker_boot::{WorkerReadySnapshot, WorkerRegistry, WorkerTaskReceipt},
     write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, BashCommandOutput,
     BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage, ConversationRuntime,
-    GrepSearchInput, LaneCommitProvenance, LaneEvent, LaneEventBlocker, LaneEventName,
-    LaneEventStatus, LaneFailureClass, McpDegradedReport, MessageRole, OAuthConfig, PermissionMode,
-    PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig, RuntimeConfig, RuntimeError,
-    RuntimeProviderConfig, RuntimeProviderKind, Session, TaskPacket, ToolError, ToolExecutor,
+    GlobSearchOutput, GrepSearchInput, GrepSearchOutput, LaneCommitProvenance, LaneEvent,
+    LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport,
+    MessageRole, OAuthConfig, PermissionMode, PermissionPolicy, PromptCacheEvent,
+    ProviderFallbackConfig, RuntimeConfig, RuntimeError, RuntimeProviderConfig,
+    RuntimeProviderKind, Session, TaskPacket, ToolError, ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -483,7 +487,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                     "-n": { "type": "boolean" },
                     "-i": { "type": "boolean" },
                     "type": { "type": "string" },
-                    "head_limit": { "type": "integer", "minimum": 1 },
+                    "head_limit": { "type": "integer", "minimum": 0 },
                     "offset": { "type": "integer", "minimum": 0 },
                     "multiline": { "type": "boolean" }
                 },
@@ -4187,6 +4191,8 @@ const PERSISTED_OUTPUT_TAG: &str = "<persisted-output>";
 const PERSISTED_OUTPUT_CLOSING_TAG: &str = "</persisted-output>";
 const PERSISTED_OUTPUT_PREVIEW_BYTES: usize = 2_000;
 const INTERRUPTED_COMMAND_TAG: &str = "<error>Command was aborted before completion</error>";
+const GLOB_RESULT_PERSIST_THRESHOLD_CHARS: usize = 100_000;
+const GREP_RESULT_PERSIST_THRESHOLD_CHARS: usize = 20_000;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ModelVisibleToolResult {
@@ -4211,17 +4217,35 @@ pub fn model_visible_tool_result(
     output: &str,
     is_error: bool,
 ) -> ModelVisibleToolResult {
-    if !matches!(tool_name, "bash" | "PowerShell") {
-        return ModelVisibleToolResult::raw_text(output, is_error);
+    model_visible_tool_result_with_id(None, tool_name, output, is_error)
+}
+
+fn model_visible_tool_result_with_id(
+    tool_use_id: Option<&str>,
+    tool_name: &str,
+    output: &str,
+    is_error: bool,
+) -> ModelVisibleToolResult {
+    if let Some((shell_output, trailing_text)) = parse_shell_tool_result(tool_name, output) {
+        let mut result = shell_tool_result_to_model_visible_result(&shell_output, is_error);
+        append_trailing_tool_text(&mut result.content, trailing_text);
+        return result;
     }
 
-    let Some((shell_output, trailing_text)) = parse_shell_tool_result(tool_name, output) else {
-        return ModelVisibleToolResult::raw_text(output, is_error);
-    };
+    if let Some((search_output, trailing_text)) = parse_search_tool_result(tool_name, output) {
+        let mut result =
+            search_tool_result_to_model_visible_result(tool_use_id, &search_output, is_error);
+        append_trailing_tool_text(&mut result.content, trailing_text);
+        return result;
+    }
 
-    let mut result = shell_tool_result_to_model_visible_result(&shell_output, is_error);
-    append_trailing_tool_text(&mut result.content, trailing_text);
-    result
+    ModelVisibleToolResult::raw_text(output, is_error)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchToolResult {
+    text: String,
+    persistence_threshold_chars: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -4319,6 +4343,41 @@ fn parse_shell_tool_result_json(
         "PowerShell" => serde_json::from_str::<PowerShellCommandOutput>(output)
             .ok()
             .map(NormalizedShellToolResult::from),
+        _ => None,
+    }
+}
+
+fn parse_search_tool_result<'a>(
+    tool_name: &str,
+    output: &'a str,
+) -> Option<(SearchToolResult, &'a str)> {
+    if let Some(parsed) = parse_search_tool_result_json(tool_name, output) {
+        return Some((parsed, ""));
+    }
+
+    let (json_prefix, trailing_text) = split_json_prefix(output)?;
+    let parsed = parse_search_tool_result_json(tool_name, json_prefix)?;
+    Some((parsed, trailing_text))
+}
+
+fn parse_search_tool_result_json(tool_name: &str, output: &str) -> Option<SearchToolResult> {
+    match tool_name {
+        "glob_search" | "Glob" => {
+            serde_json::from_str::<GlobSearchOutput>(output)
+                .ok()
+                .map(|result| SearchToolResult {
+                    text: glob_tool_result_text(&result),
+                    persistence_threshold_chars: GLOB_RESULT_PERSIST_THRESHOLD_CHARS,
+                })
+        }
+        "grep_search" | "Grep" => {
+            serde_json::from_str::<GrepSearchOutput>(output)
+                .ok()
+                .map(|result| SearchToolResult {
+                    text: grep_tool_result_text(&result),
+                    persistence_threshold_chars: GREP_RESULT_PERSIST_THRESHOLD_CHARS,
+                })
+        }
         _ => None,
     }
 }
@@ -4431,6 +4490,136 @@ fn shell_tool_result_to_model_visible_result(
     }
 }
 
+fn search_tool_result_to_model_visible_result(
+    tool_use_id: Option<&str>,
+    output: &SearchToolResult,
+    is_error: bool,
+) -> ModelVisibleToolResult {
+    let mut text = output.text.clone();
+    if text.chars().count() > output.persistence_threshold_chars {
+        if let Some(tool_use_id) = tool_use_id {
+            if let Ok(persisted) = persist_model_visible_tool_text(tool_use_id, &text) {
+                let (preview, has_more) =
+                    generate_tool_result_preview(&text, PERSISTED_OUTPUT_PREVIEW_BYTES);
+                text = build_large_tool_result_message(
+                    &persisted.path,
+                    persisted.original_size,
+                    &preview,
+                    has_more,
+                );
+            }
+        }
+    }
+
+    ModelVisibleToolResult {
+        content: vec![ToolResultContentBlock::Text { text }],
+        is_error,
+    }
+}
+
+fn glob_tool_result_text(output: &GlobSearchOutput) -> String {
+    if output.num_files == 0 {
+        return String::from("No files found");
+    }
+
+    let mut lines = output.filenames.clone();
+    if output.truncated {
+        lines.push(String::from(
+            "(Results are truncated. Consider using a more specific path or pattern.)",
+        ));
+    }
+    lines.join("\n")
+}
+
+fn grep_tool_result_text(output: &GrepSearchOutput) -> String {
+    let mode = output.mode.as_deref().unwrap_or("files_with_matches");
+    let limit_info = format_search_limit_info(output.applied_limit, output.applied_offset);
+
+    match mode {
+        "content" => {
+            let mut result = output
+                .content
+                .clone()
+                .unwrap_or_else(|| String::from("No matches found"));
+            if !limit_info.is_empty() {
+                result.push_str("\n\n[Showing results with pagination = ");
+                result.push_str(&limit_info);
+                result.push(']');
+            }
+            result
+        }
+        "count" => {
+            let raw_content = output
+                .content
+                .clone()
+                .unwrap_or_else(|| String::from("No matches found"));
+            let matches = output.num_matches.unwrap_or(0);
+            let files = output.num_files;
+            let summary = if limit_info.is_empty() {
+                format!(
+                    "\n\nFound {matches} total {} across {files} {}.",
+                    if matches == 1 {
+                        "occurrence"
+                    } else {
+                        "occurrences"
+                    },
+                    if files == 1 { "file" } else { "files" }
+                )
+            } else {
+                format!(
+                    "\n\nFound {matches} total {} across {files} {}. with pagination = {limit_info}",
+                    if matches == 1 {
+                        "occurrence"
+                    } else {
+                        "occurrences"
+                    },
+                    if files == 1 { "file" } else { "files" }
+                )
+            };
+            format!("{raw_content}{summary}")
+        }
+        _ => {
+            if output.num_files == 0 {
+                return String::from("No files found");
+            }
+
+            let header = if limit_info.is_empty() {
+                format!(
+                    "Found {} {}",
+                    output.num_files,
+                    if output.num_files == 1 {
+                        "file"
+                    } else {
+                        "files"
+                    }
+                )
+            } else {
+                format!(
+                    "Found {} {} {limit_info}",
+                    output.num_files,
+                    if output.num_files == 1 {
+                        "file"
+                    } else {
+                        "files"
+                    }
+                )
+            };
+            format!("{header}\n{}", output.filenames.join("\n"))
+        }
+    }
+}
+
+fn format_search_limit_info(applied_limit: Option<usize>, applied_offset: Option<usize>) -> String {
+    let mut parts = Vec::new();
+    if let Some(limit) = applied_limit {
+        parts.push(format!("limit: {limit}"));
+    }
+    if let Some(offset) = applied_offset {
+        parts.push(format!("offset: {offset}"));
+    }
+    parts.join(", ")
+}
+
 fn tool_result_content_block_from_value(value: &Value) -> ToolResultContentBlock {
     match value {
         Value::String(text) => ToolResultContentBlock::Text { text: text.clone() },
@@ -4498,6 +4687,34 @@ fn build_large_tool_result_message(
     }
     message.push_str(PERSISTED_OUTPUT_CLOSING_TAG);
     message
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PersistedModelVisibleToolText {
+    path: String,
+    original_size: u64,
+}
+
+fn persist_model_visible_tool_text(
+    tool_use_id: &str,
+    content: &str,
+) -> std::io::Result<PersistedModelVisibleToolText> {
+    let cwd = std::env::current_dir()?;
+    let path = tool_result_path(&cwd, tool_use_id, "txt");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => file.write_all(content.as_bytes())?,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error),
+    }
+
+    Ok(PersistedModelVisibleToolText {
+        path: path.to_string_lossy().into_owned(),
+        original_size: u64::try_from(content.len()).expect("content length fits u64"),
+    })
 }
 
 fn format_file_size(size_in_bytes: u64) -> String {
@@ -4614,7 +4831,12 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                         is_error,
                         ..
                     } => {
-                        let result = model_visible_tool_result(tool_name, output, *is_error);
+                        let result = model_visible_tool_result_with_id(
+                            Some(tool_use_id),
+                            tool_name,
+                            output,
+                            *is_error,
+                        );
                         InputContentBlock::ToolResult {
                             tool_use_id: tool_use_id.clone(),
                             content: result.content,
@@ -6050,19 +6272,19 @@ mod tests {
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, classify_lane_failure,
         derive_agent_state, execute_agent_with_spawn, execute_tool, final_assistant_text,
-        maybe_commit_provenance, model_visible_tool_result, mvp_tool_specs,
-        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_task_packet, AgentInput, AgentJob, GlobalToolRegistry, LaneEventName, LaneFailureClass,
-        ModelVisibleToolResult, PowerShellCommandOutput, ProviderRuntimeClient,
-        SubagentToolExecutor,
+        maybe_commit_provenance, model_visible_tool_result, model_visible_tool_result_with_id,
+        mvp_tool_specs, permission_mode_from_plugin, persist_agent_terminal_state,
+        push_output_block, run_task_packet, AgentInput, AgentJob, GlobalToolRegistry,
+        LaneEventName, LaneFailureClass, ModelVisibleToolResult, PowerShellCommandOutput,
+        ProviderRuntimeClient, SubagentToolExecutor,
     };
     use api::{OutputContentBlock, ToolResultContentBlock};
-    use runtime::ProviderFallbackConfig;
     use runtime::{
         permission_enforcer::PermissionEnforcer, ApiRequest, AssistantEvent, BashCommandOutput,
         ConversationRuntime, PermissionMode, PermissionPolicy, RuntimeError, Session, TaskPacket,
         ToolExecutor,
     };
+    use runtime::{tool_result_path, GlobSearchOutput, GrepSearchOutput, ProviderFallbackConfig};
     use serde_json::json;
 
     fn env_lock() -> &'static Mutex<()> {
@@ -6135,6 +6357,14 @@ mod tests {
         tool_name: &str,
     ) -> ModelVisibleToolResult {
         let serialized = serde_json::to_string_pretty(output).expect("serialize shell output");
+        model_visible_tool_result(tool_name, &serialized, false)
+    }
+
+    fn search_model_result<T: serde::Serialize>(
+        output: &T,
+        tool_name: &str,
+    ) -> ModelVisibleToolResult {
+        let serialized = serde_json::to_string_pretty(output).expect("serialize search output");
         model_visible_tool_result(tool_name, &serialized, false)
     }
 
@@ -6320,6 +6550,153 @@ mod tests {
         assert!(text.contains(
             "In assistant mode, delegate long-running work to a subagent or use run_in_background to keep this conversation responsive."
         ));
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_glob_results_like_ts() {
+        let result = search_model_result(
+            &GlobSearchOutput {
+                duration_ms: 5,
+                num_files: 2,
+                filenames: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+                truncated: false,
+            },
+            "glob_search",
+        );
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "src/lib.rs\nsrc/main.rs".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_empty_glob_results_like_ts() {
+        let result = search_model_result(
+            &GlobSearchOutput {
+                duration_ms: 3,
+                num_files: 0,
+                filenames: Vec::new(),
+                truncated: false,
+            },
+            "glob_search",
+        );
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "No files found".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_grep_count_results_like_ts() {
+        let result = search_model_result(
+            &GrepSearchOutput {
+                mode: Some("count".to_string()),
+                num_files: 2,
+                filenames: Vec::new(),
+                num_lines: None,
+                content: Some("src/lib.rs:2\nsrc/main.rs:1".to_string()),
+                num_matches: Some(3),
+                applied_limit: Some(10),
+                applied_offset: Some(5),
+            },
+            "grep_search",
+        );
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "src/lib.rs:2\nsrc/main.rs:1\n\nFound 3 total occurrences across 2 files. with pagination = limit: 10, offset: 5".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_grep_files_with_matches_like_ts() {
+        let result = search_model_result(
+            &GrepSearchOutput {
+                mode: Some("files_with_matches".to_string()),
+                num_files: 2,
+                filenames: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+                num_lines: None,
+                content: None,
+                num_matches: None,
+                applied_limit: Some(25),
+                applied_offset: Some(3),
+            },
+            "grep_search",
+        );
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "Found 2 files limit: 25, offset: 3\nsrc/lib.rs\nsrc/main.rs".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_persists_large_grep_results_for_tool_use_id() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let root = temp_path("grep-wrapper-persist");
+        fs::create_dir_all(&root).expect("create root");
+        let original_dir = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&root).expect("set cwd");
+
+        let content = "alpha\n".repeat(4_100);
+        let serialized = serde_json::to_string_pretty(&GrepSearchOutput {
+            mode: Some("content".to_string()),
+            num_files: 0,
+            filenames: Vec::new(),
+            num_lines: Some(4_100),
+            content: Some(content.clone()),
+            num_matches: None,
+            applied_limit: None,
+            applied_offset: None,
+        })
+        .expect("serialize grep output");
+
+        let result = model_visible_tool_result_with_id(
+            Some("tool:grep/1"),
+            "grep_search",
+            &serialized,
+            false,
+        );
+        let persisted_path = tool_result_path(&root, "tool:grep/1", "txt");
+
+        let ToolResultContentBlock::Text { text } = &result.content[0] else {
+            panic!("expected text block");
+        };
+        assert!(text.starts_with("<persisted-output>\n"));
+        assert!(text.contains(persisted_path.to_string_lossy().as_ref()));
+        assert!(persisted_path.exists(), "persisted output should exist");
+        assert_eq!(
+            fs::read_to_string(&persisted_path).expect("read persisted output"),
+            content
+        );
+        assert!(!result.is_error);
+
+        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        let _ = fs::remove_dir_all(root);
     }
 
     fn temp_path(name: &str) -> PathBuf {
@@ -8839,6 +9216,12 @@ mod tests {
         .expect("grep count should succeed");
         let grep_count_output: serde_json::Value = serde_json::from_str(&grep_count).expect("json");
         assert_eq!(grep_count_output["numMatches"], 3);
+        assert_eq!(grep_count_output["filenames"], json!([]));
+        let grep_count_content = grep_count_output["content"].as_str().expect("content");
+        assert_eq!(
+            grep_count_content.replace('\\', "/"),
+            "nested/lib.rs:2\nnested/notes.txt:1"
+        );
 
         let grep_error = execute_tool(
             "grep_search",

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -2019,6 +2019,7 @@ fn powershell_branch_divergence_output(
             missing_fixes,
         ),
         interrupted: false,
+        raw_output_path: None,
         return_code_interpretation: Some("preflight_blocked:branch_divergence".to_string()),
         is_image: None,
         persisted_output_path: None,
@@ -2327,6 +2328,8 @@ struct PowerShellCommandOutput {
     stdout: String,
     stderr: String,
     interrupted: bool,
+    #[serde(rename = "rawOutputPath", skip_serializing_if = "Option::is_none")]
+    raw_output_path: Option<String>,
     #[serde(
         rename = "returnCodeInterpretation",
         skip_serializing_if = "Option::is_none"
@@ -4260,10 +4263,12 @@ impl From<BashCommandOutput> for NormalizedShellToolResult {
 
 impl From<PowerShellCommandOutput> for NormalizedShellToolResult {
     fn from(value: PowerShellCommandOutput) -> Self {
-        let background_output_path = value
-            .background_task_id
-            .as_deref()
-            .and_then(derive_background_output_path);
+        let background_output_path = value.raw_output_path.clone().or_else(|| {
+            value
+                .background_task_id
+                .as_deref()
+                .and_then(derive_background_output_path)
+        });
         Self {
             stdout: value.stdout,
             stderr: value.stderr,
@@ -4280,6 +4285,8 @@ impl From<PowerShellCommandOutput> for NormalizedShellToolResult {
 }
 
 fn derive_background_output_path(task_id: &str) -> Option<String> {
+    // Older transcripts may only persist backgroundTaskId, so keep a
+    // session-aware fallback for replay/resume when rawOutputPath is absent.
     let cwd = std::env::current_dir().ok()?;
     Some(
         shell_task_output_path(&cwd, task_id)
@@ -5853,6 +5860,7 @@ fn execute_shell_command(
             stdout: String::new(),
             stderr: String::new(),
             interrupted: false,
+            raw_output_path: Some(background_output.output_path),
             is_image: None,
             background_task_id: Some(background_output.task_id),
             backgrounded_by_user: None,
@@ -5891,6 +5899,7 @@ fn execute_shell_command(
                     stdout: prepared_output.stdout,
                     stderr: prepared_output.stderr,
                     interrupted: false,
+                    raw_output_path: None,
                     is_image: None,
                     background_task_id: None,
                     backgrounded_by_user: None,
@@ -5927,6 +5936,7 @@ Command exceeded timeout of {timeout_ms} ms",
                     stdout: prepared_output.stdout,
                     stderr: prepared_output.stderr,
                     interrupted: true,
+                    raw_output_path: None,
                     is_image: None,
                     background_task_id: None,
                     backgrounded_by_user: None,
@@ -5948,6 +5958,7 @@ Command exceeded timeout of {timeout_ms} ms",
         stdout: prepared_output.stdout,
         stderr: prepared_output.stderr,
         interrupted: false,
+        raw_output_path: None,
         is_image: None,
         background_task_id: None,
         backgrounded_by_user: None,
@@ -6107,6 +6118,7 @@ mod tests {
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
             interrupted,
+            raw_output_path: None,
             return_code_interpretation: None,
             is_image: None,
             persisted_output_path: None,
@@ -6255,22 +6267,30 @@ mod tests {
     }
 
     #[test]
-    fn model_visible_tool_result_derives_powershell_background_output_path_from_task_id() {
+    fn model_visible_tool_result_uses_powershell_raw_output_path_when_present() {
         let mut output = powershell_output("", "", false);
         output.background_task_id = Some("b1234xyz".to_string());
+        output.raw_output_path = Some(
+            "C:\\repo\\.claw\\sessions\\8f86a4368751b5ad\\session-1776656373469-0\\tasks\\b1234xyz.output"
+                .to_string(),
+        );
 
         let result = shell_model_result(&output, "PowerShell");
-        let expected_path = super::derive_background_output_path("b1234xyz")
-            .expect("background output path should resolve");
 
         let ToolResultContentBlock::Text { text } = &result.content[0] else {
             panic!("expected text block");
         };
-        assert_eq!(
-            text.as_str(),
-            format!(
-                "Command running in background with ID: b1234xyz. Output is being written to: {expected_path}"
-            )
+        assert!(
+            text.starts_with(
+                "Command running in background with ID: b1234xyz. Output is being written to: "
+            ),
+            "unexpected background message: {text}"
+        );
+        assert!(
+            text.ends_with(
+                "C:\\repo\\.claw\\sessions\\8f86a4368751b5ad\\session-1776656373469-0\\tasks\\b1234xyz.output"
+            ),
+            "unexpected background message: {text}"
         );
         assert!(!result.is_error);
     }
@@ -6280,10 +6300,12 @@ mod tests {
         let mut output = powershell_output("", "", false);
         output.background_task_id = Some("babc1234".to_string());
         output.assistant_auto_backgrounded = Some(true);
+        output.raw_output_path = Some(
+            "C:\\repo\\.claw\\sessions\\8f86a4368751b5ad\\session-1776656373469-0\\tasks\\babc1234.output"
+                .to_string(),
+        );
 
         let result = shell_model_result(&output, "PowerShell");
-        let expected_path = super::derive_background_output_path("babc1234")
-            .expect("background output path should resolve");
 
         let ToolResultContentBlock::Text { text } = &result.content[0] else {
             panic!("expected text block");
@@ -6292,7 +6314,9 @@ mod tests {
             "Command exceeded the assistant-mode blocking budget (15s) and was moved to the background with ID: babc1234."
         ));
         assert!(text.contains("It is still running - you will be notified when it completes."));
-        assert!(text.contains(&format!("Output is being written to: {expected_path}.")));
+        assert!(text.contains(
+            "Output is being written to: C:\\repo\\.claw\\sessions\\8f86a4368751b5ad\\session-1776656373469-0\\tasks\\babc1234.output."
+        ));
         assert!(text.contains(
             "In assistant mode, delegate long-running work to a subagent or use run_in_background to keep this conversation responsive."
         ));
@@ -8654,22 +8678,22 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let root = temp_path("fs-suite");
         fs::create_dir_all(&root).expect("create root");
-        let original_dir = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(&root).expect("set cwd");
+        let demo_path = root.join("nested/demo.txt");
+        let demo_path_string = demo_path.to_string_lossy().into_owned();
 
         let write_create = execute_tool(
             "write_file",
-            &json!({ "path": "nested/demo.txt", "content": "alpha\nbeta\nalpha\n" }),
+            &json!({ "path": demo_path_string.as_str(), "content": "alpha\nbeta\nalpha\n" }),
         )
         .expect("write create should succeed");
         let write_create_output: serde_json::Value =
             serde_json::from_str(&write_create).expect("json");
         assert_eq!(write_create_output["type"], "create");
-        assert!(root.join("nested/demo.txt").exists());
+        assert!(demo_path.exists());
 
         let write_update = execute_tool(
             "write_file",
-            &json!({ "path": "nested/demo.txt", "content": "alpha\nbeta\ngamma\n" }),
+            &json!({ "path": demo_path_string.as_str(), "content": "alpha\nbeta\ngamma\n" }),
         )
         .expect("write update should succeed");
         let write_update_output: serde_json::Value =
@@ -8677,7 +8701,7 @@ mod tests {
         assert_eq!(write_update_output["type"], "update");
         assert_eq!(write_update_output["originalFile"], "alpha\nbeta\nalpha\n");
 
-        let read_full = execute_tool("read_file", &json!({ "path": "nested/demo.txt" }))
+        let read_full = execute_tool("read_file", &json!({ "path": demo_path_string.as_str() }))
             .expect("read full should succeed");
         let read_full_output: serde_json::Value = serde_json::from_str(&read_full).expect("json");
         assert_eq!(read_full_output["file"]["content"], "alpha\nbeta\ngamma");
@@ -8685,7 +8709,7 @@ mod tests {
 
         let read_slice = execute_tool(
             "read_file",
-            &json!({ "path": "nested/demo.txt", "offset": 1, "limit": 1 }),
+            &json!({ "path": demo_path_string.as_str(), "offset": 1, "limit": 1 }),
         )
         .expect("read slice should succeed");
         let read_slice_output: serde_json::Value = serde_json::from_str(&read_slice).expect("json");
@@ -8694,7 +8718,7 @@ mod tests {
 
         let read_past_end = execute_tool(
             "read_file",
-            &json!({ "path": "nested/demo.txt", "offset": 50 }),
+            &json!({ "path": demo_path_string.as_str(), "offset": 50 }),
         )
         .expect("read past EOF should succeed");
         let read_past_end_output: serde_json::Value =
@@ -8708,25 +8732,25 @@ mod tests {
 
         let edit_once = execute_tool(
             "edit_file",
-            &json!({ "path": "nested/demo.txt", "old_string": "alpha", "new_string": "omega" }),
+            &json!({ "path": demo_path_string.as_str(), "old_string": "alpha", "new_string": "omega" }),
         )
         .expect("single edit should succeed");
         let edit_once_output: serde_json::Value = serde_json::from_str(&edit_once).expect("json");
         assert_eq!(edit_once_output["replaceAll"], false);
         assert_eq!(
-            fs::read_to_string(root.join("nested/demo.txt")).expect("read file"),
+            fs::read_to_string(&demo_path).expect("read file"),
             "omega\nbeta\ngamma\n"
         );
 
         execute_tool(
             "write_file",
-            &json!({ "path": "nested/demo.txt", "content": "alpha\nbeta\nalpha\n" }),
+            &json!({ "path": demo_path_string.as_str(), "content": "alpha\nbeta\nalpha\n" }),
         )
         .expect("reset file");
         let edit_all = execute_tool(
             "edit_file",
             &json!({
-                "path": "nested/demo.txt",
+                "path": demo_path_string.as_str(),
                 "old_string": "alpha",
                 "new_string": "omega",
                 "replace_all": true
@@ -8736,25 +8760,24 @@ mod tests {
         let edit_all_output: serde_json::Value = serde_json::from_str(&edit_all).expect("json");
         assert_eq!(edit_all_output["replaceAll"], true);
         assert_eq!(
-            fs::read_to_string(root.join("nested/demo.txt")).expect("read file"),
+            fs::read_to_string(&demo_path).expect("read file"),
             "omega\nbeta\nomega\n"
         );
 
         let edit_same = execute_tool(
             "edit_file",
-            &json!({ "path": "nested/demo.txt", "old_string": "omega", "new_string": "omega" }),
+            &json!({ "path": demo_path_string.as_str(), "old_string": "omega", "new_string": "omega" }),
         )
         .expect_err("identical old/new should fail");
         assert!(edit_same.contains("must differ"));
 
         let edit_missing = execute_tool(
             "edit_file",
-            &json!({ "path": "nested/demo.txt", "old_string": "missing", "new_string": "omega" }),
+            &json!({ "path": demo_path_string.as_str(), "old_string": "missing", "new_string": "omega" }),
         )
         .expect_err("missing substring should fail");
         assert!(edit_missing.contains("old_string not found"));
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
         let _ = fs::remove_dir_all(root);
     }
 
@@ -9238,7 +9261,7 @@ printf 'pwsh:%s' "$1"
 
         let background_output: serde_json::Value = serde_json::from_str(&background).expect("json");
         assert!(background_output["backgroundTaskId"].as_str().is_some());
-        assert!(background_output.get("rawOutputPath").is_none());
+        assert!(background_output["rawOutputPath"].as_str().is_some());
         assert!(background_output.get("noOutputExpected").is_none());
         assert!(background_output["backgroundedByUser"].is_null());
         assert!(background_output["assistantAutoBackgrounded"].is_null());


### PR DESCRIPTION
## What changed
- ported Rust full compact output to the TS-style compact boundary + summary layout
- unified interactive `/compact`, slash-command `/compact`, and `--resume /compact` so they all route through provider-backed full compact
- added transcript metadata for compact boundaries, attachment-style post-compact context, and session-start hook result messages
- extended runtime and plugin hook plumbing so pre-compact, post-compact, and session-start hooks participate in the compact flow consistently
- preserved tail messages and post-compact context in the compacted session shape so resume behavior matches the TS design more closely
- ported TS-style model-visible wrapper rendering for Rust `glob_search` and `grep_search`
- reused the session-scoped persisted-output plumbing from Bash/PowerShell for large glob/grep results so oversized search output lands under the active session directory
- aligned Rust glob/grep output details with TS expectations, including relative path display, `count` mode summaries, and `head_limit = 0` parity

## Why
Rust still had a few important TS parity gaps after the compact migration landed. Compact entrypoints were inconsistent across runtime and slash-command flows, and the search tools still exposed raw JSON directly to the model instead of the TS wrapper layer with persisted-output handling.

## Impact
- compacted Rust sessions now persist TS-style boundary/summary structure instead of only a legacy resumable system summary
- slash-command compaction now resolves model/provider config and merged plugin hooks the same way as the runtime path
- `--resume /compact` now produces the same full compact result shape as interactive compact
- post-compact runtime context such as running agents, todo state, plan mode, invoked skills, and session-start hook output is represented explicitly in session history
- Rust `glob_search` and `grep_search` now present TS-style plain-text tool results to the model instead of raw JSON blobs
- large search results now persist in session-isolated `tool-results` directories, avoiding cross-session collisions and matching the Bash/PowerShell storage model

## Root cause
The Rust port had not yet routed every compact entrypoint through the same provider-backed runtime path, the transcript schema was still missing some of the message-layer structure needed to represent TS-style compact output cleanly, and the search tools had not yet been moved onto the same model-visible wrapper and persistence path already used for shell tools.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`