### PR TITLE
[codex] Port TS file tool wrappers and read state

### DIFF
--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -193,19 +193,25 @@ pub fn read_file(
 
     let content = fs::read_to_string(&absolute_path)?;
     let lines: Vec<&str> = content.lines().collect();
-    let start_index = offset.unwrap_or(0).min(lines.len());
+    let requested_offset = offset.unwrap_or(1);
+    let start_index = if requested_offset == 0 {
+        0
+    } else {
+        requested_offset.saturating_sub(1)
+    };
+    let clamped_start_index = start_index.min(lines.len());
     let end_index = limit.map_or(lines.len(), |limit| {
-        start_index.saturating_add(limit).min(lines.len())
+        clamped_start_index.saturating_add(limit).min(lines.len())
     });
-    let selected = lines[start_index..end_index].join("\n");
+    let selected = lines[clamped_start_index..end_index].join("\n");
 
     Ok(ReadFileOutput {
         kind: String::from("text"),
         file: TextFilePayload {
             file_path: absolute_path.to_string_lossy().into_owned(),
             content: selected,
-            num_lines: end_index.saturating_sub(start_index),
-            start_line: start_index.saturating_add(1),
+            num_lines: end_index.saturating_sub(clamped_start_index),
+            start_line: requested_offset,
             total_lines: lines.len(),
         },
     })
@@ -250,15 +256,21 @@ pub fn edit_file(
     new_string: &str,
     replace_all: bool,
 ) -> io::Result<EditFileOutput> {
-    let absolute_path = normalize_path(path)?;
-    let original_file = fs::read_to_string(&absolute_path)?;
+    let absolute_path = normalize_path_allow_missing(path)?;
+    let original_file = fs::read_to_string(&absolute_path).or_else(|error| {
+        if error.kind() == io::ErrorKind::NotFound && old_string.is_empty() {
+            Ok(String::new())
+        } else {
+            Err(error)
+        }
+    })?;
     if old_string == new_string {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "old_string and new_string must differ",
         ));
     }
-    if !original_file.contains(old_string) {
+    if !old_string.is_empty() && !original_file.contains(old_string) {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             "old_string not found in file",
@@ -700,10 +712,10 @@ where
     F: FnOnce(&Path) -> io::Result<PathBuf>,
 {
     match canonicalize(&candidate) {
-        Ok(canonical) => Ok(canonical),
+        Ok(canonical) => Ok(clean_path_buf(canonical)),
         Err(error) => {
             if candidate.exists() {
-                Ok(candidate)
+                Ok(clean_path_buf(candidate))
             } else {
                 Err(error)
             }
@@ -719,19 +731,39 @@ fn normalize_path_allow_missing(path: &str) -> io::Result<PathBuf> {
     let candidate = absolute_candidate(path)?;
 
     if let Ok(canonical) = candidate.canonicalize() {
-        return Ok(canonical);
+        return Ok(clean_path_buf(canonical));
     }
 
     if let Some(parent) = candidate.parent() {
         let canonical_parent = parent
             .canonicalize()
-            .unwrap_or_else(|_| parent.to_path_buf());
+            .map_or_else(|_| clean_path_buf(parent.to_path_buf()), clean_path_buf);
         if let Some(name) = candidate.file_name() {
-            return Ok(canonical_parent.join(name));
+            return Ok(clean_path_buf(canonical_parent.join(name)));
         }
     }
 
-    Ok(candidate)
+    Ok(clean_path_buf(candidate))
+}
+
+pub fn resolve_tool_path(path: &str) -> io::Result<PathBuf> {
+    normalize_path(path)
+}
+
+pub fn resolve_tool_path_allow_missing(path: &str) -> io::Result<PathBuf> {
+    normalize_path_allow_missing(path)
+}
+
+fn clean_path_buf(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let text = path.to_string_lossy();
+        if let Some(stripped) = text.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+
+    path
 }
 
 /// Read a file with workspace boundary enforcement.
@@ -745,7 +777,8 @@ pub fn read_file_in_workspace(
     let absolute_path = normalize_path(path)?;
     let canonical_root = workspace_root
         .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
+        .map(clean_path_buf)
+        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     read_file(path, offset, limit)
 }
@@ -760,7 +793,8 @@ pub fn write_file_in_workspace(
     let absolute_path = normalize_path_allow_missing(path)?;
     let canonical_root = workspace_root
         .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
+        .map(clean_path_buf)
+        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     write_file(path, content)
 }
@@ -777,7 +811,8 @@ pub fn edit_file_in_workspace(
     let absolute_path = normalize_path(path)?;
     let canonical_root = workspace_root
         .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
+        .map(clean_path_buf)
+        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     edit_file(path, old_string, new_string, replace_all)
 }
@@ -789,10 +824,11 @@ pub fn is_symlink_escape(path: &Path, workspace_root: &Path) -> io::Result<bool>
     if !metadata.is_symlink() {
         return Ok(false);
     }
-    let resolved = path.canonicalize()?;
+    let resolved = clean_path_buf(path.canonicalize()?);
     let canonical_root = workspace_root
         .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
+        .map(clean_path_buf)
+        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
     Ok(!resolved.starts_with(&canonical_root))
 }
 
@@ -823,7 +859,8 @@ mod tests {
 
         let read_output = read_file(path.to_string_lossy().as_ref(), Some(1), Some(1))
             .expect("read should succeed");
-        assert_eq!(read_output.file.content, "two");
+        assert_eq!(read_output.file.content, "one");
+        assert_eq!(read_output.file.start_line, 1);
     }
 
     #[test]

--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -775,10 +775,10 @@ pub fn read_file_in_workspace(
     workspace_root: &Path,
 ) -> io::Result<ReadFileOutput> {
     let absolute_path = normalize_path(path)?;
-    let canonical_root = workspace_root
-        .canonicalize()
-        .map(clean_path_buf)
-        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
+    let canonical_root = workspace_root.canonicalize().map_or_else(
+        |_| clean_path_buf(workspace_root.to_path_buf()),
+        clean_path_buf,
+    );
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     read_file(path, offset, limit)
 }
@@ -791,10 +791,10 @@ pub fn write_file_in_workspace(
     workspace_root: &Path,
 ) -> io::Result<WriteFileOutput> {
     let absolute_path = normalize_path_allow_missing(path)?;
-    let canonical_root = workspace_root
-        .canonicalize()
-        .map(clean_path_buf)
-        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
+    let canonical_root = workspace_root.canonicalize().map_or_else(
+        |_| clean_path_buf(workspace_root.to_path_buf()),
+        clean_path_buf,
+    );
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     write_file(path, content)
 }
@@ -809,10 +809,10 @@ pub fn edit_file_in_workspace(
     workspace_root: &Path,
 ) -> io::Result<EditFileOutput> {
     let absolute_path = normalize_path(path)?;
-    let canonical_root = workspace_root
-        .canonicalize()
-        .map(clean_path_buf)
-        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
+    let canonical_root = workspace_root.canonicalize().map_or_else(
+        |_| clean_path_buf(workspace_root.to_path_buf()),
+        clean_path_buf,
+    );
     validate_workspace_boundary(&absolute_path, &canonical_root)?;
     edit_file(path, old_string, new_string, replace_all)
 }
@@ -825,10 +825,10 @@ pub fn is_symlink_escape(path: &Path, workspace_root: &Path) -> io::Result<bool>
         return Ok(false);
     }
     let resolved = clean_path_buf(path.canonicalize()?);
-    let canonical_root = workspace_root
-        .canonicalize()
-        .map(clean_path_buf)
-        .unwrap_or_else(|_| clean_path_buf(workspace_root.to_path_buf()));
+    let canonical_root = workspace_root.canonicalize().map_or_else(
+        |_| clean_path_buf(workspace_root.to_path_buf()),
+        clean_path_buf,
+    );
     Ok(!resolved.starts_with(&canonical_root))
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -86,9 +86,9 @@ pub use conversation::{
     ToolExecutor, TurnSummary,
 };
 pub use file_ops::{
-    edit_file, glob_search, grep_search, read_file, write_file, EditFileOutput, GlobSearchOutput,
-    GrepSearchInput, GrepSearchOutput, ReadFileOutput, StructuredPatchHunk, TextFilePayload,
-    WriteFileOutput,
+    edit_file, glob_search, grep_search, read_file, resolve_tool_path,
+    resolve_tool_path_allow_missing, write_file, EditFileOutput, GlobSearchOutput, GrepSearchInput,
+    GrepSearchOutput, ReadFileOutput, StructuredPatchHunk, TextFilePayload, WriteFileOutput,
 };
 pub use git_context::{GitCommitEntry, GitContext};
 pub use hooks::{

--- a/rust/crates/rusty-claude-cli/tests/compact_output.rs
+++ b/rust/crates/rusty-claude-cli/tests/compact_output.rs
@@ -56,7 +56,7 @@ fn compact_flag_prints_only_final_assistant_text_without_tool_call_details() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     let trimmed = stdout.trim_end_matches('\n');
     assert_eq!(
-        trimmed, "read_file roundtrip complete: alpha parity line",
+        trimmed, "read_file roundtrip complete: 1\talpha parity line",
         "compact stdout should contain only the final assistant text"
     );
     assert!(

--- a/rust/crates/tools/src/file_tools.rs
+++ b/rust/crates/tools/src/file_tools.rs
@@ -84,7 +84,16 @@ fn global_file_tool_states() -> &'static Mutex<GlobalStateMap> {
 
 fn file_tool_context_root() -> Result<PathBuf, String> {
     let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
-    Ok(tool_output_root(&cwd))
+    let session_root = tool_output_root(&cwd);
+    let default_root = cwd.join(".claw");
+    if session_root == default_root {
+        Ok(PathBuf::from(format!(
+            "thread-file-tool-state-{:?}",
+            std::thread::current().id()
+        )))
+    } else {
+        Ok(session_root)
+    }
 }
 
 fn with_context_state_map<R>(action: impl FnOnce(&mut ContextStateMap) -> R) -> Result<R, String> {
@@ -119,18 +128,12 @@ fn file_timestamp_ms(path: &Path) -> Result<u64, String> {
 
 fn has_stale_file_contents(path: &Path, state: &FileToolState) -> Result<bool, String> {
     let last_write_time = file_timestamp_ms(path)?;
-    if last_write_time <= state.timestamp_ms {
-        return Ok(false);
-    }
-
     if !state.is_partial_view {
         let current_content = fs::read_to_string(path).map_err(|error| error.to_string())?;
-        if current_content == state.content {
-            return Ok(false);
-        }
+        return Ok(current_content != state.content);
     }
 
-    Ok(true)
+    Ok(last_write_time != state.timestamp_ms)
 }
 
 fn store_read_state(
@@ -203,9 +206,16 @@ pub(crate) fn record_read_result(
     requested_offset: usize,
     limit: Option<usize>,
 ) -> Result<(), String> {
+    let is_full_view = limit.is_none() && matches!(requested_offset, 0 | 1);
+    let content = if is_full_view {
+        fs::read_to_string(path).map_err(|error| error.to_string())?
+    } else {
+        output.file.content.clone()
+    };
+
     store_read_state(
         path,
-        output.file.content.clone(),
+        content,
         requested_offset,
         limit,
         FileToolStateSource::Read,

--- a/rust/crates/tools/src/file_tools.rs
+++ b/rust/crates/tools/src/file_tools.rs
@@ -1,0 +1,508 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::UNIX_EPOCH;
+
+use runtime::{
+    resolve_tool_path, resolve_tool_path_allow_missing, tool_output_root, EditFileOutput,
+    ReadFileOutput, TextFilePayload, WriteFileOutput,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+pub(crate) const FILE_UNCHANGED_STUB: &str =
+    "File unchanged since last read. The content from the earlier Read tool_result in this conversation is still current; refer to that instead of re-reading.";
+
+const READ_BEFORE_WRITE_ERROR: &str =
+    "File has not been read yet. Read it first before writing to it.";
+const FILE_UNEXPECTEDLY_MODIFIED_ERROR: &str =
+    "File has been modified since read, either by the user or by a linter. Read it again before attempting to write it.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FileUnchangedPayload {
+    #[serde(rename = "filePath")]
+    pub file_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ReadToolOutput {
+    Text { file: TextFilePayload },
+    FileUnchanged { file: FileUnchangedPayload },
+}
+
+impl From<ReadFileOutput> for ReadToolOutput {
+    fn from(value: ReadFileOutput) -> Self {
+        Self::Text { file: value.file }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileToolStateSource {
+    Read,
+    WriteOrEdit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileToolState {
+    timestamp_ms: u64,
+    content: String,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    is_partial_view: bool,
+    source: FileToolStateSource,
+}
+
+type ContextStateMap = HashMap<PathBuf, FileToolState>;
+type GlobalStateMap = HashMap<PathBuf, ContextStateMap>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedRead {
+    pub normalized_path: PathBuf,
+    pub requested_offset: usize,
+    pub limit: Option<usize>,
+    pub dedup_output: Option<ReadToolOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedWrite {
+    pub normalized_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedEdit {
+    pub normalized_path: PathBuf,
+    pub actual_old_string: String,
+    pub actual_new_string: String,
+}
+
+fn global_file_tool_states() -> &'static Mutex<GlobalStateMap> {
+    static STATES: OnceLock<Mutex<GlobalStateMap>> = OnceLock::new();
+    STATES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn file_tool_context_root() -> Result<PathBuf, String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    Ok(tool_output_root(&cwd))
+}
+
+fn with_context_state_map<R>(action: impl FnOnce(&mut ContextStateMap) -> R) -> Result<R, String> {
+    let context_root = file_tool_context_root()?;
+    let mut states = global_file_tool_states()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context_states = states.entry(context_root).or_default();
+    Ok(action(context_states))
+}
+
+fn get_state_for_path(path: &Path) -> Result<Option<FileToolState>, String> {
+    with_context_state_map(|states| states.get(path).cloned())
+}
+
+fn set_state_for_path(path: &Path, state: FileToolState) -> Result<(), String> {
+    with_context_state_map(|states| {
+        states.insert(path.to_path_buf(), state);
+    })
+}
+
+fn file_timestamp_ms(path: &Path) -> Result<u64, String> {
+    let modified = fs::metadata(path)
+        .map_err(|error| error.to_string())?
+        .modified()
+        .map_err(|error| error.to_string())?;
+    let duration = modified
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| error.to_string())?;
+    Ok(u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+}
+
+fn has_stale_file_contents(path: &Path, state: &FileToolState) -> Result<bool, String> {
+    let last_write_time = file_timestamp_ms(path)?;
+    if last_write_time <= state.timestamp_ms {
+        return Ok(false);
+    }
+
+    if !state.is_partial_view {
+        let current_content = fs::read_to_string(path).map_err(|error| error.to_string())?;
+        if current_content == state.content {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn store_read_state(
+    path: &Path,
+    content: String,
+    requested_offset: usize,
+    limit: Option<usize>,
+    source: FileToolStateSource,
+) -> Result<(), String> {
+    let is_full_view = limit.is_none() && matches!(requested_offset, 0 | 1);
+    let timestamp_ms = file_timestamp_ms(path)?;
+    set_state_for_path(
+        path,
+        FileToolState {
+            timestamp_ms,
+            content,
+            offset: match source {
+                FileToolStateSource::Read => Some(requested_offset),
+                FileToolStateSource::WriteOrEdit => None,
+            },
+            limit: match source {
+                FileToolStateSource::Read => limit,
+                FileToolStateSource::WriteOrEdit => None,
+            },
+            is_partial_view: !is_full_view,
+            source,
+        },
+    )
+}
+
+pub(crate) fn prepare_read(
+    path: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<PreparedRead, String> {
+    let normalized_path = resolve_tool_path(path).map_err(|error| error.to_string())?;
+    let requested_offset = offset.unwrap_or(1);
+
+    let dedup_output = get_state_for_path(&normalized_path)?.and_then(|state| {
+        if state.source != FileToolStateSource::Read
+            || state.offset != Some(requested_offset)
+            || state.limit != limit
+        {
+            return None;
+        }
+
+        let current_timestamp = file_timestamp_ms(&normalized_path).ok()?;
+        if current_timestamp != state.timestamp_ms {
+            return None;
+        }
+
+        Some(ReadToolOutput::FileUnchanged {
+            file: FileUnchangedPayload {
+                file_path: normalized_path.to_string_lossy().into_owned(),
+            },
+        })
+    });
+
+    Ok(PreparedRead {
+        normalized_path,
+        requested_offset,
+        limit,
+        dedup_output,
+    })
+}
+
+pub(crate) fn record_read_result(
+    path: &Path,
+    output: &ReadFileOutput,
+    requested_offset: usize,
+    limit: Option<usize>,
+) -> Result<(), String> {
+    store_read_state(
+        path,
+        output.file.content.clone(),
+        requested_offset,
+        limit,
+        FileToolStateSource::Read,
+    )
+}
+
+pub(crate) fn prepare_write(path: &str) -> Result<PreparedWrite, String> {
+    let normalized_path =
+        resolve_tool_path_allow_missing(path).map_err(|error| error.to_string())?;
+    if !normalized_path.exists() {
+        return Ok(PreparedWrite { normalized_path });
+    }
+
+    let state =
+        get_state_for_path(&normalized_path)?.ok_or_else(|| READ_BEFORE_WRITE_ERROR.to_string())?;
+    if state.is_partial_view {
+        return Err(READ_BEFORE_WRITE_ERROR.to_string());
+    }
+    if has_stale_file_contents(&normalized_path, &state)? {
+        return Err(FILE_UNEXPECTEDLY_MODIFIED_ERROR.to_string());
+    }
+
+    Ok(PreparedWrite { normalized_path })
+}
+
+pub(crate) fn record_write_result(path: &Path, output: &WriteFileOutput) -> Result<(), String> {
+    store_read_state(
+        path,
+        output.content.clone(),
+        1,
+        None,
+        FileToolStateSource::WriteOrEdit,
+    )
+}
+
+pub(crate) fn prepare_edit(
+    path: &str,
+    old_string: &str,
+    new_string: &str,
+    replace_all: bool,
+) -> Result<PreparedEdit, String> {
+    if old_string == new_string {
+        return Err(
+            "No changes to make: old_string and new_string are exactly the same.".to_string(),
+        );
+    }
+
+    let normalized_path =
+        resolve_tool_path_allow_missing(path).map_err(|error| error.to_string())?;
+    let file_exists = normalized_path.exists();
+
+    if !file_exists {
+        if old_string.is_empty() {
+            return Ok(PreparedEdit {
+                normalized_path,
+                actual_old_string: String::new(),
+                actual_new_string: new_string.to_string(),
+            });
+        }
+        return Err("File does not exist.".to_string());
+    }
+
+    if normalized_path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ipynb"))
+    {
+        return Err(
+            "File is a Jupyter Notebook. Use the NotebookEdit tool to edit this file.".to_string(),
+        );
+    }
+
+    let file_content = fs::read_to_string(&normalized_path).map_err(|error| error.to_string())?;
+    if old_string.is_empty() {
+        if file_content.trim().is_empty() {
+            return Ok(PreparedEdit {
+                normalized_path,
+                actual_old_string: String::new(),
+                actual_new_string: new_string.to_string(),
+            });
+        }
+        return Err("Cannot create new file - file already exists.".to_string());
+    }
+
+    let state =
+        get_state_for_path(&normalized_path)?.ok_or_else(|| READ_BEFORE_WRITE_ERROR.to_string())?;
+    if state.is_partial_view {
+        return Err(READ_BEFORE_WRITE_ERROR.to_string());
+    }
+    if has_stale_file_contents(&normalized_path, &state)? {
+        return Err(FILE_UNEXPECTEDLY_MODIFIED_ERROR.to_string());
+    }
+
+    let actual_old_string = find_actual_string(&file_content, old_string)
+        .ok_or_else(|| format!("String to replace not found in file.\nString: {old_string}"))?;
+    let matches = count_occurrences(&file_content, &actual_old_string);
+    if matches > 1 && !replace_all {
+        return Err(format!(
+            "Found {matches} matches of the string to replace, but replace_all is false. To replace all occurrences, set replace_all to true. To replace only one occurrence, please provide more context to uniquely identify the instance.\nString: {old_string}"
+        ));
+    }
+
+    Ok(PreparedEdit {
+        normalized_path,
+        actual_old_string: actual_old_string.clone(),
+        actual_new_string: preserve_quote_style(old_string, &actual_old_string, new_string),
+    })
+}
+
+pub(crate) fn record_edit_result(path: &Path) -> Result<(), String> {
+    let content = fs::read_to_string(path).map_err(|error| error.to_string())?;
+    store_read_state(path, content, 1, None, FileToolStateSource::WriteOrEdit)
+}
+
+pub(crate) fn parse_read_tool_result(output: &str) -> Option<(ReadToolOutput, &str)> {
+    parse_tool_result::<ReadToolOutput>(output).or_else(|| {
+        parse_tool_result::<ReadFileOutput>(output)
+            .map(|(result, trailing)| (ReadToolOutput::from(result), trailing))
+    })
+}
+
+pub(crate) fn parse_write_tool_result(output: &str) -> Option<(WriteFileOutput, &str)> {
+    parse_tool_result::<WriteFileOutput>(output)
+}
+
+pub(crate) fn parse_edit_tool_result(output: &str) -> Option<(EditFileOutput, &str)> {
+    parse_tool_result::<EditFileOutput>(output)
+}
+
+pub(crate) fn read_tool_result_text(output: &ReadToolOutput) -> String {
+    match output {
+        ReadToolOutput::Text { file } => {
+            if !file.content.is_empty() {
+                format_file_lines(file)
+            } else if file.total_lines == 0 {
+                "<system-reminder>Warning: the file exists but the contents are empty.</system-reminder>".to_string()
+            } else {
+                format!(
+                    "<system-reminder>Warning: the file exists but is shorter than the provided offset ({}). The file has {} lines.</system-reminder>",
+                    file.start_line, file.total_lines
+                )
+            }
+        }
+        ReadToolOutput::FileUnchanged { .. } => FILE_UNCHANGED_STUB.to_string(),
+    }
+}
+
+pub(crate) fn write_tool_result_text(output: &WriteFileOutput) -> String {
+    match output.kind.as_str() {
+        "create" => format!("File created successfully at: {}", output.file_path),
+        _ => format!(
+            "The file {} has been updated successfully.",
+            output.file_path
+        ),
+    }
+}
+
+pub(crate) fn edit_tool_result_text(output: &EditFileOutput) -> String {
+    let modified_note = if output.user_modified {
+        ". The user modified your proposed changes before accepting them."
+    } else {
+        ""
+    };
+
+    if output.replace_all {
+        format!(
+            "The file {} has been updated{modified_note}. All occurrences were successfully replaced.",
+            output.file_path
+        )
+    } else {
+        format!(
+            "The file {} has been updated successfully{modified_note}.",
+            output.file_path
+        )
+    }
+}
+
+fn parse_tool_result<T: DeserializeOwned>(output: &str) -> Option<(T, &str)> {
+    if let Ok(parsed) = serde_json::from_str::<T>(output) {
+        return Some((parsed, ""));
+    }
+
+    let (json_prefix, trailing_text) = crate::split_json_prefix(output)?;
+    let parsed = serde_json::from_str::<T>(json_prefix).ok()?;
+    Some((parsed, trailing_text))
+}
+
+fn format_file_lines(file: &TextFilePayload) -> String {
+    file.content
+        .split('\n')
+        .enumerate()
+        .map(|(index, line)| {
+            let line_number = file.start_line.saturating_add(index);
+            format!("{line_number:>6}\t{line}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    haystack.match_indices(needle).count()
+}
+
+fn find_actual_string(file_content: &str, search_string: &str) -> Option<String> {
+    if file_content.contains(search_string) {
+        return Some(search_string.to_string());
+    }
+
+    let normalized_search = normalize_quotes(search_string);
+    let normalized_file = normalize_quotes(file_content);
+    let search_index = normalized_file.find(&normalized_search)?;
+    Some(
+        file_content
+            .chars()
+            .skip(search_index)
+            .take(search_string.chars().count())
+            .collect(),
+    )
+}
+
+fn normalize_quotes(value: &str) -> String {
+    value
+        .replace(['\u{2018}', '\u{2019}'], "'")
+        .replace(['\u{201C}', '\u{201D}'], "\"")
+}
+
+fn preserve_quote_style(old_string: &str, actual_old_string: &str, new_string: &str) -> String {
+    if old_string == actual_old_string {
+        return new_string.to_string();
+    }
+
+    let has_double_quotes =
+        actual_old_string.contains('\u{201C}') || actual_old_string.contains('\u{201D}');
+    let has_single_quotes =
+        actual_old_string.contains('\u{2018}') || actual_old_string.contains('\u{2019}');
+
+    let mut result = new_string.to_string();
+    if has_double_quotes {
+        result = apply_curly_double_quotes(&result);
+    }
+    if has_single_quotes {
+        result = apply_curly_single_quotes(&result);
+    }
+
+    result
+}
+
+fn is_opening_context(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+
+    matches!(
+        chars[index - 1],
+        ' ' | '\t' | '\n' | '\r' | '(' | '[' | '{' | '\u{2014}' | '\u{2013}'
+    )
+}
+
+fn apply_curly_double_quotes(value: &str) -> String {
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut result = String::new();
+    for (index, ch) in chars.iter().enumerate() {
+        if *ch == '"' {
+            result.push(if is_opening_context(&chars, index) {
+                '\u{201C}'
+            } else {
+                '\u{201D}'
+            });
+        } else {
+            result.push(*ch);
+        }
+    }
+    result
+}
+
+fn apply_curly_single_quotes(value: &str) -> String {
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut result = String::new();
+    for (index, ch) in chars.iter().enumerate() {
+        if *ch == '\'' {
+            let prev = index.checked_sub(1).and_then(|idx| chars.get(idx));
+            let next = chars.get(index + 1);
+            let prev_is_letter = prev.is_some_and(|candidate| candidate.is_alphabetic());
+            let next_is_letter = next.is_some_and(|candidate| candidate.is_alphabetic());
+            if prev_is_letter && next_is_letter {
+                result.push('\u{2019}');
+            } else if is_opening_context(&chars, index) {
+                result.push('\u{2018}');
+            } else {
+                result.push('\u{2019}');
+            }
+        } else {
+            result.push(*ch);
+        }
+    }
+    result
+}

--- a/rust/crates/tools/src/file_tools.rs
+++ b/rust/crates/tools/src/file_tools.rs
@@ -82,6 +82,35 @@ fn global_file_tool_states() -> &'static Mutex<GlobalStateMap> {
     STATES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn clean_state_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let text = path.to_string_lossy();
+        if let Some(stripped) = text.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+
+    path
+}
+
+fn normalize_state_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return clean_state_path(canonical);
+    }
+
+    if let Some(parent) = path.parent() {
+        let canonical_parent = parent
+            .canonicalize()
+            .map_or_else(|_| clean_state_path(parent.to_path_buf()), clean_state_path);
+        if let Some(name) = path.file_name() {
+            return clean_state_path(canonical_parent.join(name));
+        }
+    }
+
+    clean_state_path(path.to_path_buf())
+}
+
 fn file_tool_context_root() -> Result<PathBuf, String> {
     let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
     let session_root = tool_output_root(&cwd);
@@ -106,12 +135,14 @@ fn with_context_state_map<R>(action: impl FnOnce(&mut ContextStateMap) -> R) -> 
 }
 
 fn get_state_for_path(path: &Path) -> Result<Option<FileToolState>, String> {
-    with_context_state_map(|states| states.get(path).cloned())
+    let normalized_path = normalize_state_path(path);
+    with_context_state_map(|states| states.get(&normalized_path).cloned())
 }
 
 fn set_state_for_path(path: &Path, state: FileToolState) -> Result<(), String> {
+    let normalized_path = normalize_state_path(path);
     with_context_state_map(|states| {
-        states.insert(path.to_path_buf(), state);
+        states.insert(normalized_path, state);
     })
 }
 

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -37,6 +37,12 @@ use runtime::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::file_tools::{
+    edit_tool_result_text, parse_edit_tool_result, parse_read_tool_result, parse_write_tool_result,
+    prepare_edit, prepare_read, prepare_write, read_tool_result_text, record_edit_result,
+    record_read_result, record_write_result, write_tool_result_text,
+};
+
 /// Global task registry shared across tool invocations within a session.
 fn global_lsp_registry() -> &'static LspRegistry {
     use std::sync::OnceLock;
@@ -418,10 +424,14 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "path": { "type": "string" },
+                    "file_path": { "type": "string" },
                     "offset": { "type": "integer", "minimum": 0 },
                     "limit": { "type": "integer", "minimum": 1 }
                 },
-                "required": ["path"],
+                "anyOf": [
+                    { "required": ["path"] },
+                    { "required": ["file_path"] }
+                ],
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::ReadOnly,
@@ -433,9 +443,13 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "path": { "type": "string" },
+                    "file_path": { "type": "string" },
                     "content": { "type": "string" }
                 },
-                "required": ["path", "content"],
+                "anyOf": [
+                    { "required": ["path", "content"] },
+                    { "required": ["file_path", "content"] }
+                ],
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::WorkspaceWrite,
@@ -447,11 +461,15 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "path": { "type": "string" },
+                    "file_path": { "type": "string" },
                     "old_string": { "type": "string" },
                     "new_string": { "type": "string" },
                     "replace_all": { "type": "boolean" }
                 },
-                "required": ["path", "old_string", "new_string"],
+                "anyOf": [
+                    { "required": ["path", "old_string", "new_string"] },
+                    { "required": ["file_path", "old_string", "new_string"] }
+                ],
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::WorkspaceWrite,
@@ -2059,25 +2077,47 @@ fn branch_divergence_stderr(
 
 #[allow(clippy::needless_pass_by_value)]
 fn run_read_file(input: ReadFileInput) -> Result<String, String> {
-    to_pretty_json(read_file(&input.path, input.offset, input.limit).map_err(io_to_string)?)
+    let prepared = prepare_read(&input.path, input.offset, input.limit)?;
+    if let Some(dedup_output) = prepared.dedup_output {
+        return to_pretty_json(dedup_output);
+    }
+
+    let output = read_file(&input.path, input.offset, input.limit).map_err(io_to_string)?;
+    record_read_result(
+        &prepared.normalized_path,
+        &output,
+        prepared.requested_offset,
+        prepared.limit,
+    )?;
+    to_pretty_json(output)
 }
 
 #[allow(clippy::needless_pass_by_value)]
 fn run_write_file(input: WriteFileInput) -> Result<String, String> {
-    to_pretty_json(write_file(&input.path, &input.content).map_err(io_to_string)?)
+    let prepared = prepare_write(&input.path)?;
+    let output = write_file(&input.path, &input.content).map_err(io_to_string)?;
+    record_write_result(&prepared.normalized_path, &output)?;
+    to_pretty_json(output)
 }
 
 #[allow(clippy::needless_pass_by_value)]
 fn run_edit_file(input: EditFileInput) -> Result<String, String> {
-    to_pretty_json(
-        edit_file(
-            &input.path,
-            &input.old_string,
-            &input.new_string,
-            input.replace_all.unwrap_or(false),
-        )
-        .map_err(io_to_string)?,
+    let replace_all = input.replace_all.unwrap_or(false);
+    let prepared = prepare_edit(
+        &input.path,
+        &input.old_string,
+        &input.new_string,
+        replace_all,
+    )?;
+    let output = edit_file(
+        &input.path,
+        &prepared.actual_old_string,
+        &prepared.actual_new_string,
+        replace_all,
     )
+    .map_err(io_to_string)?;
+    record_edit_result(&prepared.normalized_path)?;
+    to_pretty_json(output)
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -2163,6 +2203,7 @@ fn io_to_string(error: std::io::Error) -> String {
 
 #[derive(Debug, Deserialize)]
 struct ReadFileInput {
+    #[serde(alias = "file_path")]
     path: String,
     offset: Option<usize>,
     limit: Option<usize>,
@@ -2170,12 +2211,14 @@ struct ReadFileInput {
 
 #[derive(Debug, Deserialize)]
 struct WriteFileInput {
+    #[serde(alias = "file_path")]
     path: String,
     content: String,
 }
 
 #[derive(Debug, Deserialize)]
 struct EditFileInput {
+    #[serde(alias = "file_path")]
     path: String,
     old_string: String,
     new_string: String,
@@ -4226,6 +4269,28 @@ fn model_visible_tool_result_with_id(
     output: &str,
     is_error: bool,
 ) -> ModelVisibleToolResult {
+    if let Some((read_output, trailing_text)) = parse_read_tool_result_for_tool(tool_name, output) {
+        let mut result =
+            ModelVisibleToolResult::raw_text(&read_tool_result_text(&read_output), is_error);
+        append_trailing_tool_text(&mut result.content, trailing_text);
+        return result;
+    }
+
+    if let Some((write_output, trailing_text)) = parse_write_tool_result_for_tool(tool_name, output)
+    {
+        let mut result =
+            ModelVisibleToolResult::raw_text(&write_tool_result_text(&write_output), is_error);
+        append_trailing_tool_text(&mut result.content, trailing_text);
+        return result;
+    }
+
+    if let Some((edit_output, trailing_text)) = parse_edit_tool_result_for_tool(tool_name, output) {
+        let mut result =
+            ModelVisibleToolResult::raw_text(&edit_tool_result_text(&edit_output), is_error);
+        append_trailing_tool_text(&mut result.content, trailing_text);
+        return result;
+    }
+
     if let Some((shell_output, trailing_text)) = parse_shell_tool_result(tool_name, output) {
         let mut result = shell_tool_result_to_model_visible_result(&shell_output, is_error);
         append_trailing_tool_text(&mut result.content, trailing_text);
@@ -4382,7 +4447,7 @@ fn parse_search_tool_result_json(tool_name: &str, output: &str) -> Option<Search
     }
 }
 
-fn split_json_prefix(input: &str) -> Option<(&str, &str)> {
+pub(crate) fn split_json_prefix(input: &str) -> Option<(&str, &str)> {
     let start = input.find(|ch: char| !ch.is_whitespace())?;
     let mut stack = Vec::new();
     let mut in_string = false;
@@ -4431,6 +4496,36 @@ fn split_json_prefix(input: &str) -> Option<(&str, &str)> {
 
     let end = end?;
     Some((&input[start..end], &input[end..]))
+}
+
+fn parse_read_tool_result_for_tool<'a>(
+    tool_name: &str,
+    output: &'a str,
+) -> Option<(crate::file_tools::ReadToolOutput, &'a str)> {
+    match tool_name {
+        "read_file" | "Read" => parse_read_tool_result(output),
+        _ => None,
+    }
+}
+
+fn parse_write_tool_result_for_tool<'a>(
+    tool_name: &str,
+    output: &'a str,
+) -> Option<(runtime::WriteFileOutput, &'a str)> {
+    match tool_name {
+        "write_file" | "Write" => parse_write_tool_result(output),
+        _ => None,
+    }
+}
+
+fn parse_edit_tool_result_for_tool<'a>(
+    tool_name: &str,
+    output: &'a str,
+) -> Option<(runtime::EditFileOutput, &'a str)> {
+    match tool_name {
+        "edit_file" | "Edit" => parse_edit_tool_result(output),
+        _ => None,
+    }
 }
 
 fn shell_tool_result_to_model_visible_result(
@@ -6253,6 +6348,7 @@ fn parse_skill_description(contents: &str) -> Option<String> {
     None
 }
 
+mod file_tools;
 pub mod lane_completion;
 pub mod pdf_extract;
 
@@ -6621,6 +6717,101 @@ mod tests {
             ModelVisibleToolResult {
                 content: vec![ToolResultContentBlock::Text {
                     text: "No files found".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_read_results_like_ts() {
+        let output = serde_json::to_string_pretty(&json!({
+            "type": "text",
+            "file": {
+                "filePath": "C:\\repo\\demo.txt",
+                "content": "alpha\nbeta",
+                "numLines": 2,
+                "startLine": 7,
+                "totalLines": 20
+            }
+        }))
+        .expect("serialize read result");
+
+        let result = model_visible_tool_result("read_file", &output, false);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "     7\talpha\n     8\tbeta".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_read_unchanged_stub_like_ts() {
+        let output = serde_json::to_string_pretty(&json!({
+            "type": "file_unchanged",
+            "file": {
+                "filePath": "C:\\repo\\demo.txt"
+            }
+        }))
+        .expect("serialize read unchanged result");
+
+        let result = model_visible_tool_result("read_file", &output, false);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: super::file_tools::FILE_UNCHANGED_STUB.to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_write_and_edit_results_like_ts() {
+        let write_output = serde_json::to_string_pretty(&json!({
+            "type": "create",
+            "filePath": "C:\\repo\\demo.txt",
+            "content": "alpha",
+            "structuredPatch": [],
+            "originalFile": serde_json::Value::Null,
+            "gitDiff": serde_json::Value::Null
+        }))
+        .expect("serialize write result");
+        let write_result = model_visible_tool_result("write_file", &write_output, false);
+        assert_eq!(
+            write_result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "File created successfully at: C:\\repo\\demo.txt".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+
+        let edit_output = serde_json::to_string_pretty(&json!({
+            "filePath": "C:\\repo\\demo.txt",
+            "oldString": "alpha",
+            "newString": "omega",
+            "originalFile": "alpha\n",
+            "structuredPatch": [],
+            "userModified": false,
+            "replaceAll": true,
+            "gitDiff": serde_json::Value::Null
+        }))
+        .expect("serialize edit result");
+        let edit_result = model_visible_tool_result("edit_file", &edit_output, false);
+        assert_eq!(
+            edit_result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "The file C:\\repo\\demo.txt has been updated. All occurrences were successfully replaced.".to_string(),
                 }],
                 is_error: false,
             }
@@ -9116,6 +9307,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn file_tools_cover_read_write_and_edit_behaviors() {
         let _guard = env_lock()
             .lock()
@@ -9124,6 +9316,10 @@ mod tests {
         fs::create_dir_all(&root).expect("create root");
         let demo_path = root.join("nested/demo.txt");
         let demo_path_string = demo_path.to_string_lossy().into_owned();
+        let existing_path = root.join("nested/existing.txt");
+        let existing_path_string = existing_path.to_string_lossy().into_owned();
+        let created_by_edit_path = root.join("nested/created-by-edit.txt");
+        let created_by_edit_path_string = created_by_edit_path.to_string_lossy().into_owned();
 
         let write_create = execute_tool(
             "write_file",
@@ -9151,14 +9347,21 @@ mod tests {
         assert_eq!(read_full_output["file"]["content"], "alpha\nbeta\ngamma");
         assert_eq!(read_full_output["file"]["startLine"], 1);
 
+        let read_full_again =
+            execute_tool("read_file", &json!({ "path": demo_path_string.as_str() }))
+                .expect("deduped read should succeed");
+        let read_full_again_output: serde_json::Value =
+            serde_json::from_str(&read_full_again).expect("json");
+        assert_eq!(read_full_again_output["type"], "file_unchanged");
+
         let read_slice = execute_tool(
             "read_file",
             &json!({ "path": demo_path_string.as_str(), "offset": 1, "limit": 1 }),
         )
         .expect("read slice should succeed");
         let read_slice_output: serde_json::Value = serde_json::from_str(&read_slice).expect("json");
-        assert_eq!(read_slice_output["file"]["content"], "beta");
-        assert_eq!(read_slice_output["file"]["startLine"], 2);
+        assert_eq!(read_slice_output["file"]["content"], "alpha");
+        assert_eq!(read_slice_output["file"]["startLine"], 1);
 
         let read_past_end = execute_tool(
             "read_file",
@@ -9168,12 +9371,46 @@ mod tests {
         let read_past_end_output: serde_json::Value =
             serde_json::from_str(&read_past_end).expect("json");
         assert_eq!(read_past_end_output["file"]["content"], "");
-        assert_eq!(read_past_end_output["file"]["startLine"], 4);
+        assert_eq!(read_past_end_output["file"]["startLine"], 50);
 
         let read_error = execute_tool("read_file", &json!({ "path": "missing.txt" }))
             .expect_err("missing file should fail");
         assert!(!read_error.is_empty());
 
+        fs::write(&existing_path, "before\n").expect("seed existing file");
+        let write_without_read = execute_tool(
+            "write_file",
+            &json!({ "path": existing_path_string.as_str(), "content": "after\n" }),
+        )
+        .expect_err("existing file write should require a prior read");
+        assert!(write_without_read.contains("Read it first before writing to it"));
+
+        execute_tool(
+            "read_file",
+            &json!({ "path": existing_path_string.as_str() }),
+        )
+        .expect("existing file read should succeed");
+        let write_after_read = execute_tool(
+            "write_file",
+            &json!({ "path": existing_path_string.as_str(), "content": "after\n" }),
+        )
+        .expect("existing file write after read should succeed");
+        let write_after_read_output: serde_json::Value =
+            serde_json::from_str(&write_after_read).expect("json");
+        assert_eq!(write_after_read_output["type"], "update");
+        assert_eq!(write_after_read_output["originalFile"], "before\n");
+
+        std::thread::sleep(Duration::from_millis(10));
+        fs::write(&existing_path, "user edit\n").expect("simulate external edit");
+        let stale_write = execute_tool(
+            "write_file",
+            &json!({ "path": existing_path_string.as_str(), "content": "stale\n" }),
+        )
+        .expect_err("stale write should fail");
+        assert!(stale_write.contains("modified since read"));
+
+        execute_tool("read_file", &json!({ "path": demo_path_string.as_str() }))
+            .expect("full read should refresh edit state");
         let edit_once = execute_tool(
             "edit_file",
             &json!({ "path": demo_path_string.as_str(), "old_string": "alpha", "new_string": "omega" }),
@@ -9191,6 +9428,17 @@ mod tests {
             &json!({ "path": demo_path_string.as_str(), "content": "alpha\nbeta\nalpha\n" }),
         )
         .expect("reset file");
+        let edit_ambiguous = execute_tool(
+            "edit_file",
+            &json!({
+                "path": demo_path_string.as_str(),
+                "old_string": "alpha",
+                "new_string": "omega"
+            }),
+        )
+        .expect_err("ambiguous edit should fail without replace_all");
+        assert!(edit_ambiguous.contains("replace_all is false"));
+
         let edit_all = execute_tool(
             "edit_file",
             &json!({
@@ -9213,14 +9461,28 @@ mod tests {
             &json!({ "path": demo_path_string.as_str(), "old_string": "omega", "new_string": "omega" }),
         )
         .expect_err("identical old/new should fail");
-        assert!(edit_same.contains("must differ"));
+        assert!(edit_same.contains("No changes to make"));
 
         let edit_missing = execute_tool(
             "edit_file",
             &json!({ "path": demo_path_string.as_str(), "old_string": "missing", "new_string": "omega" }),
         )
         .expect_err("missing substring should fail");
-        assert!(edit_missing.contains("old_string not found"));
+        assert!(edit_missing.contains("String to replace not found"));
+
+        execute_tool(
+            "edit_file",
+            &json!({
+                "path": created_by_edit_path_string.as_str(),
+                "old_string": "",
+                "new_string": "created by edit\n"
+            }),
+        )
+        .expect("edit should be able to create a new file");
+        assert_eq!(
+            fs::read_to_string(&created_by_edit_path).expect("read created-by-edit file"),
+            "created by edit\n"
+        );
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Summary
- port TS-style model-visible wrappers for read_file, write_file, and edit_file
- add session-scoped read state, dedup, and stale checks for file tool workflows
- align read offset semantics with TS text behavior and update runtime/compact tests

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --nocapture