### PR TITLE
[codex] Port TS full compact and bundled skills

### DIFF
--- a/docs/ts-rust-migration-backlog.md
+++ b/docs/ts-rust-migration-backlog.md
@@ -1,0 +1,256 @@
+# TS -> Rust Migration Backlog
+
+Last updated: 2026-04-21
+
+## Purpose
+
+This document is the working checklist for migrating important `claw_code_ts_snapshot`
+behavior into the Rust implementation.
+
+Use this file as the execution backlog:
+
+- Mark an item `[x]` only when the model-visible behavior is implemented in Rust.
+- Prefer checking off vertical slices that include runtime wiring and regression tests.
+- If a large item needs to be split, add child checklist items beneath it instead of
+  rewriting the section from scratch.
+
+Reference roots:
+
+- TS source: [`archive/claw_code_ts_snapshot/src`](/C:/Users/esp3j/rep/appfs-agent/archive/claw_code_ts_snapshot/src)
+- Rust workspace: [`rust/`](/C:/Users/esp3j/rep/appfs-agent/rust)
+
+## Already migrated
+
+- [x] Bash / PowerShell model-visible wrapper parity for large output persistence and
+  session-scoped output paths
+- [x] Glob / Grep wrapper parity, including persisted output handling
+- [x] Read / Write / Edit text-file wrapper parity for core JSON shape
+- [x] Session-scoped tool output storage under `.claw/sessions/<session-id>/...`
+- [x] File read-state tracking for stale write / stale edit protection
+- [x] Full compact core path for Rust `/compact` and `--resume` flows
+- [x] Compact transcript support for preserved summary / attachment-style context messages
+
+## Recommended migration order
+
+1. Skill system foundation
+2. Skill execution semantics
+3. Agent runtime orchestration
+4. High-value tool deep parity
+5. Security / analytics / polish parity
+
+## Tools backlog
+
+### P0 - High-value tool parity
+
+- [x] `Skill` tool execution parity foundation
+  TS reference: `src/tools/SkillTool/SkillTool.ts`, `src/skills/loadSkillsDir.ts`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`, `rust/crates/commands/src/lib.rs`
+  Done when: Rust no longer treats `Skill` as a plain file reader and instead returns
+  normalized skill metadata plus execution-ready prompt content that matches TS rules.
+
+- [ ] `LSP` real operation parity
+  TS reference: `src/tools/LSPTool/LSPTool.ts`
+  Rust landing zone: `rust/crates/runtime/src/lsp_client.rs`, `rust/crates/tools/src/lib.rs`
+  Done when: definition / references / hover / symbols are backed by real LSP calls
+  rather than dispatch placeholders, and tool output shape is stable under tests.
+
+- [ ] `ReadMcpResource` content parity
+  TS reference: `src/tools/ReadMcpResourceTool/ReadMcpResourceTool.ts`
+  Rust landing zone: `rust/crates/runtime/src/mcp_tool_bridge.rs`,
+  `rust/crates/tools/src/lib.rs`
+  Done when: Rust returns actual resource contents, persists binary blobs to disk when
+  needed, and exposes model-visible output comparable to TS.
+
+- [ ] `McpAuth` OAuth flow parity
+  TS reference: `src/tools/McpAuthTool/McpAuthTool.ts`
+  Rust landing zone: `rust/crates/runtime/src/mcp_tool_bridge.rs`,
+  `rust/crates/runtime/src/mcp_stdio.rs`, `rust/crates/tools/src/lib.rs`
+  Done when: Rust can surface an auth URL or equivalent actionable auth state instead
+  of only reporting current connection status.
+
+- [ ] `SendMessage` tool parity
+  TS reference: `src/tools/SendMessageTool/SendMessageTool.ts`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`, `rust/crates/runtime/src/worker_boot.rs`
+  Done when: a running agent can be continued through a model-visible tool call with
+  delivery semantics comparable to TS.
+
+- [ ] `EnterWorktree` / `ExitWorktree` parity
+  TS reference: `src/tools/EnterWorktreeTool/EnterWorktreeTool.ts`,
+  `src/tools/ExitWorktreeTool`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`, `rust/crates/runtime/src/session_control.rs`
+  Done when: Rust can create a session-linked isolated worktree and switch session
+  context into and out of it with persisted state.
+
+- [ ] `Brief` attachment bridge parity
+  TS reference: `src/tools/BriefTool/BriefTool.ts`, `src/tools/BriefTool/upload.ts`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`
+  Done when: attachment metadata supports the same cross-surface behavior expected by TS,
+  including uploaded/bridged attachment identifiers where applicable.
+
+- [ ] `AskUserQuestion` interactive parity
+  TS reference: `src/tools/AskUserQuestionTool`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`
+  Done when: Rust stops relying on terminal stdin prompting and instead supports the
+  same structured user-question flow expected by the higher-level runtime/UI.
+
+### P1 - Important but not first
+
+- [ ] Cron tool durability parity
+  TS reference: `src/tools/ScheduleCronTool/CronCreateTool.ts`,
+  `src/tools/ScheduleCronTool/CronDeleteTool.ts`,
+  `src/tools/ScheduleCronTool/CronListTool.ts`
+  Rust landing zone: `rust/crates/runtime/src/team_cron_registry.rs`,
+  `rust/crates/tools/src/lib.rs`
+  Done when: cron entries are not only in-memory records, but support durable storage
+  and scheduler semantics comparable to TS.
+
+- [ ] Team / Task orchestration parity
+  TS reference: `src/tools/Task*`, `src/tools/Team*`
+  Rust landing zone: `rust/crates/runtime/src/task_registry.rs`,
+  `rust/crates/runtime/src/team_cron_registry.rs`, `rust/crates/tools/src/lib.rs`
+  Done when: tool semantics reflect actual orchestrated execution rather than only
+  registry bookkeeping.
+
+- [ ] `RemoteTrigger` semantics parity
+  TS reference: `src/tools/RemoteTriggerTool`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`
+  Done when: input validation, result shape, and failure surface match TS expectations.
+
+- [ ] Deep bash security parity
+  TS reference: `src/tools/BashTool/bashSecurity.ts`
+  Rust landing zone: `rust/crates/runtime/src/bash_validation.rs`
+  Done when: the highest-value shell parsing / escaping / redirection / substitution
+  defenses from TS are explicitly ported or intentionally rejected with rationale.
+
+## Agent runtime backlog
+
+### P0 - High-value runtime parity
+
+- [ ] Coordinator mode parity
+  TS reference: `src/coordinator/coordinatorMode.ts`
+  Rust landing zone: `rust/crates/runtime/src/conversation.rs`,
+  `rust/crates/tools/src/lib.rs`, prompt-building/runtime wiring
+  Done when: Rust can run with a coordinator-style system prompt and worker orchestration
+  model rather than only a simple local sub-agent model.
+
+- [ ] Worker notification protocol parity
+  TS reference: `src/coordinator/coordinatorMode.ts`, `src/tools/AgentTool/*`
+  Rust landing zone: `rust/crates/runtime/src/worker_boot.rs`,
+  `rust/crates/runtime/src/session.rs`
+  Done when: worker completions are surfaced back into the conversation in a structured,
+  resumable way comparable to TS task notifications.
+
+- [ ] Background / resumable agent lifecycle parity
+  TS reference: `src/tools/AgentTool/AgentTool.tsx`,
+  `src/tools/AgentTool/resumeAgent.ts`
+  Rust landing zone: `rust/crates/tools/src/lib.rs`,
+  `rust/crates/runtime/src/worker_boot.rs`
+  Done when: agent launch, backgrounding, resume, retry, kill, and continuation are
+  all first-class runtime behaviors.
+
+- [ ] Worktree-isolated sub-agent execution parity
+  TS reference: `src/tools/AgentTool/forkSubagent.ts`,
+  `src/utils/worktree.js`
+  Rust landing zone: runtime/session/worktree management modules
+  Done when: sub-agents can be launched into isolated worktrees rather than always
+  sharing the current workspace.
+
+### P1 - Important follow-up runtime parity
+
+- [ ] Session/project-root semantics parity for throwaway worktrees
+  TS reference: `src/bootstrap/state.ts`
+  Rust landing zone: `rust/crates/runtime/src/session_control.rs`,
+  prompt/context discovery
+  Done when: Rust distinguishes project identity from current cwd the way TS does for
+  skills, history, and session storage.
+
+- [ ] Cost / token tracking parity
+  TS reference: `src/cost-tracker.ts`, `src/bootstrap/state.ts`
+  Rust landing zone: `rust/crates/runtime/src/usage.rs`, conversation/runtime telemetry
+  Done when: session-visible cost and token accounting are comparable to TS.
+
+- [ ] Post-compaction analytics parity
+  TS reference: `src/bootstrap/state.ts`
+  Rust landing zone: `rust/crates/runtime/src/conversation.rs`,
+  `rust/crates/runtime/src/compact.rs`
+  Done when: Rust preserves the same useful post-compact latches / follow-up metadata
+  TS uses for prompt-cache and cache-miss attribution.
+
+- [ ] Remote / CCR agent execution parity
+  TS reference: remote agent and CCR transport code under `src/tools/AgentTool` and `src/cli/transports`
+  Rust landing zone: future runtime integration
+  Done when: remote isolated agents are a real runtime capability in Rust, or this item
+  is explicitly dropped by product decision.
+
+## Skills backlog
+
+### P0 - Foundation
+
+- [x] Shared skill frontmatter parser parity
+  TS reference: `src/skills/loadSkillsDir.ts`
+  Rust landing zone: likely new shared module under `rust/crates/tools/src/` or
+  `rust/crates/commands/src/`
+  Done when: Rust parses at least `name`, `description`, `arguments`, `argument-hint`,
+  `allowed-tools`, `model`, `effort`, `hooks`, `paths`, `context`, and `agent`.
+
+- [x] Skill argument substitution parity
+  TS reference: `src/utils/argumentSubstitution.js`, `src/skills/loadSkillsDir.ts`
+  Rust landing zone: tool/command skill loading path
+  Done when: Rust can apply skill arguments into prompt content using TS-compatible
+  substitution rules.
+
+- [x] Conditional skill activation by `paths` parity
+  TS reference: `src/skills/loadSkillsDir.ts`
+  Rust landing zone: skill discovery and prompt-building layers
+  Done when: path-scoped skills activate only when the current workspace context matches
+  their path selectors.
+
+- [x] Skill execution-context parity
+  TS reference: `src/tools/SkillTool/SkillTool.ts`, `src/skills/loadSkillsDir.ts`
+  Rust landing zone: `Skill` tool plus agent runtime wiring
+  Done when: Rust honors whether a skill should run directly or in a forked agent context.
+
+### P1 - Important follow-up skill parity
+
+- [ ] Bundled skill registry parity
+  TS reference: `src/skills/bundled`, `src/skills/bundledSkills.ts`
+  Rust landing zone: new bundled-skill registry plus command/tool discovery wiring
+  Done when: high-value built-in skills such as `verify`, `stuck`, `remember`, `skillify`,
+  and `batch` are available in Rust with stable discovery semantics.
+  - [x] Shared bundled-skill registry and `/skills` discovery wiring
+  - [x] `Skill` tool execution path for bundled skills, including prompt wrapper and
+    session-scoped reference-file extraction
+  - [x] Prompt-based bundled skills: `verify`, `remember`, `stuck`
+- [x] Context-heavy bundled skill: `skillify`
+  - [ ] Worktree/coordinator-heavy bundled skill: `batch`
+
+- [ ] MCP-generated skill parity
+  TS reference: `src/skills/mcpSkillBuilders.ts`
+  Rust landing zone: MCP + skill integration layer
+  Done when: MCP-provided prompts/skills can participate in the Rust skill system the
+  way they do in TS.
+
+- [x] Invoked-skill preservation registry parity
+  TS reference: `src/bootstrap/state.ts`, `src/tools/SkillTool/SkillTool.ts`
+  Rust landing zone: `rust/crates/runtime/src/compact.rs`, runtime session state
+  Done when: compaction preserves invoked skills from explicit state, not only by
+  scanning historical tool results.
+
+- [ ] Skill metadata surfaces parity
+  TS reference: `src/tools/SkillTool/prompt.ts`, `src/skills/loadSkillsDir.ts`
+  Rust landing zone: `rust/crates/commands/src/lib.rs`, `rust/crates/tools/src/lib.rs`
+  Done when: listing/discovery surfaces expose the same important metadata the model and
+  user rely on in TS.
+
+## First implementation slice
+
+Start here unless a more urgent product need appears:
+
+- [x] Build a shared Rust skill loader that parses TS-compatible frontmatter fields and
+  returns structured metadata for both `/skills` inventory and the `Skill` tool.
+
+Why this first:
+
+- It unlocks most of the remaining skill backlog.
+- It is lower-risk than coordinator/worktree migration.
+- It creates a clean seam for later `Skill` execution parity and bundled skills.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -113,9 +113,11 @@ name = "commands"
 version = "0.1.0"
 dependencies = [
  "api",
+ "glob",
  "plugins",
  "runtime",
  "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 
@@ -247,7 +249,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1141,7 +1143,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1314,6 +1316,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1691,6 +1706,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/rust/crates/commands/Cargo.toml
+++ b/rust/crates/commands/Cargo.toml
@@ -10,7 +10,9 @@ workspace = true
 
 [dependencies]
 api = { path = "../api" }
+glob = "0.3"
 plugins = { path = "../plugins" }
 runtime = { path = "../runtime" }
 serde_json.workspace = true
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/rust/crates/commands/src/bundled_skills.rs
+++ b/rust/crates/commands/src/bundled_skills.rs
@@ -1,0 +1,556 @@
+use std::collections::BTreeMap;
+
+use runtime::{
+    current_tool_session_compaction_summary, current_tool_session_messages, ContentBlock,
+    ConversationMessage, MessageRole, SystemMessageSubtype,
+};
+
+use crate::{parse_skill_document, SkillDocument};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundledSkillId {
+    Verify,
+    Remember,
+    Stuck,
+    Skillify,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundledSkillFile {
+    pub relative_path: &'static str,
+    pub content: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BundledSkill {
+    pub id: BundledSkillId,
+    pub document: SkillDocument,
+}
+
+impl BundledSkillId {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Verify => "verify",
+            Self::Remember => "remember",
+            Self::Stuck => "stuck",
+            Self::Skillify => "skillify",
+        }
+    }
+
+    fn markdown(self) -> &'static str {
+        match self {
+            Self::Verify => VERIFY_SKILL_MD,
+            Self::Remember => REMEMBER_SKILL_MD,
+            Self::Stuck => STUCK_SKILL_MD,
+            Self::Skillify => SKILLIFY_SKILL_MD,
+        }
+    }
+
+    fn render_prompt(self, document: &SkillDocument, args: Option<&str>) -> String {
+        match self {
+            Self::Verify => {
+                let mut parts = vec![document.markdown_content.trim().to_string()];
+                if let Some(args) = args.map(str::trim).filter(|value| !value.is_empty()) {
+                    parts.push(format!("## User Request\n\n{args}"));
+                }
+                parts.join("\n\n")
+            }
+            Self::Remember => {
+                let mut prompt = document.markdown_content.trim_start().to_string();
+                if let Some(args) = args.map(str::trim).filter(|value| !value.is_empty()) {
+                    prompt.push_str("\n\n## Additional Context From User\n\n");
+                    prompt.push_str(args);
+                }
+                prompt
+            }
+            Self::Stuck => {
+                let mut prompt = document.markdown_content.trim_start().to_string();
+                if let Some(args) = args.map(str::trim).filter(|value| !value.is_empty()) {
+                    prompt.push_str("\n\n## User-Provided Context\n\n");
+                    prompt.push_str(args);
+                }
+                prompt
+            }
+            Self::Skillify => render_skillify_prompt(document, args),
+        }
+    }
+
+    fn reference_files(self) -> &'static [BundledSkillFile] {
+        match self {
+            Self::Verify => &[
+                BundledSkillFile {
+                    relative_path: "examples/cli.md",
+                    content: VERIFY_EXAMPLE_CLI_MD,
+                },
+                BundledSkillFile {
+                    relative_path: "examples/server.md",
+                    content: VERIFY_EXAMPLE_SERVER_MD,
+                },
+            ],
+            Self::Remember | Self::Stuck | Self::Skillify => &[],
+        }
+    }
+
+    fn is_enabled(self) -> bool {
+        match self {
+            Self::Verify | Self::Remember | Self::Stuck | Self::Skillify => true,
+        }
+    }
+}
+
+#[must_use]
+pub fn bundled_skill_inventory() -> Vec<BundledSkill> {
+    [
+        BundledSkillId::Verify,
+        BundledSkillId::Remember,
+        BundledSkillId::Stuck,
+        BundledSkillId::Skillify,
+    ]
+    .into_iter()
+    .filter(|skill| skill.is_enabled())
+    .map(|id| BundledSkill {
+        id,
+        document: parse_skill_document(id.markdown(), id.name().to_string(), "Skill"),
+    })
+    .collect()
+}
+
+#[must_use]
+pub fn resolve_bundled_skill(requested: &str) -> Option<BundledSkill> {
+    let requested = requested.trim();
+    if requested.is_empty() {
+        return None;
+    }
+
+    bundled_skill_inventory().into_iter().find(|skill| {
+        skill.document.resolved_name.eq_ignore_ascii_case(requested)
+            || skill
+                .document
+                .user_facing_name()
+                .eq_ignore_ascii_case(requested)
+    })
+}
+
+#[must_use]
+pub fn render_bundled_skill_prompt(skill: &BundledSkill, args: Option<&str>) -> String {
+    skill.id.render_prompt(&skill.document, args)
+}
+
+#[must_use]
+pub fn bundled_skill_reference_files(skill: &BundledSkill) -> BTreeMap<String, String> {
+    skill
+        .id
+        .reference_files()
+        .iter()
+        .map(|file| (file.relative_path.to_string(), file.content.to_string()))
+        .collect()
+}
+
+fn render_skillify_prompt(document: &SkillDocument, args: Option<&str>) -> String {
+    let session_memory = current_tool_session_compaction_summary()
+        .unwrap_or_else(|| "No session memory available.".to_string());
+    let user_messages = render_skillify_user_messages(
+        current_tool_session_messages()
+            .as_deref()
+            .map(extract_skillify_user_messages),
+    );
+    let user_description_block = args
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("The user described this process as: \"{value}\"\n\n"))
+        .unwrap_or_default();
+
+    document
+        .markdown_content
+        .trim_start()
+        .replace("{{sessionMemory}}", &session_memory)
+        .replace("{{userMessages}}", &user_messages)
+        .replace("{{userDescriptionBlock}}", &user_description_block)
+}
+
+fn render_skillify_user_messages(user_messages: Option<Vec<String>>) -> String {
+    let user_messages = user_messages.unwrap_or_default();
+    if user_messages.is_empty() {
+        "No recent user messages available.".to_string()
+    } else {
+        user_messages.join("\n\n---\n\n")
+    }
+}
+
+fn extract_skillify_user_messages(messages: &[ConversationMessage]) -> Vec<String> {
+    messages_after_compact_boundary(messages)
+        .iter()
+        .filter_map(|message| {
+            if message.role != MessageRole::User
+                || message.is_compact_summary
+                || message.is_visible_in_transcript_only
+                || message.attachment_metadata.is_some()
+                || message.hook_result_metadata.is_some()
+            {
+                return None;
+            }
+
+            let text = message
+                .blocks
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            (!text.trim().is_empty()).then_some(text)
+        })
+        .collect()
+}
+
+fn messages_after_compact_boundary(messages: &[ConversationMessage]) -> &[ConversationMessage] {
+    let boundary_index = messages
+        .iter()
+        .rposition(|message| message.subtype == Some(SystemMessageSubtype::CompactBoundary));
+    boundary_index.map_or(messages, |index| &messages[index..])
+}
+
+const VERIFY_SKILL_MD: &str = r"---
+name: verify
+description: Verify a code change does what it should by running the app.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+when_to_use: Use when the user wants the change exercised end-to-end instead of only reasoning about it.
+---
+# Verify
+
+You are validating that the current code change actually works in the running app or CLI.
+
+## Goal
+Produce a concrete verification report based on commands you ran and behavior you observed.
+
+## Expectations
+- Prefer exercising the real user-facing flow over only reading code.
+- Reuse existing scripts, dev commands, or test harnesses when the repo already defines them.
+- If you need examples, inspect files in this skill's base directory, especially the `examples/` notes.
+- If the app needs setup, do the minimum setup required to verify the specific change.
+
+## Output
+Provide:
+1. What you ran
+2. What you observed
+3. Whether the change is verified, partially verified, or blocked
+4. Any follow-up gaps the user should know about
+";
+
+const VERIFY_EXAMPLE_CLI_MD: &str = r#"# CLI Verification Example
+
+1. Build or start the CLI in the cheapest realistic way.
+2. Run the exact command flow affected by the change.
+3. Capture the visible output and any files written.
+4. Report the concrete pass/fail evidence, not just "looks good".
+"#;
+
+const VERIFY_EXAMPLE_SERVER_MD: &str = r"# Server Verification Example
+
+1. Start the app or server with the repo's documented command.
+2. Hit the changed endpoint or UI flow with a real request.
+3. Check both the response and any user-visible side effects.
+4. Summarize the verification steps and observed result.
+";
+
+const REMEMBER_SKILL_MD: &str = r"---
+name: remember
+description: Review memory-related context and propose promotions or cleanup across memory layers.
+when_to_use: Use when the user wants to review, organize, or promote memory entries, or clean up conflicts between CLAUDE.md, CLAUDE.local.md, and auto-memory style notes.
+---
+# Memory Review
+
+## Goal
+Review the user's memory landscape and produce a clear report of proposed changes, grouped by action type. Do not apply changes unless the user explicitly asks.
+
+## Steps
+
+### 1. Gather all memory layers
+Read `CLAUDE.md` and `CLAUDE.local.md` from the project root if they exist. Review any already-loaded memory context in the conversation and note which layers are present.
+
+### 2. Classify what belongs where
+For each substantive memory item, propose whether it belongs in:
+- `CLAUDE.md` for repo-wide instructions
+- `CLAUDE.local.md` for user-specific preferences
+- shared/team memory if the repo clearly uses it
+- the current transient memory layer if it is temporary or uncertain
+
+### 3. Look for cleanup opportunities
+Call out duplicates, outdated instructions, and conflicts between layers. Say which source seems newer or more authoritative when that is clear.
+
+### 4. Present a proposal, not an edit
+Group the report into:
+1. Promotions
+2. Cleanup
+3. Ambiguous items that need the user's choice
+4. No-action items
+
+## Rules
+- Present proposals before making changes
+- Ask rather than guess when the destination is ambiguous
+- Keep the report actionable and easy to approve item by item
+";
+
+const STUCK_SKILL_MD: &str = r"---
+name: stuck
+description: Investigate a frozen, stuck, or unusually slow agent session on this machine and produce a diagnostic report.
+allowed-tools:
+  - Bash
+  - Read
+when_to_use: Use when the user says another agent session appears frozen, hung, or extremely slow.
+---
+# Diagnose Stuck Session
+
+The user believes another agent session on this machine is frozen, stuck, or unusually slow. Investigate and produce a concise diagnostic report.
+
+## What to look for
+- Sustained high CPU that suggests a loop
+- Stopped, zombie, or uninterruptible processes
+- A hung child process such as `git`, `node`, or a shell command
+- Very large memory usage compared with nearby sessions
+
+## Investigation steps
+1. List relevant agent processes on this machine.
+2. For suspicious processes, inspect child processes and collect more detail.
+3. If logs or session files are available, read the most relevant tail rather than dumping everything.
+4. Do not kill processes unless the user explicitly asks.
+
+## Report
+Explain:
+1. Which process or session looks unhealthy
+2. The evidence you found
+3. Your best diagnosis
+4. Safe next actions for the user
+";
+
+const SKILLIFY_SKILL_MD: &str = r#"---
+name: skillify
+description: Capture this session's repeatable process into a reusable skill.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Bash(mkdir:*)
+argument-hint: "[description of the process you want to capture]"
+when_to_use: Use when the user wants to turn the process from this session into a reusable skill, especially near the end of the workflow.
+---
+# Skillify
+
+{{userDescriptionBlock}}You are capturing this session's repeatable process as a reusable skill.
+
+## Your Session Context
+
+Here is the session memory summary:
+<session_memory>
+{{sessionMemory}}
+</session_memory>
+
+Here are the user's messages during this session. Pay attention to how they steered the process so you can preserve their preferences in the skill:
+<user_messages>
+{{userMessages}}
+</user_messages>
+
+## Your Task
+
+### Step 1: Analyze the session
+
+Before asking any questions, analyze the session to identify:
+- What repeatable process was performed
+- What the inputs or parameters were
+- The distinct steps, in order
+- The success artifacts or criteria for each step
+- Where the user corrected or steered you
+- What tools and permissions were needed
+- What agents were used
+- What the goals and success artifacts were
+
+### Step 2: Interview the user
+
+Use `AskUserQuestion` for all questions. Never ask these questions in plain assistant text.
+
+For each round:
+- Iterate until the user is happy.
+- Offer substantive choices only. The user already has a freeform option if they want to type edits.
+- Do not over-interview simple workflows.
+
+Round 1: High-level confirmation
+- Suggest a name and description for the skill based on your analysis.
+- Suggest the high-level goal and success criteria.
+
+Round 2: Workflow structure
+- Present the high-level steps you identified as a numbered list.
+- If the skill needs arguments, suggest them based on what you observed.
+- If it is not obvious, ask whether this skill should run inline or forked.
+- Ask where the skill should be saved. Suggest a default based on context. Options:
+  - This repo (`.claw/skills/<name>/SKILL.md`) for workflows specific to this project
+  - Personal (`~/.claw/skills/<name>/SKILL.md`) for workflows that should follow the user across repos
+
+Round 3: Break down each step
+For each major step, ask whatever is needed to clarify:
+- What this step produces that later steps need
+- What proves the step succeeded
+- Whether the user should confirm before proceeding
+- Whether any steps can run in parallel
+- Whether any steps should use a task agent or teammate
+- What hard constraints or hard preferences must be preserved
+
+Round 4: Final questions
+- Confirm when the skill should be invoked and suggest trigger phrases
+- Ask about any remaining gotchas only if they still matter
+
+### Step 3: Write the SKILL.md
+
+Create the skill directory and file at the location the user chose in Round 2.
+
+Use this format:
+
+```markdown
+---
+name: {{skill-name}}
+description: {{one-line description}}
+allowed-tools:
+  {{list of tool permission patterns observed during session}}
+when_to_use: {{detailed description of when the skill should be invoked, including trigger phrases and example user messages}}
+argument-hint: "{{hint showing argument placeholders}}"
+arguments:
+  {{list of argument names}}
+context: {{inline or fork -- omit for inline}}
+---
+
+# {{Skill Title}}
+Description of skill
+
+## Inputs
+- `$arg_name`: Description of this input
+
+## Goal
+Clearly stated goal for this workflow. Prefer explicit artifacts or criteria for completion.
+
+## Steps
+
+### 1. Step Name
+What to do in this step. Be specific and actionable.
+
+**Success criteria**: Always include this. It should be clear when the step is done and the skill can move on.
+```
+
+Per-step annotations:
+- `Success criteria` is required on every step.
+- `Execution`: `Direct` by default, or `Task agent`, `Teammate`, or `[human]` when needed.
+- `Artifacts`: Only include this when later steps depend on outputs from the current step.
+- `Human checkpoint`: Use this for irreversible actions, judgment calls, or output review.
+- `Rules`: Capture hard requirements, especially where the user corrected you during the session.
+
+Step structure tips:
+- Steps that can run concurrently can use sub-numbers such as `3a` and `3b`.
+- Steps requiring the user to act should use `[human]` in the title.
+- Keep simple skills simple.
+
+Frontmatter rules:
+- `allowed-tools`: Capture the minimum permissions needed. Prefer precise patterns such as `Bash(gh:*)`.
+- `context`: Only set `context: fork` for self-contained skills that do not need mid-process user input.
+- `when_to_use` is critical. Start with `Use when...` and include trigger phrases.
+- `arguments` and `argument-hint`: Only include these when the skill takes parameters.
+
+### Step 4: Confirm and save
+
+Before writing the file:
+- Output the complete `SKILL.md` content as a `yaml` fenced code block so the user can review it.
+- Ask for confirmation using `AskUserQuestion` with a concise question such as `Does this SKILL.md look good to save?`
+
+After writing, tell the user:
+- Where the skill was saved
+- How to invoke it: `/{{skill-name}} [arguments]`
+- That they can edit the `SKILL.md` directly to refine it
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bundled_skill_inventory, bundled_skill_reference_files, render_bundled_skill_prompt,
+        resolve_bundled_skill,
+    };
+    use runtime::{
+        with_tool_session_snapshot, AttachmentKind, CompactBoundaryMetadata, CompactTrigger,
+        ConversationMessage,
+    };
+
+    #[test]
+    fn resolve_bundled_skill_matches_name_case_insensitively() {
+        let skill = resolve_bundled_skill("VeRiFy").expect("verify skill should resolve");
+        assert_eq!(skill.document.resolved_name, "verify");
+        assert_eq!(
+            render_bundled_skill_prompt(&skill, Some("check login flow")),
+            concat!(
+                "# Verify\n\n",
+                "You are validating that the current code change actually works in the running app or CLI.\n\n",
+                "## Goal\n",
+                "Produce a concrete verification report based on commands you ran and behavior you observed.\n\n",
+                "## Expectations\n",
+                "- Prefer exercising the real user-facing flow over only reading code.\n",
+                "- Reuse existing scripts, dev commands, or test harnesses when the repo already defines them.\n",
+                "- If you need examples, inspect files in this skill's base directory, especially the `examples/` notes.\n",
+                "- If the app needs setup, do the minimum setup required to verify the specific change.\n\n",
+                "## Output\n",
+                "Provide:\n",
+                "1. What you ran\n",
+                "2. What you observed\n",
+                "3. Whether the change is verified, partially verified, or blocked\n",
+                "4. Any follow-up gaps the user should know about\n\n",
+                "## User Request\n\n",
+                "check login flow"
+            )
+        );
+    }
+
+    #[test]
+    fn bundled_skill_inventory_exposes_reference_files() {
+        let verify = bundled_skill_inventory()
+            .into_iter()
+            .find(|skill| skill.document.resolved_name == "verify")
+            .expect("verify should exist");
+        let files = bundled_skill_reference_files(&verify);
+        assert_eq!(files.len(), 2);
+        assert!(files.contains_key("examples/cli.md"));
+        assert!(files.contains_key("examples/server.md"));
+    }
+
+    #[test]
+    fn skillify_prompt_uses_session_snapshot_and_recent_user_messages() {
+        let skill = resolve_bundled_skill("skillify").expect("skillify skill should resolve");
+        let messages = vec![
+            ConversationMessage::user_text("before compact"),
+            ConversationMessage::compact_boundary(CompactBoundaryMetadata {
+                trigger: CompactTrigger::Manual,
+                pre_tokens: 128,
+                user_context: None,
+                messages_summarized: Some(2),
+                pre_compact_discovered_tools: Vec::new(),
+                preserved_segment: None,
+            }),
+            ConversationMessage::compact_summary_user_text("summarized history", false),
+            ConversationMessage::user_text("please preserve my review workflow"),
+            ConversationMessage::attachment_user_text("todo state", AttachmentKind::TodoList),
+        ];
+
+        let prompt = with_tool_session_snapshot(&messages, Some("Older session summary"), || {
+            render_bundled_skill_prompt(&skill, Some("capture this workflow"))
+        });
+
+        assert!(prompt.contains("Older session summary"));
+        assert!(prompt.contains("please preserve my review workflow"));
+        assert!(prompt.contains("The user described this process as: \"capture this workflow\""));
+        assert!(!prompt.contains("before compact"));
+        assert!(!prompt.contains("summarized history"));
+        assert!(!prompt.contains("todo state"));
+    }
+}

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1,25 +1,79 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use api::{
     max_tokens_for_model, resolve_model_alias, InputContentBlock, InputMessage, MessageRequest,
     MessageResponse, OutputContentBlock, PromptCache, ProviderClient, ProviderKind,
     ProviderOverride, ToolResultContentBlock,
 };
+use glob::Pattern;
 use plugins::{
     PluginError, PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry, PluginSummary,
 };
 use runtime::{
-    load_system_prompt, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
-    ConversationMessage, ConversationRuntime, McpOAuthConfig, McpServerConfig, MessageRole,
-    PermissionMode, PermissionPolicy, RuntimeConfig, RuntimeFeatureConfig, RuntimeHookConfig,
-    RuntimeProviderConfig, RuntimeProviderKind, ScopedMcpServerConfig, Session, StaticToolExecutor,
+    load_system_prompt, tool_output_root, AssistantEvent, CompactionConfig, ConfigLoader,
+    ConfigSource, ConversationMessage, ConversationRuntime, McpOAuthConfig, McpServerConfig,
+    MessageRole, PermissionMode, PermissionPolicy, RuntimeConfig, RuntimeFeatureConfig,
+    RuntimeHookConfig, RuntimeProviderConfig, RuntimeProviderKind, ScopedMcpServerConfig, Session,
+    StaticToolExecutor,
 };
 use serde_json::{json, Value};
+
+mod bundled_skills;
+mod skill_docs;
+
+pub use bundled_skills::{
+    bundled_skill_reference_files, render_bundled_skill_prompt, resolve_bundled_skill,
+    BundledSkill, BundledSkillId,
+};
+pub use skill_docs::{
+    extract_skill_frontmatter_name, load_skill_document, parse_skill_document, SkillDocument,
+    SkillExecutionContext,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedSkill {
+    pub document: SkillDocument,
+    pub source: ResolvedSkillSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedSkillSource {
+    Filesystem { path: PathBuf },
+    Bundled { id: BundledSkillId },
+}
+
+#[must_use]
+pub fn render_resolved_skill_prompt(skill: &ResolvedSkill, args: Option<&str>) -> String {
+    match &skill.source {
+        ResolvedSkillSource::Filesystem { .. } => {
+            skill.document.render_markdown_with_arguments(args)
+        }
+        ResolvedSkillSource::Bundled { id } => render_bundled_skill_prompt(
+            &BundledSkill {
+                id: *id,
+                document: skill.document.clone(),
+            },
+            args,
+        ),
+    }
+}
+
+#[must_use]
+pub fn resolved_skill_reference_files(skill: &ResolvedSkill) -> BTreeMap<String, String> {
+    match &skill.source {
+        ResolvedSkillSource::Filesystem { .. } => BTreeMap::new(),
+        ResolvedSkillSource::Bundled { id } => bundled_skill_reference_files(&BundledSkill {
+            id: *id,
+            document: skill.document.clone(),
+        }),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandManifestEntry {
@@ -1994,6 +2048,7 @@ pub struct PluginsCommandResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum DefinitionSource {
+    Bundled,
     ProjectClaw,
     ProjectCodex,
     ProjectClaude,
@@ -2006,6 +2061,7 @@ enum DefinitionSource {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum DefinitionScope {
+    Bundled,
     Project,
     UserConfigHome,
     UserHome,
@@ -2014,6 +2070,7 @@ enum DefinitionScope {
 impl DefinitionScope {
     fn label(self) -> &'static str {
         match self {
+            Self::Bundled => "Bundled",
             Self::Project => "Project (.claw)",
             Self::UserConfigHome => "User ($CLAW_CONFIG_HOME)",
             Self::UserHome => "User (~/.claw)",
@@ -2024,6 +2081,7 @@ impl DefinitionScope {
 impl DefinitionSource {
     fn report_scope(self) -> DefinitionScope {
         match self {
+            Self::Bundled => DefinitionScope::Bundled,
             Self::ProjectClaw | Self::ProjectCodex | Self::ProjectClaude => {
                 DefinitionScope::Project
             }
@@ -2047,17 +2105,26 @@ struct AgentSummary {
     shadowed_by: Option<DefinitionSource>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct SkillSummary {
     name: String,
     description: Option<String>,
+    location: SkillLocation,
+    document: SkillDocument,
     source: DefinitionSource,
     shadowed_by: Option<DefinitionSource>,
     origin: SkillOrigin,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SkillLocation {
+    Filesystem(PathBuf),
+    Bundled(BundledSkillId),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SkillOrigin {
+    Bundled,
     SkillsDir,
     LegacyCommandsDir,
 }
@@ -2065,6 +2132,7 @@ enum SkillOrigin {
 impl SkillOrigin {
     fn detail_label(self) -> Option<&'static str> {
         match self {
+            Self::Bundled => Some("bundled"),
             Self::SkillsDir => None,
             Self::LegacyCommandsDir => Some("legacy /commands"),
         }
@@ -2268,7 +2336,7 @@ pub fn handle_skills_slash_command(args: Option<&str>, cwd: &Path) -> std::io::R
     match normalize_optional_args(args) {
         None | Some("list") => {
             let roots = discover_skill_roots(cwd);
-            let skills = load_skills_from_roots(&roots)?;
+            let skills = load_skills_from_roots_for_context(&roots, cwd)?;
             Ok(render_skills_report(&skills))
         }
         Some("install") => Ok(render_skills_usage(Some("install"))),
@@ -2299,7 +2367,7 @@ pub fn handle_skills_slash_command_json(args: Option<&str>, cwd: &Path) -> std::
     match normalize_optional_args(args) {
         None | Some("list") => {
             let roots = discover_skill_roots(cwd);
-            let skills = load_skills_from_roots(&roots)?;
+            let skills = load_skills_from_roots_for_context(&roots, cwd)?;
             Ok(render_skills_report_json(&skills))
         }
         Some("install") => Ok(render_skills_usage_json(Some("install"))),
@@ -2343,10 +2411,10 @@ pub fn resolve_skill_invocation(
             .next()
             .unwrap_or_default();
         if !skill_token.is_empty() {
-            if let Err(error) = resolve_skill_path(cwd, skill_token) {
+            if let Err(error) = resolve_skill(cwd, skill_token) {
                 let mut message = format!("Unknown skill: {skill_token} ({error})");
                 let roots = discover_skill_roots(cwd);
-                if let Ok(available) = load_skills_from_roots(&roots) {
+                if let Ok(available) = load_skills_from_roots_for_context(&roots, cwd) {
                     let names: Vec<String> = available
                         .iter()
                         .filter(|s| s.shadowed_by.is_none())
@@ -2364,69 +2432,67 @@ pub fn resolve_skill_invocation(
     Ok(dispatch)
 }
 
-pub fn resolve_skill_path(cwd: &Path, skill: &str) -> std::io::Result<PathBuf> {
-    let requested = skill.trim().trim_start_matches('/').trim_start_matches('$');
+fn requested_skill_name(skill: &str) -> std::io::Result<String> {
+    let requested = skill
+        .trim()
+        .trim_start_matches('/')
+        .trim_start_matches('$')
+        .to_string();
     if requested.is_empty() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "skill must not be empty",
         ));
     }
+    Ok(requested)
+}
+
+pub fn resolve_skill(cwd: &Path, skill: &str) -> std::io::Result<ResolvedSkill> {
+    let requested = requested_skill_name(skill)?;
+    let roots = discover_skill_roots(cwd);
+
+    for skill in load_skills_from_roots_for_context(&roots, cwd)? {
+        if skill.name.eq_ignore_ascii_case(requested.as_str())
+            || skill
+                .document
+                .resolved_name
+                .eq_ignore_ascii_case(requested.as_str())
+        {
+            let source = match skill.location {
+                SkillLocation::Filesystem(path) => ResolvedSkillSource::Filesystem { path },
+                SkillLocation::Bundled(id) => ResolvedSkillSource::Bundled { id },
+            };
+            return Ok(ResolvedSkill {
+                document: skill.document,
+                source,
+            });
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("unknown skill: {requested}"),
+    ))
+}
+
+pub fn resolve_skill_path(cwd: &Path, skill: &str) -> std::io::Result<PathBuf> {
+    let requested = requested_skill_name(skill)?;
 
     let roots = discover_skill_roots(cwd);
-    for root in &roots {
-        let mut entries = Vec::new();
-        for entry in fs::read_dir(&root.path)? {
-            let entry = entry?;
-            match root.origin {
-                SkillOrigin::SkillsDir => {
-                    if !entry.path().is_dir() {
-                        continue;
-                    }
-                    let skill_path = entry.path().join("SKILL.md");
-                    if !skill_path.is_file() {
-                        continue;
-                    }
-                    let contents = fs::read_to_string(&skill_path)?;
-                    let (name, _) = parse_skill_frontmatter(&contents);
-                    entries.push((
-                        name.unwrap_or_else(|| entry.file_name().to_string_lossy().to_string()),
-                        skill_path,
-                    ));
-                }
-                SkillOrigin::LegacyCommandsDir => {
-                    let path = entry.path();
-                    let markdown_path = if path.is_dir() {
-                        let skill_path = path.join("SKILL.md");
-                        if !skill_path.is_file() {
-                            continue;
-                        }
-                        skill_path
-                    } else if path
-                        .extension()
-                        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
-                    {
-                        path
-                    } else {
-                        continue;
-                    };
-
-                    let contents = fs::read_to_string(&markdown_path)?;
-                    let fallback_name = markdown_path.file_stem().map_or_else(
-                        || entry.file_name().to_string_lossy().to_string(),
-                        |stem| stem.to_string_lossy().to_string(),
-                    );
-                    let (name, _) = parse_skill_frontmatter(&contents);
-                    entries.push((name.unwrap_or(fallback_name), markdown_path));
-                }
-            }
-        }
-        entries.sort_by(|left, right| left.0.cmp(&right.0));
-        if let Some((_, path)) = entries
-            .into_iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case(requested))
+    for skill in load_skills_from_roots_for_context(&roots, cwd)? {
+        if skill.name.eq_ignore_ascii_case(&requested)
+            || skill
+                .document
+                .resolved_name
+                .eq_ignore_ascii_case(&requested)
         {
-            return Ok(path);
+            return match skill.location {
+                SkillLocation::Filesystem(path) => Ok(path),
+                SkillLocation::Bundled(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("skill `{requested}` is bundled and has no filesystem path"),
+                )),
+            };
         }
     }
 
@@ -2755,6 +2821,110 @@ fn discover_skill_roots(cwd: &Path) -> Vec<SkillRoot> {
     roots
 }
 
+type ConditionalSkillActivationMap = BTreeMap<PathBuf, BTreeSet<String>>;
+
+fn conditional_skill_activations() -> &'static Mutex<ConditionalSkillActivationMap> {
+    static ACTIVATIONS: OnceLock<Mutex<ConditionalSkillActivationMap>> = OnceLock::new();
+    ACTIVATIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn conditional_skill_context_root(cwd: &Path) -> PathBuf {
+    tool_output_root(cwd)
+}
+
+fn is_conditional_skill_activated(cwd: &Path, skill_name: &str) -> bool {
+    let activations = conditional_skill_activations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    activations
+        .get(&conditional_skill_context_root(cwd))
+        .is_some_and(|names| names.contains(skill_name))
+}
+
+fn record_conditional_skill_activation(cwd: &Path, skill_name: &str) {
+    let mut activations = conditional_skill_activations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    activations
+        .entry(conditional_skill_context_root(cwd))
+        .or_default()
+        .insert(skill_name.to_string());
+}
+
+pub fn activate_conditional_skills_for_paths(
+    file_paths: &[PathBuf],
+    cwd: &Path,
+) -> std::io::Result<Vec<String>> {
+    if file_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let roots = discover_skill_roots(cwd);
+    let skills = load_skills_from_roots(&roots)?;
+    let mut activated = Vec::new();
+
+    for skill in skills {
+        let Some(patterns) = skill.document.paths.as_deref() else {
+            continue;
+        };
+        if is_conditional_skill_activated(cwd, &skill.document.resolved_name) {
+            continue;
+        }
+
+        let matches_path = file_paths.iter().any(|path| {
+            normalize_relative_match_path(path, cwd)
+                .is_some_and(|relative_path| skill_paths_match(patterns, &relative_path))
+        });
+        if !matches_path {
+            continue;
+        }
+
+        record_conditional_skill_activation(cwd, &skill.document.resolved_name);
+        activated.push(skill.document.resolved_name);
+    }
+
+    Ok(activated)
+}
+
+fn normalize_relative_match_path(path: &Path, cwd: &Path) -> Option<String> {
+    let relative = path.strip_prefix(cwd).ok()?;
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    let relative = relative.trim_start_matches("./").trim_matches('/');
+    if relative.is_empty() || relative.starts_with("..") {
+        None
+    } else {
+        Some(relative.to_string())
+    }
+}
+
+fn skill_paths_match(patterns: &[String], relative_path: &str) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| skill_path_pattern_matches(pattern, relative_path))
+}
+
+fn skill_path_pattern_matches(pattern: &str, relative_path: &str) -> bool {
+    let normalized_pattern = pattern.replace('\\', "/").trim_matches('/').to_string();
+    if normalized_pattern.is_empty() {
+        return false;
+    }
+
+    if !pattern_has_glob_metacharacters(&normalized_pattern) {
+        return relative_path == normalized_pattern
+            || relative_path.starts_with(&format!("{normalized_pattern}/"));
+    }
+
+    Pattern::new(&normalized_pattern)
+        .ok()
+        .is_some_and(|compiled| compiled.matches(relative_path))
+}
+
+fn pattern_has_glob_metacharacters(pattern: &str) -> bool {
+    pattern
+        .chars()
+        .any(|ch| matches!(ch, '*' | '?' | '[' | ']' | '{' | '}' | '!'))
+}
+
 fn install_skill(source: &str, cwd: &Path) -> std::io::Result<InstalledSkill> {
     let registry_root = default_skill_install_root()?;
     install_skill_into(source, cwd, &registry_root)
@@ -2767,8 +2937,7 @@ fn install_skill_into(
 ) -> std::io::Result<InstalledSkill> {
     let source = resolve_skill_install_source(source, cwd)?;
     let prompt_path = source.prompt_path();
-    let contents = fs::read_to_string(prompt_path)?;
-    let display_name = parse_skill_frontmatter(&contents).0;
+    let display_name = load_skill_document(prompt_path, "Skill")?.display_name;
     let invocation_name = derive_skill_install_name(&source, display_name.as_deref())?;
     let installed_path = registry_root.join(&invocation_name);
 
@@ -3023,80 +3192,127 @@ fn load_agents_from_roots(
 }
 
 fn load_skills_from_roots(roots: &[SkillRoot]) -> std::io::Result<Vec<SkillSummary>> {
+    load_skills_from_roots_impl(roots, None)
+}
+
+fn load_skills_from_roots_for_context(
+    roots: &[SkillRoot],
+    cwd: &Path,
+) -> std::io::Result<Vec<SkillSummary>> {
+    load_skills_from_roots_impl(roots, Some(cwd))
+}
+
+fn load_skills_from_roots_impl(
+    roots: &[SkillRoot],
+    activation_cwd: Option<&Path>,
+) -> std::io::Result<Vec<SkillSummary>> {
     let mut skills = Vec::new();
     let mut active_sources = BTreeMap::<String, DefinitionSource>::new();
 
+    merge_skill_summaries(&mut skills, &mut active_sources, bundled_skill_summaries());
+
     for root in roots {
-        let mut root_skills = Vec::new();
-        for entry in fs::read_dir(&root.path)? {
-            let entry = entry?;
-            match root.origin {
-                SkillOrigin::SkillsDir => {
-                    if !entry.path().is_dir() {
-                        continue;
-                    }
-                    let skill_path = entry.path().join("SKILL.md");
-                    if !skill_path.is_file() {
-                        continue;
-                    }
-                    let contents = fs::read_to_string(skill_path)?;
-                    let (name, description) = parse_skill_frontmatter(&contents);
-                    root_skills.push(SkillSummary {
-                        name: name
-                            .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string()),
-                        description,
-                        source: root.source,
-                        shadowed_by: None,
-                        origin: root.origin,
-                    });
-                }
-                SkillOrigin::LegacyCommandsDir => {
-                    let path = entry.path();
-                    let markdown_path = if path.is_dir() {
-                        let skill_path = path.join("SKILL.md");
-                        if !skill_path.is_file() {
-                            continue;
-                        }
-                        skill_path
-                    } else if path
-                        .extension()
-                        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
-                    {
-                        path
-                    } else {
-                        continue;
-                    };
-
-                    let contents = fs::read_to_string(&markdown_path)?;
-                    let fallback_name = markdown_path.file_stem().map_or_else(
-                        || entry.file_name().to_string_lossy().to_string(),
-                        |stem| stem.to_string_lossy().to_string(),
-                    );
-                    let (name, description) = parse_skill_frontmatter(&contents);
-                    root_skills.push(SkillSummary {
-                        name: name.unwrap_or(fallback_name),
-                        description,
-                        source: root.source,
-                        shadowed_by: None,
-                        origin: root.origin,
-                    });
-                }
-            }
-        }
-        root_skills.sort_by(|left, right| left.name.cmp(&right.name));
-
-        for mut skill in root_skills {
-            let key = skill.name.to_ascii_lowercase();
-            if let Some(existing) = active_sources.get(&key) {
-                skill.shadowed_by = Some(*existing);
-            } else {
-                active_sources.insert(key, skill.source);
-            }
-            skills.push(skill);
-        }
+        merge_skill_summaries(
+            &mut skills,
+            &mut active_sources,
+            load_skills_from_root(root, activation_cwd)?,
+        );
     }
 
     Ok(skills)
+}
+
+fn bundled_skill_summaries() -> Vec<SkillSummary> {
+    let mut bundled_skills = bundled_skills::bundled_skill_inventory()
+        .into_iter()
+        .map(|skill| SkillSummary {
+            name: skill.document.user_facing_name().to_string(),
+            description: Some(skill.document.description.clone()),
+            location: SkillLocation::Bundled(skill.id),
+            document: skill.document,
+            source: DefinitionSource::Bundled,
+            shadowed_by: None,
+            origin: SkillOrigin::Bundled,
+        })
+        .collect::<Vec<_>>();
+    bundled_skills.sort_by(|left, right| left.name.cmp(&right.name));
+    bundled_skills
+}
+
+fn load_skills_from_root(
+    root: &SkillRoot,
+    activation_cwd: Option<&Path>,
+) -> std::io::Result<Vec<SkillSummary>> {
+    let mut root_skills = Vec::new();
+    for entry in fs::read_dir(&root.path)? {
+        let entry = entry?;
+        let Some((skill_path, description_fallback_label)) =
+            resolve_skill_entry_path(root.origin, entry.path())
+        else {
+            continue;
+        };
+        let document = load_skill_document(&skill_path, description_fallback_label)?;
+        if should_skip_conditional_skill(&document, activation_cwd) {
+            continue;
+        }
+        root_skills.push(SkillSummary {
+            name: document.user_facing_name().to_string(),
+            description: Some(document.description.clone()),
+            location: SkillLocation::Filesystem(skill_path),
+            document,
+            source: root.source,
+            shadowed_by: None,
+            origin: root.origin,
+        });
+    }
+    root_skills.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(root_skills)
+}
+
+fn resolve_skill_entry_path(origin: SkillOrigin, path: PathBuf) -> Option<(PathBuf, &'static str)> {
+    match origin {
+        SkillOrigin::Bundled => unreachable!("bundled skills are synthesized in-memory"),
+        SkillOrigin::SkillsDir => {
+            if !path.is_dir() {
+                return None;
+            }
+            let skill_path = path.join("SKILL.md");
+            skill_path.is_file().then_some((skill_path, "Skill"))
+        }
+        SkillOrigin::LegacyCommandsDir => {
+            if path.is_dir() {
+                let skill_path = path.join("SKILL.md");
+                return skill_path
+                    .is_file()
+                    .then_some((skill_path, "Custom command"));
+            }
+            path.extension()
+                .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
+                .then_some((path, "Custom command"))
+        }
+    }
+}
+
+fn should_skip_conditional_skill(document: &SkillDocument, activation_cwd: Option<&Path>) -> bool {
+    activation_cwd.is_some_and(|cwd| {
+        document.paths.is_some() && !is_conditional_skill_activated(cwd, &document.resolved_name)
+    })
+}
+
+fn merge_skill_summaries(
+    destination: &mut Vec<SkillSummary>,
+    active_sources: &mut BTreeMap<String, DefinitionSource>,
+    skill_summaries: Vec<SkillSummary>,
+) {
+    for mut skill in skill_summaries {
+        let key = skill.name.to_ascii_lowercase();
+        if let Some(existing) = active_sources.get(&key) {
+            skill.shadowed_by = Some(*existing);
+        } else {
+            active_sources.insert(key, skill.source);
+        }
+        destination.push(skill);
+    }
 }
 
 fn parse_toml_string(contents: &str, key: &str) -> Option<String> {
@@ -3123,51 +3339,6 @@ fn parse_toml_string(contents: &str, key: &str) -> Option<String> {
     None
 }
 
-fn parse_skill_frontmatter(contents: &str) -> (Option<String>, Option<String>) {
-    let mut lines = contents.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return (None, None);
-    }
-
-    let mut name = None;
-    let mut description = None;
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break;
-        }
-        if let Some(value) = trimmed.strip_prefix("name:") {
-            let value = unquote_frontmatter_value(value.trim());
-            if !value.is_empty() {
-                name = Some(value);
-            }
-            continue;
-        }
-        if let Some(value) = trimmed.strip_prefix("description:") {
-            let value = unquote_frontmatter_value(value.trim());
-            if !value.is_empty() {
-                description = Some(value);
-            }
-        }
-    }
-
-    (name, description)
-}
-
-fn unquote_frontmatter_value(value: &str) -> String {
-    value
-        .strip_prefix('"')
-        .and_then(|trimmed| trimmed.strip_suffix('"'))
-        .or_else(|| {
-            value
-                .strip_prefix('\'')
-                .and_then(|trimmed| trimmed.strip_suffix('\''))
-        })
-        .unwrap_or(value)
-        .trim()
-        .to_string()
-}
-
 fn render_agents_report(agents: &[AgentSummary]) -> String {
     if agents.is_empty() {
         return "No agents found.".to_string();
@@ -3184,6 +3355,7 @@ fn render_agents_report(agents: &[AgentSummary]) -> String {
     ];
 
     for scope in [
+        DefinitionScope::Bundled,
         DefinitionScope::Project,
         DefinitionScope::UserConfigHome,
         DefinitionScope::UserHome,
@@ -3259,6 +3431,7 @@ fn render_skills_report(skills: &[SkillSummary]) -> String {
     ];
 
     for scope in [
+        DefinitionScope::Bundled,
         DefinitionScope::Project,
         DefinitionScope::UserConfigHome,
         DefinitionScope::UserHome,
@@ -3536,7 +3709,8 @@ fn render_skills_usage(unexpected: Option<&str>) -> String {
         "  Direct CLI       claw skills [list|install <path>|help|<skill> [args]]".to_string(),
         "  Invoke           /skills help overview -> $help overview".to_string(),
         "  Install root     $CLAW_CONFIG_HOME/skills or ~/.claw/skills".to_string(),
-        "  Sources          .claw/skills, ~/.claw/skills, legacy /commands".to_string(),
+        "  Sources          bundled built-ins, .claw/skills, ~/.claw/skills, legacy /commands"
+            .to_string(),
     ];
     if let Some(args) = unexpected {
         lines.push(format!("  Unexpected       {args}"));
@@ -3554,6 +3728,7 @@ fn render_skills_usage_json(unexpected: Option<&str>) -> Value {
             "invoke": "/skills help overview -> $help overview",
             "install_root": "$CLAW_CONFIG_HOME/skills or ~/.claw/skills",
             "sources": [
+                "bundled built-ins",
                 ".claw/skills",
                 "~/.claw/skills",
                 "legacy /commands",
@@ -3668,6 +3843,7 @@ fn format_mcp_oauth(oauth: Option<&McpOAuthConfig>) -> String {
 
 fn definition_source_id(source: DefinitionSource) -> &'static str {
     match source {
+        DefinitionSource::Bundled => "bundled",
         DefinitionSource::ProjectClaw
         | DefinitionSource::ProjectCodex
         | DefinitionSource::ProjectClaude => "project_claw",
@@ -3701,6 +3877,7 @@ fn agent_summary_json(agent: &AgentSummary) -> Value {
 
 fn skill_origin_id(origin: SkillOrigin) -> &'static str {
     match origin {
+        SkillOrigin::Bundled => "bundled",
         SkillOrigin::SkillsDir => "skills_dir",
         SkillOrigin::LegacyCommandsDir => "legacy_commands_dir",
     }
@@ -3717,10 +3894,34 @@ fn skill_summary_json(skill: &SkillSummary) -> Value {
     json!({
         "name": &skill.name,
         "description": &skill.description,
+        "metadata": skill_document_json(&skill.document),
         "source": definition_source_json(skill.source),
         "origin": skill_origin_json(skill.origin),
         "active": skill.shadowed_by.is_none(),
         "shadowed_by": skill.shadowed_by.map(definition_source_json),
+    })
+}
+
+fn skill_document_json(document: &SkillDocument) -> Value {
+    json!({
+        "resolved_name": &document.resolved_name,
+        "display_name": &document.display_name,
+        "description": &document.description,
+        "has_user_specified_description": document.has_user_specified_description,
+        "allowed_tools": &document.allowed_tools,
+        "argument_hint": &document.argument_hint,
+        "argument_names": &document.argument_names,
+        "when_to_use": &document.when_to_use,
+        "version": &document.version,
+        "model": &document.model,
+        "disable_model_invocation": document.disable_model_invocation,
+        "user_invocable": document.user_invocable,
+        "hooks": &document.hooks,
+        "execution_context": document.execution_context.map(SkillExecutionContext::as_str),
+        "agent": &document.agent,
+        "effort": &document.effort,
+        "paths": &document.paths,
+        "shell": &document.shell,
     })
 }
 
@@ -4197,14 +4398,16 @@ pub fn handle_slash_command(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_skills_slash_command, handle_agents_slash_command_json,
-        handle_plugins_slash_command, handle_skills_slash_command_json, handle_slash_command,
+        activate_conditional_skills_for_paths, classify_skills_slash_command, discover_skill_roots,
+        handle_agents_slash_command_json, handle_plugins_slash_command,
+        handle_skills_slash_command_json, handle_slash_command,
         handle_slash_command_with_compactor, load_agents_from_roots, load_skills_from_roots,
-        render_agents_report, render_agents_report_json, render_mcp_report_json_for,
-        render_plugins_report, render_skills_report, render_slash_command_help,
-        render_slash_command_help_detail, resolve_skill_path, resume_supported_slash_commands,
-        slash_command_specs, suggest_slash_commands, validate_slash_command_input,
-        DefinitionSource, SkillOrigin, SkillRoot, SkillSlashDispatch, SlashCommand,
+        load_skills_from_roots_for_context, render_agents_report, render_agents_report_json,
+        render_mcp_report_json_for, render_plugins_report, render_skills_report,
+        render_slash_command_help, render_slash_command_help_detail, resolve_skill,
+        resolve_skill_path, resume_supported_slash_commands, slash_command_specs,
+        suggest_slash_commands, validate_slash_command_input, DefinitionSource, SkillOrigin,
+        SkillRoot, SkillSlashDispatch, SlashCommand,
     };
     use plugins::{PluginKind, PluginManager, PluginManagerConfig, PluginMetadata, PluginSummary};
     use runtime::{
@@ -4651,6 +4854,12 @@ mod tests {
             resolve_skill_path(&workspace, "/handoff").expect("legacy command should resolve"),
             legacy_commands.join("handoff.md")
         );
+        let bundled = resolve_skill(&workspace, "verify").expect("bundled verify should resolve");
+        assert_eq!(bundled.document.resolved_name, "verify");
+        assert!(matches!(
+            bundled.source,
+            super::ResolvedSkillSource::Bundled { .. }
+        ));
     }
 
     #[test]
@@ -4688,13 +4897,39 @@ mod tests {
         );
         assert_eq!(report["kind"], "skills");
         assert_eq!(report["action"], "list");
-        assert_eq!(report["summary"]["active"], 3);
+        assert_eq!(report["summary"]["active"], 7);
         assert_eq!(report["summary"]["shadowed"], 1);
-        assert_eq!(report["skills"][0]["name"], "plan");
-        assert_eq!(report["skills"][0]["source"]["id"], "project_claw");
-        assert_eq!(report["skills"][1]["name"], "deploy");
-        assert_eq!(report["skills"][1]["origin"]["id"], "legacy_commands_dir");
-        assert_eq!(report["skills"][3]["shadowed_by"]["id"], "project_claw");
+        let skills = report["skills"].as_array().expect("skills array");
+        let verify = skills
+            .iter()
+            .find(|skill| skill["name"] == "verify")
+            .expect("verify bundled skill");
+        assert_eq!(verify["source"]["id"], "bundled");
+        assert_eq!(verify["origin"]["id"], "bundled");
+        let plan = skills
+            .iter()
+            .find(|skill| {
+                skill["name"] == "plan"
+                    && skill["source"]["id"] == "project_claw"
+                    && skill["active"] == true
+            })
+            .expect("project plan");
+        assert_eq!(plan["metadata"]["resolved_name"], "plan");
+        assert_eq!(plan["metadata"]["description"], "Project planning guidance");
+        let deploy = skills
+            .iter()
+            .find(|skill| skill["name"] == "deploy")
+            .expect("deploy skill");
+        assert_eq!(deploy["origin"]["id"], "legacy_commands_dir");
+        let shadowed_plan = skills
+            .iter()
+            .find(|skill| {
+                skill["name"] == "plan"
+                    && skill["source"]["id"] == "user_claw"
+                    && skill["active"] == false
+            })
+            .expect("shadowed user plan");
+        assert_eq!(shadowed_plan["shadowed_by"]["id"], "project_claw");
 
         let help = handle_skills_slash_command_json(Some("help"), &workspace).expect("skills help");
         assert_eq!(help["kind"], "skills");
@@ -4706,6 +4941,59 @@ mod tests {
 
         let _ = fs::remove_dir_all(workspace);
         let _ = fs::remove_dir_all(user_home);
+    }
+
+    #[test]
+    fn conditional_skills_activate_only_after_matching_path_touch() {
+        let workspace = temp_dir("conditional-skills-workspace");
+        let project_skills = workspace.join(".codex").join("skills");
+        let source_file = workspace.join("src").join("lib.rs");
+        fs::create_dir_all(
+            source_file
+                .parent()
+                .expect("source file should have parent"),
+        )
+        .expect("create source dir");
+        fs::write(&source_file, "fn helper() {}\n").expect("write source file");
+        write_skill(&project_skills, "help", "Help guidance");
+
+        let conditional_root = project_skills.join("rustacean");
+        fs::create_dir_all(&conditional_root).expect("conditional skill root");
+        fs::write(
+            conditional_root.join("SKILL.md"),
+            "---\nname: rustacean\ndescription: Rust path guidance\npaths: src/**\n---\n\n# rustacean\n",
+        )
+        .expect("write conditional skill");
+
+        let roots = discover_skill_roots(&workspace);
+        let before = load_skills_from_roots_for_context(&roots, &workspace)
+            .expect("skills should load before activation");
+        assert_eq!(before.len(), 5);
+        assert!(before
+            .iter()
+            .any(|skill| skill.document.resolved_name == "help" && skill.shadowed_by.is_none()));
+        assert!(!before
+            .iter()
+            .any(|skill| skill.document.resolved_name == "rustacean"));
+        assert!(resolve_skill_path(&workspace, "rustacean").is_err());
+
+        let activated =
+            activate_conditional_skills_for_paths(std::slice::from_ref(&source_file), &workspace)
+                .expect("activation should succeed");
+        assert_eq!(activated, vec!["rustacean".to_string()]);
+
+        let after = load_skills_from_roots_for_context(&roots, &workspace)
+            .expect("skills should load after activation");
+        assert_eq!(after.len(), 6);
+        assert!(after.iter().any(|skill| {
+            skill.document.resolved_name == "rustacean" && skill.shadowed_by.is_none()
+        }));
+        assert_eq!(
+            resolve_skill_path(&workspace, "rustacean").expect("conditional skill should resolve"),
+            conditional_root.join("SKILL.md")
+        );
+
+        let _ = fs::remove_dir_all(workspace);
     }
 
     #[test]
@@ -5281,7 +5569,10 @@ mod tests {
             render_skills_report(&load_skills_from_roots(&roots).expect("skill roots should load"));
 
         assert!(report.contains("Skills"));
-        assert!(report.contains("3 available skills"));
+        assert!(report.contains("7 available skills"));
+        assert!(report.contains("Bundled:"));
+        assert!(report.contains("verify"));
+        assert!(report.contains("Verify a code change does what it should by running the app."));
         assert!(report.contains("Project (.claw):"));
         assert!(report.contains("plan · Project planning guidance"));
         assert!(report.contains("deploy · Legacy deployment guidance · legacy /commands"));
@@ -5314,6 +5605,7 @@ mod tests {
             .contains("Usage            /skills [list|install <path>|help|<skill> [args]]"));
         assert!(skills_help.contains("Invoke           /skills help overview -> $help overview"));
         assert!(skills_help.contains("Install root     $CLAW_CONFIG_HOME/skills or ~/.claw/skills"));
+        assert!(skills_help.contains("bundled built-ins"));
         assert!(skills_help.contains("legacy /commands"));
 
         let skills_unexpected =
@@ -5430,9 +5722,10 @@ mod tests {
     #[test]
     fn parses_quoted_skill_frontmatter_values() {
         let contents = "---\nname: \"hud\"\ndescription: 'Quoted description'\n---\n";
-        let (name, description) = super::parse_skill_frontmatter(contents);
-        assert_eq!(name.as_deref(), Some("hud"));
-        assert_eq!(description.as_deref(), Some("Quoted description"));
+        let document = super::parse_skill_document(contents, "hud".to_string(), "Skill");
+        assert_eq!(document.display_name.as_deref(), Some("hud"));
+        assert_eq!(document.description, "Quoted description");
+        assert!(document.has_user_specified_description);
     }
 
     #[test]

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -2887,7 +2887,9 @@ pub fn activate_conditional_skills_for_paths(
 }
 
 fn normalize_relative_match_path(path: &Path, cwd: &Path) -> Option<String> {
-    let relative = path.strip_prefix(cwd).ok()?;
+    let normalized_path = normalize_conditional_skill_match_path(path);
+    let normalized_cwd = normalize_conditional_skill_match_path(cwd);
+    let relative = normalized_path.strip_prefix(&normalized_cwd).ok()?;
     let relative = relative.to_string_lossy().replace('\\', "/");
     let relative = relative.trim_start_matches("./").trim_matches('/');
     if relative.is_empty() || relative.starts_with("..") {
@@ -2895,6 +2897,36 @@ fn normalize_relative_match_path(path: &Path, cwd: &Path) -> Option<String> {
     } else {
         Some(relative.to_string())
     }
+}
+
+fn normalize_conditional_skill_match_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return clean_conditional_skill_match_path(canonical);
+    }
+
+    if let Some(parent) = path.parent() {
+        let canonical_parent = parent.canonicalize().map_or_else(
+            |_| clean_conditional_skill_match_path(parent.to_path_buf()),
+            clean_conditional_skill_match_path,
+        );
+        if let Some(name) = path.file_name() {
+            return clean_conditional_skill_match_path(canonical_parent.join(name));
+        }
+    }
+
+    clean_conditional_skill_match_path(path.to_path_buf())
+}
+
+fn clean_conditional_skill_match_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let text = path.to_string_lossy();
+        if let Some(stripped) = text.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+
+    path
 }
 
 fn skill_paths_match(patterns: &[String], relative_path: &str) -> bool {
@@ -4402,10 +4434,10 @@ mod tests {
         handle_agents_slash_command_json, handle_plugins_slash_command,
         handle_skills_slash_command_json, handle_slash_command,
         handle_slash_command_with_compactor, load_agents_from_roots, load_skills_from_roots,
-        load_skills_from_roots_for_context, render_agents_report, render_agents_report_json,
-        render_mcp_report_json_for, render_plugins_report, render_skills_report,
-        render_slash_command_help, render_slash_command_help_detail, resolve_skill,
-        resolve_skill_path, resume_supported_slash_commands, slash_command_specs,
+        load_skills_from_roots_for_context, normalize_relative_match_path, render_agents_report,
+        render_agents_report_json, render_mcp_report_json_for, render_plugins_report,
+        render_skills_report, render_slash_command_help, render_slash_command_help_detail,
+        resolve_skill, resolve_skill_path, resume_supported_slash_commands, slash_command_specs,
         suggest_slash_commands, validate_slash_command_input, DefinitionSource, SkillOrigin,
         SkillRoot, SkillSlashDispatch, SlashCommand,
     };
@@ -4991,6 +5023,25 @@ mod tests {
         assert_eq!(
             resolve_skill_path(&workspace, "rustacean").expect("conditional skill should resolve"),
             conditional_root.join("SKILL.md")
+        );
+
+        let _ = fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn conditional_skill_matching_normalizes_noncanonical_workspace_roots() {
+        let workspace = temp_dir("conditional-skills-noncanonical");
+        let source_dir = workspace.join("src");
+        let source_file = source_dir.join("lib.rs");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+        fs::write(&source_file, "fn helper() {}\n").expect("write source file");
+
+        let canonical_file = source_file.canonicalize().expect("canonical source file");
+        let aliased_workspace = workspace.join("src").join("..");
+
+        assert_eq!(
+            normalize_relative_match_path(&canonical_file, &aliased_workspace),
+            Some("src/lib.rs".to_string())
         );
 
         let _ = fs::remove_dir_all(workspace);

--- a/rust/crates/commands/src/skill_docs.rs
+++ b/rust/crates/commands/src/skill_docs.rs
@@ -1,0 +1,819 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use serde_json::Value as JsonValue;
+use serde_yaml::{Mapping, Value as YamlValue};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillExecutionContext {
+    Fork,
+}
+
+impl SkillExecutionContext {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fork => "fork",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillDocument {
+    pub resolved_name: String,
+    pub display_name: Option<String>,
+    pub description: String,
+    pub has_user_specified_description: bool,
+    pub allowed_tools: Vec<String>,
+    pub argument_hint: Option<String>,
+    pub argument_names: Vec<String>,
+    pub when_to_use: Option<String>,
+    pub version: Option<String>,
+    pub model: Option<String>,
+    pub disable_model_invocation: bool,
+    pub user_invocable: bool,
+    pub hooks: Option<JsonValue>,
+    pub execution_context: Option<SkillExecutionContext>,
+    pub agent: Option<String>,
+    pub effort: Option<String>,
+    pub paths: Option<Vec<String>>,
+    pub shell: Option<String>,
+    pub markdown_content: String,
+}
+
+impl SkillDocument {
+    #[must_use]
+    pub fn user_facing_name(&self) -> &str {
+        self.display_name
+            .as_deref()
+            .unwrap_or(self.resolved_name.as_str())
+    }
+
+    #[must_use]
+    pub fn render_markdown_with_arguments(&self, args: Option<&str>) -> String {
+        substitute_arguments(&self.markdown_content, args, true, &self.argument_names)
+    }
+}
+
+pub fn load_skill_document(
+    path: &Path,
+    description_fallback_label: &str,
+) -> io::Result<SkillDocument> {
+    let contents = fs::read_to_string(path)?;
+    let resolved_name = default_skill_name(path);
+    Ok(parse_skill_document(
+        &contents,
+        resolved_name,
+        description_fallback_label,
+    ))
+}
+
+#[must_use]
+pub fn parse_skill_document(
+    contents: &str,
+    resolved_name: String,
+    description_fallback_label: &str,
+) -> SkillDocument {
+    let (frontmatter, markdown_content) = split_frontmatter(contents);
+    let frontmatter = frontmatter.and_then(parse_frontmatter_mapping).or_else(|| {
+        frontmatter.and_then(|text| parse_frontmatter_mapping(&quote_problematic_values(text)))
+    });
+
+    let display_name = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "name"));
+    let user_specified_description = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_description(mapping, "description"));
+    let description = user_specified_description.clone().unwrap_or_else(|| {
+        extract_description_from_markdown(markdown_content, description_fallback_label)
+    });
+
+    let allowed_tools = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "allowed-tools"))
+        .map(parse_allowed_tools)
+        .unwrap_or_default();
+    let argument_hint = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "argument-hint"));
+    let argument_names = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "arguments"))
+        .map(parse_argument_names)
+        .unwrap_or_default();
+    let when_to_use = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "when_to_use"));
+    let version = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "version"));
+    let model = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "model"))
+        .filter(|value| !value.eq_ignore_ascii_case("inherit"));
+    let disable_model_invocation = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "disable-model-invocation"))
+        .is_some_and(parse_boolean_frontmatter);
+    let user_invocable = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "user-invocable"))
+        .is_none_or(parse_boolean_frontmatter);
+    let hooks = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "hooks"))
+        .and_then(yaml_to_json);
+    let execution_context = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "context"))
+        .and_then(|value| {
+            if value.eq_ignore_ascii_case("fork") {
+                Some(SkillExecutionContext::Fork)
+            } else {
+                None
+            }
+        });
+    let agent = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "agent"));
+    let effort = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_scalar_string(mapping, "effort"));
+    let paths = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_value(mapping, "paths"))
+        .and_then(parse_paths);
+    let shell = frontmatter
+        .as_ref()
+        .and_then(|mapping| mapping_string(mapping, "shell"))
+        .and_then(|value| parse_shell(&value));
+
+    SkillDocument {
+        resolved_name,
+        display_name,
+        description,
+        has_user_specified_description: user_specified_description.is_some(),
+        allowed_tools,
+        argument_hint,
+        argument_names,
+        when_to_use,
+        version,
+        model,
+        disable_model_invocation,
+        user_invocable,
+        hooks,
+        execution_context,
+        agent,
+        effort,
+        paths,
+        shell,
+        markdown_content: markdown_content.to_string(),
+    }
+}
+
+#[must_use]
+pub fn extract_skill_frontmatter_name(contents: &str) -> Option<String> {
+    let (frontmatter, _) = split_frontmatter(contents);
+    frontmatter
+        .and_then(parse_frontmatter_mapping)
+        .or_else(|| {
+            frontmatter.and_then(|text| parse_frontmatter_mapping(&quote_problematic_values(text)))
+        })
+        .and_then(|mapping| mapping_string(&mapping, "name"))
+}
+
+fn default_skill_name(path: &Path) -> String {
+    if path
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("SKILL.md"))
+    {
+        return path
+            .parent()
+            .and_then(Path::file_name)
+            .map(|name| name.to_string_lossy().to_string())
+            .or_else(|| {
+                path.file_stem()
+                    .map(|stem| stem.to_string_lossy().to_string())
+            })
+            .unwrap_or_else(|| "skill".to_string());
+    }
+
+    path.file_stem().map_or_else(
+        || "skill".to_string(),
+        |stem| stem.to_string_lossy().to_string(),
+    )
+}
+
+fn split_frontmatter(contents: &str) -> (Option<&str>, &str) {
+    let mut lines = contents.split_inclusive('\n');
+    let Some(first_line) = lines.next() else {
+        return (None, contents);
+    };
+    if first_line.trim() != "---" {
+        return (None, contents);
+    }
+
+    let mut cursor = first_line.len();
+    for line in lines {
+        if line.trim() == "---" {
+            let frontmatter = &contents[first_line.len()..cursor];
+            let body = &contents[cursor + line.len()..];
+            return (Some(frontmatter), body);
+        }
+        cursor += line.len();
+    }
+
+    (None, contents)
+}
+
+fn parse_frontmatter_mapping(frontmatter: &str) -> Option<Mapping> {
+    match serde_yaml::from_str::<YamlValue>(frontmatter).ok()? {
+        YamlValue::Mapping(mapping) => Some(mapping),
+        _ => None,
+    }
+}
+
+fn quote_problematic_values(frontmatter: &str) -> String {
+    frontmatter
+        .lines()
+        .map(|line| {
+            if line.starts_with(' ') || line.starts_with('\t') || line.starts_with('-') {
+                return line.to_string();
+            }
+
+            let Some((key, value)) = line.split_once(':') else {
+                return line.to_string();
+            };
+            if !key
+                .chars()
+                .all(|ch| ch.is_ascii_alphabetic() || matches!(ch, '_' | '-'))
+            {
+                return line.to_string();
+            }
+            let Some(value) = value.strip_prefix(' ') else {
+                return line.to_string();
+            };
+            if value.is_empty() || is_quoted_yaml(value) || !has_yaml_special_chars(value) {
+                return line.to_string();
+            }
+
+            let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("{key}: \"{escaped}\"")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_quoted_yaml(value: &str) -> bool {
+    (value.starts_with('"') && value.ends_with('"'))
+        || (value.starts_with('\'') && value.ends_with('\''))
+}
+
+fn has_yaml_special_chars(value: &str) -> bool {
+    value.contains(": ")
+        || value.chars().any(|ch| {
+            matches!(
+                ch,
+                '{' | '}' | '[' | ']' | '*' | '&' | '#' | '!' | '|' | '>' | '%' | '@' | '`'
+            )
+        })
+}
+
+fn mapping_value<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a YamlValue> {
+    mapping.get(YamlValue::String(key.to_string()))
+}
+
+fn mapping_string(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping_value(mapping, key).and_then(yaml_stringish)
+}
+
+fn mapping_scalar_string(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping_value(mapping, key).and_then(yaml_scalar_string)
+}
+
+fn mapping_description(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping_value(mapping, key).and_then(yaml_description_string)
+}
+
+fn yaml_scalar_string(value: &YamlValue) -> Option<String> {
+    match value {
+        YamlValue::Bool(value) => Some(value.to_string()),
+        YamlValue::Number(value) => Some(value.to_string()),
+        YamlValue::String(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn yaml_stringish(value: &YamlValue) -> Option<String> {
+    match value {
+        YamlValue::Sequence(items) => {
+            let values = items
+                .iter()
+                .filter_map(yaml_scalar_string)
+                .collect::<Vec<_>>();
+            (!values.is_empty()).then(|| values.join(","))
+        }
+        _ => yaml_scalar_string(value),
+    }
+}
+
+fn yaml_description_string(value: &YamlValue) -> Option<String> {
+    match value {
+        YamlValue::Bool(value) => Some(value.to_string()),
+        YamlValue::Number(value) => Some(value.to_string()),
+        YamlValue::String(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn parse_boolean_frontmatter(value: &YamlValue) -> bool {
+    matches!(value, YamlValue::Bool(true))
+        || matches!(value, YamlValue::String(text) if text == "true")
+}
+
+fn parse_allowed_tools(value: &YamlValue) -> Vec<String> {
+    let segments = match value {
+        YamlValue::String(text) => vec![text.clone()],
+        YamlValue::Sequence(items) => items
+            .iter()
+            .filter_map(yaml_scalar_string)
+            .collect::<Vec<_>>(),
+        _ => return Vec::new(),
+    };
+
+    parse_tool_list_from_cli(&segments)
+}
+
+fn parse_tool_list_from_cli(values: &[String]) -> Vec<String> {
+    let mut parsed = Vec::new();
+
+    for value in values {
+        if value.trim().is_empty() {
+            continue;
+        }
+
+        let mut current = String::new();
+        let mut depth = 0_u32;
+        for ch in value.chars() {
+            match ch {
+                '(' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' => {
+                    depth = depth.saturating_sub(1);
+                    current.push(ch);
+                }
+                ',' | ' ' if depth == 0 => {
+                    let trimmed = current.trim();
+                    if !trimmed.is_empty() {
+                        parsed.push(trimmed.to_string());
+                    }
+                    current.clear();
+                }
+                _ => current.push(ch),
+            }
+        }
+
+        let trimmed = current.trim();
+        if !trimmed.is_empty() {
+            parsed.push(trimmed.to_string());
+        }
+    }
+
+    parsed
+}
+
+fn parse_argument_names(value: &YamlValue) -> Vec<String> {
+    let is_valid =
+        |name: &str| !name.trim().is_empty() && !name.chars().all(|ch| ch.is_ascii_digit());
+    match value {
+        YamlValue::String(text) => text
+            .split_whitespace()
+            .filter(|name| is_valid(name))
+            .map(ToString::to_string)
+            .collect(),
+        YamlValue::Sequence(items) => items
+            .iter()
+            .filter_map(yaml_scalar_string)
+            .filter(|name| is_valid(name))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_paths(value: &YamlValue) -> Option<Vec<String>> {
+    let inputs = match value {
+        YamlValue::String(text) => vec![text.clone()],
+        YamlValue::Sequence(items) => items
+            .iter()
+            .filter_map(yaml_scalar_string)
+            .collect::<Vec<_>>(),
+        _ => return None,
+    };
+
+    let patterns = inputs
+        .iter()
+        .flat_map(|text| split_path_in_frontmatter(text))
+        .map(|pattern| pattern.strip_suffix("/**").unwrap_or(&pattern).to_string())
+        .filter(|pattern| !pattern.is_empty())
+        .collect::<Vec<_>>();
+
+    if patterns.is_empty() || patterns.iter().all(|pattern| pattern == "**") {
+        None
+    } else {
+        Some(patterns)
+    }
+}
+
+fn split_path_in_frontmatter(input: &str) -> Vec<String> {
+    if input.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut brace_depth = 0_i32;
+
+    for ch in input.chars() {
+        match ch {
+            '{' => {
+                brace_depth += 1;
+                current.push(ch);
+            }
+            '}' => {
+                brace_depth -= 1;
+                current.push(ch);
+            }
+            ',' if brace_depth == 0 => {
+                let trimmed = current.trim();
+                if !trimmed.is_empty() {
+                    parts.push(trimmed.to_string());
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        parts.push(trimmed.to_string());
+    }
+
+    parts
+        .into_iter()
+        .flat_map(|pattern| expand_braces(&pattern))
+        .collect()
+}
+
+fn expand_braces(pattern: &str) -> Vec<String> {
+    let Some(open_index) = pattern.find('{') else {
+        return vec![pattern.to_string()];
+    };
+    let Some(close_index) = pattern[open_index + 1..].find('}') else {
+        return vec![pattern.to_string()];
+    };
+    let close_index = open_index + 1 + close_index;
+    let prefix = &pattern[..open_index];
+    let alternatives = &pattern[open_index + 1..close_index];
+    let suffix = &pattern[close_index + 1..];
+
+    alternatives
+        .split(',')
+        .flat_map(|part| expand_braces(&format!("{prefix}{}{suffix}", part.trim())))
+        .collect()
+}
+
+fn parse_shell(value: &str) -> Option<String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "bash" => Some("bash".to_string()),
+        "powershell" => Some("powershell".to_string()),
+        _ => None,
+    }
+}
+
+fn yaml_to_json(value: &YamlValue) -> Option<JsonValue> {
+    serde_json::to_value(value).ok()
+}
+
+fn substitute_arguments(
+    content: &str,
+    args: Option<&str>,
+    append_if_no_placeholder: bool,
+    argument_names: &[String],
+) -> String {
+    let Some(args) = args else {
+        return content.to_string();
+    };
+
+    let parsed_args = parse_arguments(args);
+    let original = content.to_string();
+    let mut replaced = original.clone();
+
+    for (index, name) in argument_names.iter().enumerate() {
+        if name.is_empty() {
+            continue;
+        }
+        replaced = replace_named_argument_occurrences(
+            &replaced,
+            name,
+            parsed_args.get(index).map_or("", String::as_str),
+        );
+    }
+
+    replaced = replace_arguments_indexed_occurrences(&replaced, &parsed_args);
+    replaced = replace_shorthand_indexed_occurrences(&replaced, &parsed_args);
+    replaced = replaced.replace("$ARGUMENTS", args);
+
+    if replaced == original && append_if_no_placeholder && !args.is_empty() {
+        replaced.push_str("\n\nARGUMENTS: ");
+        replaced.push_str(args);
+    }
+
+    replaced
+}
+
+fn parse_arguments(args: &str) -> Vec<String> {
+    if args.trim().is_empty() {
+        return Vec::new();
+    }
+
+    try_parse_arguments(args).unwrap_or_else(|| {
+        args.split_whitespace()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    })
+}
+
+fn try_parse_arguments(args: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = args.chars().peekable();
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' if !in_double_quotes => {
+                in_single_quotes = !in_single_quotes;
+            }
+            '"' if !in_single_quotes => {
+                in_double_quotes = !in_double_quotes;
+            }
+            '\\' if !in_single_quotes => {
+                current.push(chars.next()?);
+            }
+            ch if !in_single_quotes && !in_double_quotes && ch.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            ch if !in_single_quotes && !in_double_quotes && is_shell_operator(ch) => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if in_single_quotes || in_double_quotes {
+        return None;
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    Some(tokens)
+}
+
+fn is_shell_operator(ch: char) -> bool {
+    matches!(ch, '|' | '&' | ';' | '(' | ')' | '<' | '>')
+}
+
+fn replace_named_argument_occurrences(content: &str, name: &str, replacement: &str) -> String {
+    let mut output = String::with_capacity(content.len());
+    let mut cursor = 0;
+
+    while cursor < content.len() {
+        let slice = &content[cursor..];
+        if let Some(rest) = slice
+            .strip_prefix('$')
+            .filter(|rest| rest.starts_with(name))
+        {
+            let after = &rest[name.len()..];
+            let next = after.chars().next();
+            if next != Some('[') && !next.is_some_and(is_word_char) {
+                output.push_str(replacement);
+                cursor += 1 + name.len();
+                continue;
+            }
+        }
+
+        let ch = slice
+            .chars()
+            .next()
+            .expect("non-empty slice should have a character");
+        output.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    output
+}
+
+fn replace_arguments_indexed_occurrences(content: &str, parsed_args: &[String]) -> String {
+    let mut output = String::with_capacity(content.len());
+    let mut cursor = 0;
+
+    while cursor < content.len() {
+        let slice = &content[cursor..];
+        if let Some(rest) = slice.strip_prefix("$ARGUMENTS[") {
+            let digits_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+            if digits_len > 0 && rest[digits_len..].starts_with(']') {
+                let index = rest[..digits_len].parse::<usize>().ok();
+                output.push_str(
+                    index
+                        .and_then(|idx| parsed_args.get(idx))
+                        .map_or("", String::as_str),
+                );
+                cursor += "$ARGUMENTS[".len() + digits_len + 1;
+                continue;
+            }
+        }
+
+        let ch = slice
+            .chars()
+            .next()
+            .expect("non-empty slice should have a character");
+        output.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    output
+}
+
+fn replace_shorthand_indexed_occurrences(content: &str, parsed_args: &[String]) -> String {
+    let mut output = String::with_capacity(content.len());
+    let mut cursor = 0;
+
+    while cursor < content.len() {
+        let slice = &content[cursor..];
+        if let Some(rest) = slice.strip_prefix('$') {
+            let digits_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+            if digits_len > 0 {
+                let next = rest[digits_len..].chars().next();
+                if !next.is_some_and(is_word_char) {
+                    let index = rest[..digits_len].parse::<usize>().ok();
+                    output.push_str(
+                        index
+                            .and_then(|idx| parsed_args.get(idx))
+                            .map_or("", String::as_str),
+                    );
+                    cursor += 1 + digits_len;
+                    continue;
+                }
+            }
+        }
+
+        let ch = slice
+            .chars()
+            .next()
+            .expect("non-empty slice should have a character");
+        output.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    output
+}
+
+fn is_word_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn extract_description_from_markdown(content: &str, default_description: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let text = trimmed
+            .strip_prefix("# ")
+            .or_else(|| trimmed.strip_prefix("## "))
+            .or_else(|| trimmed.strip_prefix("### "))
+            .or_else(|| trimmed.strip_prefix("#### "))
+            .or_else(|| trimmed.strip_prefix("##### "))
+            .or_else(|| trimmed.strip_prefix("###### "))
+            .unwrap_or(trimmed);
+        let shortened = if text.chars().count() > 100 {
+            let mut collected = text.chars().take(97).collect::<String>();
+            collected.push_str("...");
+            collected
+        } else {
+            text.to_string()
+        };
+        return shortened;
+    }
+
+    default_description.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_skill_frontmatter_name, parse_skill_document, SkillExecutionContext};
+
+    #[test]
+    fn parses_rich_skill_frontmatter_fields() {
+        let doc = parse_skill_document(
+            "---\nname: planner\ndescription: Useful planner\narguments: [topic, depth]\nargument-hint: \"[topic] [depth]\"\nallowed-tools: \"Bash, Read(Edit)\"\nmodel: claude-3-7-sonnet\nversion: 1.2.3\ndisable-model-invocation: true\nuser-invocable: false\ncontext: fork\nagent: general-purpose\neffort: high\npaths: \"src/*.{ts,tsx}, docs/**\"\nshell: powershell\nhooks:\n  PreToolUse:\n    - matcher: Bash\n      hooks:\n        - command: echo hi\n---\n# planner\n\nBody\n",
+            "planner".to_string(),
+            "Skill",
+        );
+
+        assert_eq!(doc.display_name.as_deref(), Some("planner"));
+        assert_eq!(doc.user_facing_name(), "planner");
+        assert_eq!(doc.description, "Useful planner");
+        assert_eq!(doc.argument_names, vec!["topic", "depth"]);
+        assert_eq!(doc.argument_hint.as_deref(), Some("[topic] [depth]"));
+        assert_eq!(doc.allowed_tools, vec!["Bash", "Read(Edit)"]);
+        assert_eq!(doc.model.as_deref(), Some("claude-3-7-sonnet"));
+        assert!(doc.disable_model_invocation);
+        assert!(!doc.user_invocable);
+        assert_eq!(doc.execution_context, Some(SkillExecutionContext::Fork));
+        assert_eq!(doc.agent.as_deref(), Some("general-purpose"));
+        assert_eq!(doc.effort.as_deref(), Some("high"));
+        assert_eq!(
+            doc.paths,
+            Some(vec![
+                "src/*.ts".to_string(),
+                "src/*.tsx".to_string(),
+                "docs".to_string(),
+            ])
+        );
+        assert_eq!(doc.shell.as_deref(), Some("powershell"));
+        assert!(doc.hooks.is_some());
+        assert_eq!(doc.markdown_content, "# planner\n\nBody\n");
+    }
+
+    #[test]
+    fn falls_back_to_heading_for_description_when_frontmatter_is_missing() {
+        let doc = parse_skill_document(
+            "# Review PR\n\nFollow the checklist.\n",
+            "review-pr".to_string(),
+            "Skill",
+        );
+        assert_eq!(doc.description, "Review PR");
+        assert!(!doc.has_user_specified_description);
+    }
+
+    #[test]
+    fn extracts_frontmatter_name_with_yaml_quoting_retry() {
+        let name = extract_skill_frontmatter_name(
+            "---\nname: \"trace\"\npaths: src/*.{ts,tsx}\n---\n# trace\n",
+        );
+        assert_eq!(name.as_deref(), Some("trace"));
+    }
+
+    #[test]
+    fn substitutes_named_indexed_and_full_arguments() {
+        let doc = parse_skill_document(
+            "---\narguments: [topic, depth]\n---\nTopic: $topic\nFirst: $0\nSecond: $ARGUMENTS[1]\nRaw: $ARGUMENTS\n",
+            "planner".to_string(),
+            "Skill",
+        );
+
+        let rendered = doc.render_markdown_with_arguments(Some("alpha \"two words\" tail"));
+        assert_eq!(
+            rendered,
+            "Topic: alpha\nFirst: alpha\nSecond: two words\nRaw: alpha \"two words\" tail\n"
+        );
+    }
+
+    #[test]
+    fn appends_arguments_block_when_no_placeholder_exists() {
+        let doc = parse_skill_document("# help\n\nGuide body\n", "help".to_string(), "Skill");
+        let rendered = doc.render_markdown_with_arguments(Some("overview"));
+        assert_eq!(rendered, "# help\n\nGuide body\n\n\nARGUMENTS: overview");
+    }
+
+    #[test]
+    fn malformed_quotes_fall_back_to_whitespace_argument_split() {
+        let doc = parse_skill_document(
+            "---\narguments: [first, second]\n---\nA=$first B=$second\n",
+            "help".to_string(),
+            "Skill",
+        );
+        let rendered = doc.render_markdown_with_arguments(Some("alpha \"two words"));
+        assert_eq!(rendered, "A=alpha B=\"two\n");
+    }
+}

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::session::{
     AttachmentKind, CompactBoundaryMetadata, CompactPreservedSegment, CompactTrigger, ContentBlock,
-    ConversationMessage, MessageRole, Session,
+    ConversationMessage, InvokedSkill, MessageRole, Session,
 };
 
 const NO_TOOLS_PREAMBLE: &str = r"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
@@ -508,7 +508,7 @@ fn collect_post_compact_context_messages(session: &Session) -> Vec<ConversationM
     if let Some(plan_mode) = create_plan_mode_context_message(&session.messages) {
         messages.push(plan_mode);
     }
-    if let Some(skills) = create_invoked_skills_context_message(&session.messages) {
+    if let Some(skills) = create_invoked_skills_context_message(session) {
         messages.push(skills);
     }
 
@@ -648,15 +648,16 @@ fn create_plan_mode_context_message(
     ))
 }
 
-fn create_invoked_skills_context_message(
-    messages: &[ConversationMessage],
-) -> Option<ConversationMessage> {
+fn create_invoked_skills_context_message(session: &Session) -> Option<ConversationMessage> {
     let mut skills = BTreeMap::new();
-    for output in successful_tool_outputs(messages, "Skill") {
-        let Some(parsed) = parse_tool_result_json_prefix::<CompactSkillOutput>(output) else {
-            continue;
-        };
-        skills.insert(parsed.skill.clone(), parsed);
+    if session.invoked_skills.is_empty() {
+        for skill in legacy_invoked_skills_from_messages(&session.messages) {
+            skills.insert(skill.skill.clone(), skill);
+        }
+    } else {
+        for skill in &session.invoked_skills {
+            skills.insert(skill.skill.clone(), skill.clone());
+        }
     }
 
     if skills.is_empty() {
@@ -666,7 +667,11 @@ fn create_invoked_skills_context_message(
     let mut content = String::from("Previously invoked skills remain available after compaction.");
     for skill in skills.into_values() {
         let _ = write!(content, "\n\nSkill `{}`", skill.skill);
-        let _ = write!(content, "\nPath: {}", skill.path);
+        if let Some(path) = skill.path.as_deref().map(str::trim) {
+            if !path.is_empty() {
+                let _ = write!(content, "\nPath: {path}");
+            }
+        }
         if let Some(description) = skill.description.as_deref().map(str::trim) {
             if !description.is_empty() {
                 let _ = write!(content, "\nDescription: {description}");
@@ -685,6 +690,20 @@ fn create_invoked_skills_context_message(
         content,
         AttachmentKind::InvokedSkills,
     ))
+}
+
+fn legacy_invoked_skills_from_messages(messages: &[ConversationMessage]) -> Vec<InvokedSkill> {
+    successful_tool_outputs(messages, "Skill")
+        .filter_map(parse_tool_result_json_prefix::<CompactSkillOutput>)
+        .map(|parsed| InvokedSkill {
+            skill: parsed.skill,
+            resolved_name: None,
+            path: Some(parsed.path),
+            description: parsed.description,
+            args: parsed.args,
+            prompt: parsed.prompt,
+        })
+        .collect()
 }
 
 fn successful_tool_outputs<'a>(
@@ -1181,7 +1200,8 @@ mod tests {
         BuildCompactionResultOptions, CompactionConfig, CompactionLayout, PreservedSegmentAnchor,
     };
     use crate::session::{
-        AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, MessageRole, Session,
+        AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, InvokedSkill,
+        MessageRole, Session,
     };
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -1257,19 +1277,6 @@ mod tests {
                 false,
             ),
             ConversationMessage::tool_result(
-                "skill-1",
-                "Skill",
-                serde_json::to_string_pretty(&json!({
-                    "skill": "$compact",
-                    "path": workspace.join(".codex").join("skills").join("compact").join("SKILL.md").display().to_string(),
-                    "args": "full",
-                    "description": "Compact guidance",
-                    "prompt": "Prefer TS full compact parity over local summaries."
-                }))
-                .expect("skill json should serialize"),
-                false,
-            ),
-            ConversationMessage::tool_result(
                 "agent-1",
                 "Agent",
                 serde_json::to_string_pretty(&json!({
@@ -1285,6 +1292,22 @@ mod tests {
                 false,
             ),
         ];
+        session.invoked_skills.push(InvokedSkill {
+            skill: "$compact".to_string(),
+            resolved_name: Some("compact".to_string()),
+            path: Some(
+                workspace
+                    .join(".codex")
+                    .join("skills")
+                    .join("compact")
+                    .join("SKILL.md")
+                    .display()
+                    .to_string(),
+            ),
+            description: Some("Compact guidance".to_string()),
+            args: Some("full".to_string()),
+            prompt: "Prefer TS full compact parity over local summaries.".to_string(),
+        });
         session
     }
 
@@ -1692,5 +1715,42 @@ mod tests {
         assert!(rendered[3].contains("Prefer TS full compact parity over local summaries."));
 
         fs::remove_dir_all(&workspace).expect("workspace cleanup should succeed");
+    }
+
+    #[test]
+    fn invoked_skills_context_falls_back_to_legacy_skill_tool_results() {
+        let workspace = temp_dir("legacy-invoked-skills");
+        let mut session = Session::new();
+        session.messages = vec![ConversationMessage::tool_result(
+            "skill-1",
+            "Skill",
+            serde_json::to_string_pretty(&json!({
+                "skill": "trace",
+                "path": workspace.join(".codex").join("skills").join("trace").join("SKILL.md").display().to_string(),
+                "args": "focus",
+                "description": "Trace helper",
+                "prompt": "Trace the failure end to end."
+            }))
+            .expect("skill json should serialize"),
+            false,
+        )];
+
+        let message = super::create_invoked_skills_context_message(&session)
+            .expect("legacy skill context message");
+        let rendered = match &message.blocks[0] {
+            ContentBlock::Text { text } => text,
+            ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => {
+                panic!("expected text attachment")
+            }
+        };
+        assert!(rendered.contains("Skill `trace`"));
+        assert!(rendered.contains("Trace the failure end to end."));
+        assert_eq!(
+            message
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::InvokedSkills)
+        );
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -15,9 +15,10 @@ use crate::permissions::{
     PermissionContext, PermissionOutcome, PermissionPolicy, PermissionPrompter,
 };
 use crate::session::{
-    AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent, Session,
+    AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent,
+    InvokedSkill, Session,
 };
-use crate::tool_session::with_tool_session_context;
+use crate::tool_session::{with_tool_session_context, with_tool_session_snapshot};
 use crate::usage::{TokenUsage, UsageTracker};
 
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 100_000;
@@ -29,6 +30,8 @@ pub struct ApiRequest {
     pub messages: Vec<ConversationMessage>,
     /// Full compact uses a text-only request and must not expose tool schemas.
     pub allow_tools: bool,
+    pub model_override: Option<String>,
+    pub reasoning_effort: Option<String>,
 }
 
 impl ApiRequest {
@@ -38,6 +41,8 @@ impl ApiRequest {
             system_prompt,
             messages,
             allow_tools: true,
+            model_override: None,
+            reasoning_effort: None,
         }
     }
 
@@ -47,6 +52,8 @@ impl ApiRequest {
             system_prompt,
             messages,
             allow_tools: false,
+            model_override: None,
+            reasoning_effort: None,
         }
     }
 }
@@ -78,7 +85,7 @@ pub trait ApiClient {
 }
 
 pub trait ToolExecutor {
-    fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError>;
+    fn execute(&mut self, tool_name: &str, input: &str) -> Result<ToolExecutionResult, ToolError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,6 +131,103 @@ impl Display for RuntimeError {
 }
 
 impl std::error::Error for RuntimeError {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolContextUpdate {
+    pub model_override: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub additional_allow_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolExecutionResult {
+    pub output: String,
+    pub additional_messages: Vec<ConversationMessage>,
+    pub context_update: Option<ToolContextUpdate>,
+    pub invoked_skills: Vec<InvokedSkill>,
+}
+
+impl ToolExecutionResult {
+    #[must_use]
+    pub fn text(output: impl Into<String>) -> Self {
+        Self {
+            output: output.into(),
+            additional_messages: Vec::new(),
+            context_update: None,
+            invoked_skills: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_additional_messages(
+        mut self,
+        additional_messages: Vec<ConversationMessage>,
+    ) -> Self {
+        self.additional_messages = additional_messages;
+        self
+    }
+
+    #[must_use]
+    pub fn with_context_update(mut self, context_update: ToolContextUpdate) -> Self {
+        self.context_update = Some(context_update);
+        self
+    }
+
+    #[must_use]
+    pub fn with_invoked_skill(mut self, invoked_skill: InvokedSkill) -> Self {
+        self.invoked_skills.push(invoked_skill);
+        self
+    }
+}
+
+impl From<String> for ToolExecutionResult {
+    fn from(value: String) -> Self {
+        Self::text(value)
+    }
+}
+
+impl From<&str> for ToolExecutionResult {
+    fn from(value: &str) -> Self {
+        Self::text(value)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ConversationToolContext {
+    model_override: Option<String>,
+    reasoning_effort: Option<String>,
+    additional_allow_rules: Vec<String>,
+}
+
+impl ConversationToolContext {
+    fn apply(&mut self, update: ToolContextUpdate) {
+        if let Some(model_override) = update.model_override {
+            self.model_override = Some(model_override);
+        }
+        if let Some(reasoning_effort) = update.reasoning_effort {
+            self.reasoning_effort = Some(reasoning_effort);
+        }
+        for rule in update.additional_allow_rules {
+            if !self.additional_allow_rules.contains(&rule) {
+                self.additional_allow_rules.push(rule);
+            }
+        }
+    }
+
+    fn apply_to_api_request(&self, request: &mut ApiRequest) {
+        request.model_override.clone_from(&self.model_override);
+        request.reasoning_effort.clone_from(&self.reasoning_effort);
+    }
+
+    fn permission_context(
+        &self,
+        override_decision: Option<crate::permissions::PermissionOverride>,
+        override_reason: Option<String>,
+    ) -> PermissionContext {
+        PermissionContext::new(override_decision, override_reason)
+            .with_additional_allow_rules(self.additional_allow_rules.clone())
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurnSummary {
@@ -349,6 +453,7 @@ where
         let mut tool_results = Vec::new();
         let mut prompt_cache_events = Vec::new();
         let mut iterations = 0;
+        let mut tool_context = ConversationToolContext::default();
 
         loop {
             iterations += 1;
@@ -360,8 +465,9 @@ where
                 return Err(error);
             }
 
-            let request =
+            let mut request =
                 ApiRequest::conversation(self.system_prompt.clone(), self.session.messages.clone());
+            tool_context.apply_to_api_request(&mut request);
             let events = match with_tool_session_context(
                 &self.session.session_id,
                 self.session.persistence_path(),
@@ -415,7 +521,7 @@ where
                 let effective_input = pre_hook_result
                     .updated_input()
                     .map_or_else(|| input.clone(), ToOwned::to_owned);
-                let permission_context = PermissionContext::new(
+                let permission_context = tool_context.permission_context(
                     pre_hook_result.permission_override(),
                     pre_hook_result.permission_reason().map(ToOwned::to_owned),
                 );
@@ -460,27 +566,48 @@ where
                 let result_message = match permission_outcome {
                     PermissionOutcome::Allow => {
                         self.record_tool_started(iterations, &tool_name);
-                        let (mut output, mut is_error) = with_tool_session_context(
+                        let session_messages = self.session.messages.clone();
+                        let compaction_summary = self
+                            .session
+                            .compaction
+                            .as_ref()
+                            .map(|compaction| compaction.summary.clone());
+                        let (mut execution, mut is_error) = with_tool_session_context(
                             &self.session.session_id,
                             self.session.persistence_path(),
-                            || match self.tool_executor.execute(&tool_name, &effective_input) {
-                                Ok(output) => (output, false),
-                                Err(error) => (error.to_string(), true),
+                            || {
+                                with_tool_session_snapshot(
+                                    &session_messages,
+                                    compaction_summary.as_deref(),
+                                    || match self
+                                        .tool_executor
+                                        .execute(&tool_name, &effective_input)
+                                    {
+                                        Ok(output) => (output, false),
+                                        Err(error) => {
+                                            (ToolExecutionResult::text(error.to_string()), true)
+                                        }
+                                    },
+                                )
                             },
                         );
-                        output = merge_hook_feedback(pre_hook_result.messages(), output, false);
+                        execution.output = merge_hook_feedback(
+                            pre_hook_result.messages(),
+                            execution.output,
+                            false,
+                        );
 
                         let post_hook_result = if is_error {
                             self.run_post_tool_use_failure_hook(
                                 &tool_name,
                                 &effective_input,
-                                &output,
+                                &execution.output,
                             )
                         } else {
                             self.run_post_tool_use_hook(
                                 &tool_name,
                                 &effective_input,
-                                &output,
+                                &execution.output,
                                 false,
                             )
                         };
@@ -490,15 +617,40 @@ where
                         {
                             is_error = true;
                         }
-                        output = merge_hook_feedback(
+                        execution.output = merge_hook_feedback(
                             post_hook_result.messages(),
-                            output,
+                            execution.output,
                             post_hook_result.is_denied()
                                 || post_hook_result.is_failed()
                                 || post_hook_result.is_cancelled(),
                         );
-
-                        ConversationMessage::tool_result(tool_use_id, tool_name, output, is_error)
+                        let result_message = ConversationMessage::tool_result(
+                            tool_use_id,
+                            tool_name,
+                            execution.output,
+                            is_error,
+                        );
+                        self.session
+                            .push_message(result_message.clone())
+                            .map_err(|error| RuntimeError::new(error.to_string()))?;
+                        self.record_tool_finished(iterations, &result_message);
+                        tool_results.push(result_message.clone());
+                        if !is_error {
+                            for invoked_skill in execution.invoked_skills {
+                                self.session
+                                    .upsert_invoked_skill(invoked_skill)
+                                    .map_err(|error| RuntimeError::new(error.to_string()))?;
+                            }
+                        }
+                        if let Some(context_update) = execution.context_update {
+                            tool_context.apply(context_update);
+                        }
+                        for message in execution.additional_messages {
+                            self.session
+                                .push_message(message)
+                                .map_err(|error| RuntimeError::new(error.to_string()))?;
+                        }
+                        continue;
                     }
                     PermissionOutcome::Deny { reason } => ConversationMessage::tool_result(
                         tool_use_id,
@@ -904,7 +1056,7 @@ fn session_start_hook_messages(source: &str, result: &HookRunResult) -> Vec<Conv
         .collect()
 }
 
-type ToolHandler = Box<dyn FnMut(&str) -> Result<String, ToolError>>;
+type ToolHandler = Box<dyn FnMut(&str) -> Result<ToolExecutionResult, ToolError>>;
 
 #[derive(Default)]
 pub struct StaticToolExecutor {
@@ -918,18 +1070,24 @@ impl StaticToolExecutor {
     }
 
     #[must_use]
-    pub fn register(
+    pub fn register<R>(
         mut self,
         tool_name: impl Into<String>,
-        handler: impl FnMut(&str) -> Result<String, ToolError> + 'static,
-    ) -> Self {
-        self.handlers.insert(tool_name.into(), Box::new(handler));
+        mut handler: impl FnMut(&str) -> Result<R, ToolError> + 'static,
+    ) -> Self
+    where
+        R: Into<ToolExecutionResult> + 'static,
+    {
+        self.handlers.insert(
+            tool_name.into(),
+            Box::new(move |input| handler(input).map(Into::into)),
+        );
         self
     }
 }
 
 impl ToolExecutor for StaticToolExecutor {
-    fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+    fn execute(&mut self, tool_name: &str, input: &str) -> Result<ToolExecutionResult, ToolError> {
         self.handlers
             .get_mut(tool_name)
             .ok_or_else(|| ToolError::new(format!("unknown tool: {tool_name}")))?(input)
@@ -941,7 +1099,8 @@ mod tests {
     use super::{
         build_assistant_message, parse_auto_compaction_threshold, ApiClient, ApiRequest,
         AssistantEvent, AutoCompactionEvent, ConversationRuntime, PromptCacheEvent, RuntimeError,
-        StaticToolExecutor, ToolExecutor, DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
+        StaticToolExecutor, ToolContextUpdate, ToolExecutionResult, ToolExecutor,
+        DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
     };
     use crate::compact::CompactionConfig;
     use crate::config::{RuntimeFeatureConfig, RuntimeHookConfig};
@@ -951,7 +1110,11 @@ mod tests {
     };
     use crate::prompt::{ProjectContext, SystemPromptBuilder};
     use crate::session::{
-        AttachmentKind, CompactTrigger, ContentBlock, HookResultEvent, MessageRole, Session,
+        AttachmentKind, CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent,
+        InvokedSkill, MessageRole, Session, SessionCompaction,
+    };
+    use crate::tool_session::{
+        current_tool_session_compaction_summary, current_tool_session_messages,
     };
     use crate::usage::TokenUsage;
     use crate::ToolError;
@@ -1093,6 +1256,180 @@ mod tests {
     }
 
     #[test]
+    fn applies_tool_side_effects_to_follow_up_requests() {
+        struct RecordingApiClient {
+            call_count: usize,
+        }
+
+        impl ApiClient for RecordingApiClient {
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.call_count += 1;
+                match self.call_count {
+                    1 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "skill".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    2 => {
+                        assert_eq!(request.model_override.as_deref(), Some("claude-sonnet-4-6"),);
+                        assert_eq!(request.reasoning_effort.as_deref(), Some("high"));
+                        let last_message = request.messages.last().expect("injected prompt");
+                        assert_eq!(last_message.role, MessageRole::User);
+                        assert_eq!(
+                            last_message.attachment_metadata.as_ref().map(|m| m.kind),
+                            Some(AttachmentKind::InvokedSkills),
+                        );
+                        assert!(matches!(
+                            last_message.blocks.first(),
+                            Some(ContentBlock::Text { text }) if text == "Injected skill prompt"
+                        ));
+                        Ok(vec![
+                            AssistantEvent::TextDelta("continued".to_string()),
+                            AssistantEvent::MessageStop,
+                        ])
+                    }
+                    _ => unreachable!("extra API call"),
+                }
+            }
+        }
+
+        let tool_executor = StaticToolExecutor::new().register("skill", |_input| {
+            Ok(ToolExecutionResult::text("launched")
+                .with_additional_messages(vec![ConversationMessage::attachment_user_text(
+                    "Injected skill prompt",
+                    AttachmentKind::InvokedSkills,
+                )])
+                .with_invoked_skill(InvokedSkill {
+                    skill: "trace".to_string(),
+                    resolved_name: Some("trace".to_string()),
+                    path: Some("C:\\repo\\.agents\\skills\\trace\\SKILL.md".to_string()),
+                    description: Some("Trace skill".to_string()),
+                    args: None,
+                    prompt: "Injected skill prompt".to_string(),
+                })
+                .with_context_update(ToolContextUpdate {
+                    model_override: Some("claude-sonnet-4-6".to_string()),
+                    reasoning_effort: Some("high".to_string()),
+                    additional_allow_rules: Vec::new(),
+                }))
+        });
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            RecordingApiClient { call_count: 0 },
+            tool_executor,
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+        );
+
+        let summary = runtime
+            .run_turn("run skill", None)
+            .expect("conversation loop should succeed");
+
+        assert_eq!(summary.tool_results.len(), 1);
+        assert_eq!(runtime.session().messages.len(), 5);
+        assert_eq!(
+            runtime.session().messages[3]
+                .attachment_metadata
+                .as_ref()
+                .map(|m| m.kind),
+            Some(AttachmentKind::InvokedSkills),
+        );
+        assert_eq!(runtime.session().invoked_skills.len(), 1);
+        assert_eq!(runtime.session().invoked_skills[0].skill, "trace");
+    }
+
+    #[test]
+    fn transient_allow_rules_enable_follow_up_tool_calls() {
+        struct RecordingApiClient {
+            call_count: usize,
+        }
+
+        impl ApiClient for RecordingApiClient {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.call_count += 1;
+                match self.call_count {
+                    1 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "skill".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    2 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-2".to_string(),
+                            name: "bash".to_string(),
+                            input: r#"{"command":"git status"}"#.to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    3 => Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => unreachable!("extra API call"),
+                }
+            }
+        }
+
+        let tool_executor = StaticToolExecutor::new()
+            .register("skill", |_input| {
+                Ok(ToolExecutionResult::text("launched")
+                    .with_additional_messages(vec![ConversationMessage::attachment_user_text(
+                        "Skill prompt",
+                        AttachmentKind::InvokedSkills,
+                    )])
+                    .with_invoked_skill(InvokedSkill {
+                        skill: "trace".to_string(),
+                        resolved_name: Some("trace".to_string()),
+                        path: Some("C:\\repo\\.agents\\skills\\trace\\SKILL.md".to_string()),
+                        description: Some("Trace skill".to_string()),
+                        args: None,
+                        prompt: "Skill prompt".to_string(),
+                    })
+                    .with_context_update(ToolContextUpdate {
+                        model_override: None,
+                        reasoning_effort: None,
+                        additional_allow_rules: vec!["bash(git:*)".to_string()],
+                    }))
+            })
+            .register("bash", |_input| Ok("git output".to_string()));
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            RecordingApiClient { call_count: 0 },
+            tool_executor,
+            PermissionPolicy::new(PermissionMode::ReadOnly)
+                .with_tool_requirement("skill", PermissionMode::ReadOnly)
+                .with_tool_requirement("bash", PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+        );
+
+        let summary = runtime
+            .run_turn("run skill", None)
+            .expect("conversation loop should succeed");
+
+        assert_eq!(summary.tool_results.len(), 2);
+        assert!(matches!(
+            summary.tool_results[1].blocks.first(),
+            Some(ContentBlock::ToolResult {
+                tool_name,
+                output,
+                is_error: false,
+                ..
+            }) if tool_name == "bash" && output == "git output"
+        ));
+    }
+
+    #[test]
     fn records_runtime_session_trace_events() {
         let sink = Arc::new(MemoryTelemetrySink::default());
         let tracer = SessionTracer::new("session-runtime", sink.clone());
@@ -1123,6 +1460,92 @@ mod tests {
         assert!(trace_names.contains(&"tool_execution_started"));
         assert!(trace_names.contains(&"tool_execution_finished"));
         assert!(trace_names.contains(&"turn_completed"));
+    }
+
+    #[test]
+    fn exposes_session_snapshot_during_tool_execution() {
+        struct SnapshotApi {
+            call_count: usize,
+        }
+
+        impl ApiClient for SnapshotApi {
+            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.call_count += 1;
+                match self.call_count {
+                    1 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "snapshot".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    2 => {
+                        assert!(request
+                            .messages
+                            .iter()
+                            .any(|message| message.role == MessageRole::Tool));
+                        Ok(vec![
+                            AssistantEvent::TextDelta("done".to_string()),
+                            AssistantEvent::MessageStop,
+                        ])
+                    }
+                    _ => Err(RuntimeError::new("unexpected extra API call")),
+                }
+            }
+        }
+
+        struct SnapshotTool;
+
+        impl ToolExecutor for SnapshotTool {
+            fn execute(
+                &mut self,
+                tool_name: &str,
+                _input: &str,
+            ) -> Result<ToolExecutionResult, ToolError> {
+                assert_eq!(tool_name, "snapshot");
+                let summary = current_tool_session_compaction_summary();
+                assert_eq!(summary.as_deref(), Some("Older compact summary"));
+
+                let messages = current_tool_session_messages().expect("session snapshot");
+                assert!(messages.iter().any(|message| {
+                    message.role == MessageRole::User
+                        && message.blocks.iter().any(|block| {
+                            matches!(block, ContentBlock::Text { text } if text == "check snapshot")
+                        })
+                }));
+                assert!(messages.iter().any(|message| {
+                    message.role == MessageRole::Assistant
+                        && message.blocks.iter().any(|block| {
+                            matches!(
+                                block,
+                                ContentBlock::ToolUse { name, .. } if name == "snapshot"
+                            )
+                        })
+                }));
+
+                Ok(ToolExecutionResult::text("ok"))
+            }
+        }
+
+        let mut session = Session::new();
+        session.compaction = Some(SessionCompaction {
+            count: 1,
+            removed_message_count: 3,
+            summary: "Older compact summary".to_string(),
+        });
+
+        let mut runtime = ConversationRuntime::new(
+            session,
+            SnapshotApi { call_count: 0 },
+            SnapshotTool,
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+        );
+
+        runtime
+            .run_turn("check snapshot", None)
+            .expect("conversation loop should succeed");
     }
 
     #[test]
@@ -1208,7 +1631,7 @@ mod tests {
         let mut runtime = ConversationRuntime::new_with_features(
             Session::new(),
             SingleCallApiClient,
-            StaticToolExecutor::new().register("blocked", |_input| {
+            StaticToolExecutor::new().register("blocked", |_input| -> Result<String, ToolError> {
                 panic!("tool should not execute when hook denies")
             }),
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
@@ -1271,7 +1694,7 @@ mod tests {
         let mut runtime = ConversationRuntime::new_with_features(
             Session::new(),
             SingleCallApiClient,
-            StaticToolExecutor::new().register("blocked", |_input| {
+            StaticToolExecutor::new().register("blocked", |_input| -> Result<String, ToolError> {
                 panic!("tool should not execute when hook fails")
             }),
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
@@ -1422,8 +1845,9 @@ mod tests {
         let mut runtime = ConversationRuntime::new_with_features(
             Session::new(),
             TwoCallApiClient { calls: 0 },
-            StaticToolExecutor::new()
-                .register("fail", |_input| Err(ToolError::new("tool exploded"))),
+            StaticToolExecutor::new().register("fail", |_input| -> Result<String, ToolError> {
+                Err(ToolError::new("tool exploded"))
+            }),
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
             vec!["system".to_string()],
             &RuntimeFeatureConfig::default().with_hooks(RuntimeHookConfig::new(

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -82,8 +82,8 @@ pub use context::{
 };
 pub use conversation::{
     auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent, AutoCompactionEvent,
-    ConversationRuntime, PromptCacheEvent, RuntimeError, StaticToolExecutor, ToolError,
-    ToolExecutor, TurnSummary,
+    ConversationRuntime, PromptCacheEvent, RuntimeError, StaticToolExecutor, ToolContextUpdate,
+    ToolError, ToolExecutionResult, ToolExecutor, TurnSummary,
 };
 pub use file_ops::{
     edit_file, glob_search, grep_search, read_file, resolve_tool_path,
@@ -161,8 +161,8 @@ pub use sandbox::{
 pub use session::{
     AttachmentKind, AttachmentMetadata, CompactBoundaryMetadata, CompactPreservedSegment,
     CompactTrigger, ContentBlock, ConversationMessage, HookResultEvent, HookResultMetadata,
-    MessageRole, Session, SessionCompaction, SessionError, SessionFork, SessionPromptEntry,
-    SystemMessageSubtype,
+    InvokedSkill, MessageRole, Session, SessionCompaction, SessionError, SessionFork,
+    SessionPromptEntry, SystemMessageSubtype,
 };
 pub use sse::{IncrementalSseParser, SseEvent};
 pub use stale_base::{
@@ -175,6 +175,10 @@ pub use stale_branch::{
 };
 pub use task_packet::{validate_packet, TaskPacket, TaskPacketValidationError, ValidatedPacket};
 pub use tool_output::{tool_output_root, tool_result_path, tool_results_dir};
+pub use tool_session::{
+    current_tool_session_compaction_summary, current_tool_session_messages,
+    with_tool_session_snapshot,
+};
 #[cfg(test)]
 pub use trust_resolver::{TrustConfig, TrustDecision, TrustEvent, TrustPolicy, TrustResolver};
 pub use usage::{

--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -37,6 +37,7 @@ pub enum PermissionOverride {
 pub struct PermissionContext {
     override_decision: Option<PermissionOverride>,
     override_reason: Option<String>,
+    additional_allow_rules: Vec<String>,
 }
 
 impl PermissionContext {
@@ -48,6 +49,7 @@ impl PermissionContext {
         Self {
             override_decision,
             override_reason,
+            additional_allow_rules: Vec::new(),
         }
     }
 
@@ -59,6 +61,17 @@ impl PermissionContext {
     #[must_use]
     pub fn override_reason(&self) -> Option<&str> {
         self.override_reason.as_deref()
+    }
+
+    #[must_use]
+    pub fn with_additional_allow_rules(mut self, additional_allow_rules: Vec<String>) -> Self {
+        self.additional_allow_rules = additional_allow_rules;
+        self
+    }
+
+    #[must_use]
+    pub fn additional_allow_rules(&self) -> &[String] {
+        &self.additional_allow_rules
     }
 }
 
@@ -184,6 +197,8 @@ impl PermissionPolicy {
         let required_mode = self.required_mode_for(tool_name);
         let ask_rule = Self::find_matching_rule(&self.ask_rules, tool_name, input);
         let allow_rule = Self::find_matching_rule(&self.allow_rules, tool_name, input);
+        let contextual_allow_rule =
+            Self::find_matching_raw_rule(context.additional_allow_rules(), tool_name, input);
 
         match context.override_decision() {
             Some(PermissionOverride::Deny) => {
@@ -224,6 +239,7 @@ impl PermissionPolicy {
                     );
                 }
                 if allow_rule.is_some()
+                    || contextual_allow_rule.is_some()
                     || current_mode == PermissionMode::Allow
                     || current_mode >= required_mode
                 {
@@ -249,6 +265,7 @@ impl PermissionPolicy {
         }
 
         if allow_rule.is_some()
+            || contextual_allow_rule.is_some()
             || current_mode == PermissionMode::Allow
             || current_mode >= required_mode
         {
@@ -321,6 +338,13 @@ impl PermissionPolicy {
         input: &str,
     ) -> Option<&'a PermissionRule> {
         rules.iter().find(|rule| rule.matches(tool_name, input))
+    }
+
+    fn find_matching_raw_rule(rules: &[String], tool_name: &str, input: &str) -> Option<String> {
+        rules
+            .iter()
+            .find(|rule| PermissionRule::parse(rule).matches(tool_name, input))
+            .cloned()
     }
 }
 

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -131,6 +131,16 @@ pub struct SessionPromptEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvokedSkill {
+    pub skill: String,
+    pub resolved_name: Option<String>,
+    pub path: Option<String>,
+    pub description: Option<String>,
+    pub args: Option<String>,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionPersistence {
     path: PathBuf,
 }
@@ -154,6 +164,7 @@ pub struct Session {
     pub fork: Option<SessionFork>,
     pub workspace_root: Option<PathBuf>,
     pub prompt_history: Vec<SessionPromptEntry>,
+    pub invoked_skills: Vec<InvokedSkill>,
     persistence: Option<SessionPersistence>,
 }
 
@@ -168,6 +179,7 @@ impl PartialEq for Session {
             && self.fork == other.fork
             && self.workspace_root == other.workspace_root
             && self.prompt_history == other.prompt_history
+            && self.invoked_skills == other.invoked_skills
     }
 }
 
@@ -218,6 +230,7 @@ impl Session {
             fork: None,
             workspace_root: None,
             prompt_history: Vec::new(),
+            invoked_skills: Vec::new(),
             persistence: None,
         }
     }
@@ -304,6 +317,27 @@ impl Session {
         });
     }
 
+    pub fn upsert_invoked_skill(
+        &mut self,
+        invoked_skill: InvokedSkill,
+    ) -> Result<(), SessionError> {
+        let previous_updated_at_ms = self.updated_at_ms;
+        let previous_invoked_skills = self.invoked_skills.clone();
+        self.touch();
+        upsert_invoked_skill_entry(&mut self.invoked_skills, invoked_skill);
+
+        let persistence_path = self.persistence_path().map(Path::to_path_buf);
+        if let Some(path) = persistence_path {
+            if let Err(error) = self.save_to_path(path) {
+                self.updated_at_ms = previous_updated_at_ms;
+                self.invoked_skills = previous_invoked_skills;
+                return Err(error);
+            }
+        }
+
+        Ok(())
+    }
+
     #[must_use]
     pub fn fork(&self, branch_name: Option<String>) -> Self {
         let now = current_time_millis();
@@ -320,6 +354,7 @@ impl Session {
             }),
             workspace_root: self.workspace_root.clone(),
             prompt_history: self.prompt_history.clone(),
+            invoked_skills: self.invoked_skills.clone(),
             persistence: None,
         }
     }
@@ -370,6 +405,17 @@ impl Session {
                     self.prompt_history
                         .iter()
                         .map(SessionPromptEntry::to_jsonl_record)
+                        .collect(),
+                ),
+            );
+        }
+        if !self.invoked_skills.is_empty() {
+            object.insert(
+                "invoked_skills".to_string(),
+                JsonValue::Array(
+                    self.invoked_skills
+                        .iter()
+                        .map(InvokedSkill::to_json)
                         .collect(),
                 ),
             );
@@ -428,6 +474,11 @@ impl Session {
                     .collect()
             })
             .unwrap_or_default();
+        let invoked_skills = object
+            .get("invoked_skills")
+            .map(invoked_skills_from_json)
+            .transpose()?
+            .unwrap_or_default();
         Ok(Self {
             version,
             session_id,
@@ -438,6 +489,7 @@ impl Session {
             fork,
             workspace_root,
             prompt_history,
+            invoked_skills,
             persistence: None,
         })
     }
@@ -452,6 +504,7 @@ impl Session {
         let mut fork = None;
         let mut workspace_root = None;
         let mut prompt_history = Vec::new();
+        let mut invoked_skills = Vec::new();
 
         for (line_number, raw_line) in contents.lines().enumerate() {
             let line = raw_line.trim();
@@ -490,6 +543,9 @@ impl Session {
                         .get("workspace_root")
                         .and_then(JsonValue::as_str)
                         .map(PathBuf::from);
+                    if let Some(value) = object.get("invoked_skills") {
+                        invoked_skills = invoked_skills_from_json(value)?;
+                    }
                 }
                 "message" => {
                     let message_value = object.get("message").ok_or_else(|| {
@@ -532,6 +588,7 @@ impl Session {
             fork,
             workspace_root,
             prompt_history,
+            invoked_skills,
             persistence: None,
         })
     }
@@ -635,6 +692,17 @@ impl Session {
             object.insert(
                 "workspace_root".to_string(),
                 JsonValue::String(workspace_root_to_string(workspace_root)?),
+            );
+        }
+        if !self.invoked_skills.is_empty() {
+            object.insert(
+                "invoked_skills".to_string(),
+                JsonValue::Array(
+                    self.invoked_skills
+                        .iter()
+                        .map(InvokedSkill::to_json)
+                        .collect(),
+                ),
             );
         }
         Ok(JsonValue::Object(object))
@@ -1445,6 +1513,67 @@ impl SessionPromptEntry {
     }
 }
 
+impl InvokedSkill {
+    fn identity_key(&self) -> &str {
+        self.resolved_name.as_deref().unwrap_or(self.skill.as_str())
+    }
+
+    fn to_json(&self) -> JsonValue {
+        let mut object = BTreeMap::new();
+        object.insert("skill".to_string(), JsonValue::String(self.skill.clone()));
+        if let Some(resolved_name) = &self.resolved_name {
+            object.insert(
+                "resolved_name".to_string(),
+                JsonValue::String(resolved_name.clone()),
+            );
+        }
+        if let Some(path) = &self.path {
+            object.insert("path".to_string(), JsonValue::String(path.clone()));
+        }
+        if let Some(description) = &self.description {
+            object.insert(
+                "description".to_string(),
+                JsonValue::String(description.clone()),
+            );
+        }
+        if let Some(args) = &self.args {
+            object.insert("args".to_string(), JsonValue::String(args.clone()));
+        }
+        object.insert("prompt".to_string(), JsonValue::String(self.prompt.clone()));
+        JsonValue::Object(object)
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, SessionError> {
+        let object = value
+            .as_object()
+            .ok_or_else(|| SessionError::Format("invoked skill must be an object".to_string()))?;
+        Ok(Self {
+            skill: required_string(object, "skill")?,
+            resolved_name: object
+                .get("resolved_name")
+                .and_then(JsonValue::as_str)
+                .map(ToOwned::to_owned)
+                .and_then(|value| normalize_optional_string(Some(value))),
+            path: object
+                .get("path")
+                .and_then(JsonValue::as_str)
+                .map(ToOwned::to_owned)
+                .and_then(|value| normalize_optional_string(Some(value))),
+            description: object
+                .get("description")
+                .and_then(JsonValue::as_str)
+                .map(ToOwned::to_owned)
+                .and_then(|value| normalize_optional_string(Some(value))),
+            args: object
+                .get("args")
+                .and_then(JsonValue::as_str)
+                .map(ToOwned::to_owned)
+                .and_then(|value| normalize_optional_string(Some(value))),
+            prompt: required_string(object, "prompt")?,
+        })
+    }
+}
+
 fn message_record(message: &ConversationMessage) -> JsonValue {
     let mut object = BTreeMap::new();
     object.insert("type".to_string(), JsonValue::String("message".to_string()));
@@ -1554,6 +1683,28 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
             Some(trimmed.to_string())
         }
     })
+}
+
+fn invoked_skills_from_json(value: &JsonValue) -> Result<Vec<InvokedSkill>, SessionError> {
+    value
+        .as_array()
+        .ok_or_else(|| SessionError::Format("invoked_skills must be an array".to_string()))?
+        .iter()
+        .map(InvokedSkill::from_json)
+        .collect()
+}
+
+fn upsert_invoked_skill_entry(invoked_skills: &mut Vec<InvokedSkill>, invoked_skill: InvokedSkill) {
+    if let Some(existing) = invoked_skills.iter_mut().find(|existing| {
+        existing
+            .identity_key()
+            .eq_ignore_ascii_case(invoked_skill.identity_key())
+    }) {
+        *existing = invoked_skill;
+        return;
+    }
+
+    invoked_skills.push(invoked_skill);
 }
 
 fn current_time_millis() -> u64 {
@@ -1703,7 +1854,7 @@ mod tests {
     use super::{
         cleanup_rotated_logs, current_time_millis, rotate_session_file_if_needed, AttachmentKind,
         CompactBoundaryMetadata, CompactPreservedSegment, CompactTrigger, ContentBlock,
-        ConversationMessage, HookResultEvent, MessageRole, Session, SessionFork,
+        ConversationMessage, HookResultEvent, InvokedSkill, MessageRole, Session, SessionFork,
         SystemMessageSubtype,
     };
     use crate::json::JsonValue;
@@ -1866,6 +2017,40 @@ mod tests {
             [ContentBlock::Text { text }] if text == "hi"
         ));
         assert!(!restored.messages[0].uuid.is_empty());
+    }
+
+    #[test]
+    fn persists_invoked_skills_in_session_metadata() {
+        let path = temp_session_path("invoked-skills");
+        let mut session = Session::new().with_persistence_path(path.clone());
+        session
+            .push_user_text("run trace")
+            .expect("message should append");
+        session
+            .upsert_invoked_skill(InvokedSkill {
+                skill: "trace".to_string(),
+                resolved_name: Some("trace".to_string()),
+                path: Some("C:\\repo\\.agents\\skills\\trace\\SKILL.md".to_string()),
+                description: Some("Trace helper".to_string()),
+                args: Some("full".to_string()),
+                prompt: "# trace\nFollow the traces\n".to_string(),
+            })
+            .expect("invoked skill should persist");
+
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        assert_eq!(restored.invoked_skills.len(), 1);
+        assert_eq!(restored.invoked_skills[0].skill, "trace");
+        assert_eq!(
+            restored.invoked_skills[0].resolved_name.as_deref(),
+            Some("trace")
+        );
+        assert_eq!(restored.invoked_skills[0].args.as_deref(), Some("full"));
+        assert!(restored.invoked_skills[0]
+            .prompt
+            .contains("Follow the traces"));
+        assert_eq!(restored.messages.len(), 1);
     }
 
     #[test]

--- a/rust/crates/runtime/src/tool_session.rs
+++ b/rust/crates/runtime/src/tool_session.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
+use crate::session::ConversationMessage;
 use crate::session_control::SessionStore;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,8 +10,15 @@ pub(crate) struct ToolSessionContext {
     persistence_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolSessionSnapshot {
+    messages: Vec<ConversationMessage>,
+    compaction_summary: Option<String>,
+}
+
 thread_local! {
     static CURRENT_TOOL_SESSION_CONTEXT: RefCell<Option<ToolSessionContext>> = const { RefCell::new(None) };
+    static CURRENT_TOOL_SESSION_SNAPSHOT: RefCell<Option<ToolSessionSnapshot>> = const { RefCell::new(None) };
 }
 
 pub(crate) fn with_tool_session_context<R>(
@@ -40,11 +48,56 @@ pub(crate) fn with_tool_session_context<R>(
     action()
 }
 
+pub fn with_tool_session_snapshot<R>(
+    messages: &[ConversationMessage],
+    compaction_summary: Option<&str>,
+    action: impl FnOnce() -> R,
+) -> R {
+    struct ResetGuard {
+        previous: Option<ToolSessionSnapshot>,
+    }
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            CURRENT_TOOL_SESSION_SNAPSHOT.with(|slot| {
+                *slot.borrow_mut() = self.previous.take();
+            });
+        }
+    }
+
+    let previous = CURRENT_TOOL_SESSION_SNAPSHOT.with(|slot| {
+        slot.replace(Some(ToolSessionSnapshot {
+            messages: messages.to_vec(),
+            compaction_summary: compaction_summary.map(ToOwned::to_owned),
+        }))
+    });
+    let _guard = ResetGuard { previous };
+    action()
+}
+
 pub(crate) fn current_tool_session_storage_root(cwd: &Path) -> Option<PathBuf> {
     CURRENT_TOOL_SESSION_CONTEXT.with(|slot| {
         slot.borrow()
             .as_ref()
             .and_then(|context| derive_tool_session_storage_root(context, cwd))
+    })
+}
+
+#[must_use]
+pub fn current_tool_session_messages() -> Option<Vec<ConversationMessage>> {
+    CURRENT_TOOL_SESSION_SNAPSHOT.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|snapshot| snapshot.messages.clone())
+    })
+}
+
+#[must_use]
+pub fn current_tool_session_compaction_summary() -> Option<String> {
+    CURRENT_TOOL_SESSION_SNAPSHOT.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .and_then(|snapshot| snapshot.compaction_summary.clone())
     })
 }
 
@@ -60,7 +113,11 @@ fn derive_tool_session_storage_root(context: &ToolSessionContext, cwd: &Path) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{current_tool_session_storage_root, with_tool_session_context};
+    use super::{
+        current_tool_session_compaction_summary, current_tool_session_messages,
+        current_tool_session_storage_root, with_tool_session_context, with_tool_session_snapshot,
+    };
+    use crate::session::ConversationMessage;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -102,5 +159,26 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn exposes_snapshot_messages_and_compaction_summary_inside_scope() {
+        let messages = vec![
+            ConversationMessage::user_text("hello"),
+            ConversationMessage::assistant(vec![]),
+        ];
+
+        let (snapshot_messages, summary) =
+            with_tool_session_snapshot(&messages, Some("Older session summary"), || {
+                (
+                    current_tool_session_messages().expect("messages snapshot"),
+                    current_tool_session_compaction_summary(),
+                )
+            });
+
+        assert_eq!(snapshot_messages, messages);
+        assert_eq!(summary.as_deref(), Some("Older session summary"));
+        assert!(current_tool_session_messages().is_none());
+        assert!(current_tool_session_compaction_summary().is_none());
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -52,13 +52,14 @@ use runtime::{
     McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest,
     OAuthConfig, OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, ProjectContext,
     PromptCacheEvent, ResolvedPermissionMode, RuntimeConfig, RuntimeError, RuntimeProviderConfig,
-    RuntimeProviderKind, Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
+    RuntimeProviderKind, Session, TokenUsage, ToolError, ToolExecutionResult, ToolExecutor,
+    UsageTracker,
 };
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tools::{
-    execute_tool, model_visible_tool_result, mvp_tool_specs, GlobalToolRegistry,
-    RuntimeToolDefinition, ToolSearchOutput,
+    execute_tool, execute_tool_with_effects, model_visible_tool_result, mvp_tool_specs,
+    GlobalToolRegistry, RuntimeToolDefinition, ToolSearchOutput,
 };
 
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
@@ -7246,6 +7247,26 @@ impl AnthropicRuntimeClient {
             progress_reporter,
         })
     }
+
+    fn provider_client_for_model(&self, model: &str) -> Result<ProviderClient, RuntimeError> {
+        let cwd = env::current_dir().map_err(|error| RuntimeError::new(error.to_string()))?;
+        let runtime_config = load_runtime_config_for_cwd(&cwd).map_err(|error| {
+            RuntimeError::new(format!(
+                "failed to load runtime config for model override: {error}"
+            ))
+        })?;
+        let provider_override = runtime_config
+            .provider()
+            .map(provider_override_from_runtime_config);
+        let oauth = runtime_config.oauth().cloned();
+        ProviderClient::from_model_with_anthropic_auth_resolver(
+            model,
+            provider_override.as_ref(),
+            || resolve_cli_auth_source(oauth.as_ref()),
+        )
+        .map(|client| client.with_prompt_cache(PromptCache::new(&self.session_id)))
+        .map_err(|error| RuntimeError::new(error.to_string()))
+    }
 }
 
 fn resolve_cli_auth_source(oauth: Option<&OAuthConfig>) -> Result<AuthSource, api::ApiError> {
@@ -7305,16 +7326,28 @@ impl ApiClient for AnthropicRuntimeClient {
         }
         let is_post_tool = request_ends_with_tool_result(&request);
         let allow_tools = self.enable_tools && request.allow_tools;
+        let effective_model = request
+            .model_override
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
         let message_request = MessageRequest {
-            model: self.model.clone(),
-            max_tokens: max_tokens_for_model(&self.model),
+            model: effective_model.clone(),
+            max_tokens: max_tokens_for_model(&effective_model),
             messages: convert_messages(&request.messages),
             system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
             tools: allow_tools
                 .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref())),
             tool_choice: allow_tools.then_some(ToolChoice::Auto),
+            reasoning_effort: request.reasoning_effort.clone(),
             stream: true,
             ..Default::default()
+        };
+        let override_client;
+        let client = if request.model_override.is_some() {
+            override_client = self.provider_client_for_model(&effective_model)?;
+            &override_client
+        } else {
+            &self.client
         };
 
         self.runtime.block_on(async {
@@ -7326,7 +7359,7 @@ impl ApiClient for AnthropicRuntimeClient {
 
             for attempt in 1..=max_attempts {
                 let result = self
-                    .consume_stream(&message_request, is_post_tool && attempt == 1)
+                    .consume_stream(client, &message_request, is_post_tool && attempt == 1)
                     .await;
                 match result {
                     Ok(events) => return Ok(events),
@@ -7352,11 +7385,11 @@ impl AnthropicRuntimeClient {
     #[allow(clippy::too_many_lines)]
     async fn consume_stream(
         &self,
+        client: &ProviderClient,
         message_request: &MessageRequest,
         apply_stall_timeout: bool,
     ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-        let mut stream = self
-            .client
+        let mut stream = client
             .stream_message(message_request)
             .await
             .map_err(|error| {
@@ -7483,7 +7516,7 @@ impl AnthropicRuntimeClient {
             }
         }
 
-        push_prompt_cache_record(&self.client, &mut events);
+        push_prompt_cache_record(client, &mut events);
 
         if !saw_stop
             && events.iter().any(|event| {
@@ -7501,8 +7534,7 @@ impl AnthropicRuntimeClient {
             return Ok(events);
         }
 
-        let response = self
-            .client
+        let response = client
             .send_message(&MessageRequest {
                 stream: false,
                 ..message_request.clone()
@@ -7512,7 +7544,7 @@ impl AnthropicRuntimeClient {
                 RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
             })?;
         let mut events = response_to_events(response, out)?;
-        push_prompt_cache_record(&self.client, &mut events);
+        push_prompt_cache_record(client, &mut events);
         Ok(events)
     }
 }
@@ -8395,7 +8427,7 @@ impl CliToolExecutor {
 }
 
 impl ToolExecutor for CliToolExecutor {
-    fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+    fn execute(&mut self, tool_name: &str, input: &str) -> Result<ToolExecutionResult, ToolError> {
         let resolved_tool_name = strip_tool_call_prefix(tool_name);
         if self
             .allowed_tools
@@ -8410,17 +8442,25 @@ impl ToolExecutor for CliToolExecutor {
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
         let result = if resolved_tool_name == "ToolSearch" {
             self.execute_search_tool(value)
+                .map(ToolExecutionResult::text)
         } else if self.tool_registry.has_runtime_tool(resolved_tool_name) {
             self.execute_runtime_tool(resolved_tool_name, value)
+                .map(ToolExecutionResult::text)
+        } else if mvp_tool_specs()
+            .iter()
+            .any(|spec| spec.name == resolved_tool_name)
+        {
+            execute_tool_with_effects(resolved_tool_name, &value).map_err(ToolError::new)
         } else {
             self.tool_registry
                 .execute(resolved_tool_name, &value)
+                .map(ToolExecutionResult::text)
                 .map_err(ToolError::new)
         };
         match result {
             Ok(output) => {
                 if self.emit_output {
-                    let markdown = format_tool_result(resolved_tool_name, &output, false);
+                    let markdown = format_tool_result(resolved_tool_name, &output.output, false);
                     self.renderer
                         .stream_markdown(&markdown, &mut io::stdout())
                         .map_err(|error| ToolError::new(error.to_string()))?;
@@ -12249,7 +12289,7 @@ UU conflicted.rs",
             .execute("mcp__alpha__echo", r#"{"text":"hello"}"#)
             .expect("discovered mcp tool should execute");
         let tool_json: serde_json::Value =
-            serde_json::from_str(&tool_output).expect("tool output should be json");
+            serde_json::from_str(&tool_output.output).expect("tool output should be json");
         assert_eq!(tool_json["structuredContent"]["echoed"], "hello");
 
         let wrapped_output = executor
@@ -12259,14 +12299,14 @@ UU conflicted.rs",
             )
             .expect("generic mcp wrapper should execute");
         let wrapped_json: serde_json::Value =
-            serde_json::from_str(&wrapped_output).expect("wrapped output should be json");
+            serde_json::from_str(&wrapped_output.output).expect("wrapped output should be json");
         assert_eq!(wrapped_json["structuredContent"]["echoed"], "wrapped");
 
         let search_output = executor
             .execute("ToolSearch", r#"{"query":"alpha echo","max_results":5}"#)
             .expect("tool search should execute");
         let search_json: serde_json::Value =
-            serde_json::from_str(&search_output).expect("search output should be json");
+            serde_json::from_str(&search_output.output).expect("search output should be json");
         assert_eq!(search_json["matches"][0], "mcp__alpha__echo");
         assert_eq!(search_json["pending_mcp_servers"][0], "broken");
         assert_eq!(
@@ -12286,7 +12326,7 @@ UU conflicted.rs",
             .execute("ListMcpResourcesTool", r#"{"server":"alpha"}"#)
             .expect("resources should list");
         let listed_json: serde_json::Value =
-            serde_json::from_str(&listed).expect("resource output should be json");
+            serde_json::from_str(&listed.output).expect("resource output should be json");
         assert_eq!(listed_json["resources"][0]["uri"], "file://guide.txt");
 
         let read = executor
@@ -12296,7 +12336,7 @@ UU conflicted.rs",
             )
             .expect("resource should read");
         let read_json: serde_json::Value =
-            serde_json::from_str(&read).expect("resource read output should be json");
+            serde_json::from_str(&read.output).expect("resource read output should be json");
         assert_eq!(
             read_json["contents"][0]["text"],
             "contents for file://guide.txt"
@@ -12347,7 +12387,7 @@ UU conflicted.rs",
             .execute("ToolSearch", r#"{"query":"remote","max_results":5}"#)
             .expect("tool search should execute");
         let search_json: serde_json::Value =
-            serde_json::from_str(&search_output).expect("search output should be json");
+            serde_json::from_str(&search_output.output).expect("search output should be json");
         assert_eq!(search_json["pending_mcp_servers"][0], "remote");
         assert_eq!(
             search_json["mcp_degraded"]["failed_servers"][0]["server_name"],
@@ -12382,7 +12422,7 @@ UU conflicted.rs",
             )
             .expect("prefixed tool call name should be allow-listed");
         let json: serde_json::Value =
-            serde_json::from_str(&output).expect("tool search output should be valid json");
+            serde_json::from_str(&output.output).expect("tool search output should be valid json");
         assert!(json["query"].is_string());
     }
 

--- a/rust/crates/tools/src/file_tools.rs
+++ b/rust/crates/tools/src/file_tools.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
 
+use commands::activate_conditional_skills_for_paths;
 use runtime::{
     resolve_tool_path, resolve_tool_path_allow_missing, tool_output_root, EditFileOutput,
     ReadFileOutput, TextFilePayload, WriteFileOutput,
@@ -134,6 +135,13 @@ fn with_context_state_map<R>(action: impl FnOnce(&mut ContextStateMap) -> R) -> 
     Ok(action(context_states))
 }
 
+fn activate_skills_for_path(path: &Path) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    activate_conditional_skills_for_paths(&[path.to_path_buf()], &cwd)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
 fn get_state_for_path(path: &Path) -> Result<Option<FileToolState>, String> {
     let normalized_path = normalize_state_path(path);
     with_context_state_map(|states| states.get(&normalized_path).cloned())
@@ -201,6 +209,7 @@ pub(crate) fn prepare_read(
     limit: Option<usize>,
 ) -> Result<PreparedRead, String> {
     let normalized_path = resolve_tool_path(path).map_err(|error| error.to_string())?;
+    activate_skills_for_path(&normalized_path)?;
     let requested_offset = offset.unwrap_or(1);
 
     let dedup_output = get_state_for_path(&normalized_path)?.and_then(|state| {
@@ -256,6 +265,7 @@ pub(crate) fn record_read_result(
 pub(crate) fn prepare_write(path: &str) -> Result<PreparedWrite, String> {
     let normalized_path =
         resolve_tool_path_allow_missing(path).map_err(|error| error.to_string())?;
+    activate_skills_for_path(&normalized_path)?;
     if !normalized_path.exists() {
         return Ok(PreparedWrite { normalized_path });
     }
@@ -296,6 +306,7 @@ pub(crate) fn prepare_edit(
 
     let normalized_path =
         resolve_tool_path_allow_missing(path).map_err(|error| error.to_string())?;
+    activate_skills_for_path(&normalized_path)?;
     let file_exists = normalized_path.exists();
 
     if !file_exists {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7575,7 +7575,6 @@ mod tests {
     #[test]
     fn worker_create_merges_config_trusted_roots_without_per_call_override() {
         let _guard = env_guard();
-        use std::fs;
         // Write a .claw/settings.json in a temp dir with trustedRoots
         let worktree = temp_path("config-trust-worktree");
         let claw_dir = worktree.join(".claw");
@@ -7754,7 +7753,6 @@ mod tests {
         let _guard = env_guard();
         // End-to-end proof: .claw/worker-state.json reflects every transition
         // through the stall-detect -> resolve-trust -> ready loop.
-        use std::fs;
 
         // Use a real temp CWD so state file can be written
         let worktree = temp_path("recovery-loop-state");
@@ -9004,6 +9002,7 @@ mod tests {
         fs::create_dir_all(&root).expect("root dir should exist");
         let original_dir = std::env::current_dir().expect("cwd");
         std::env::set_current_dir(&root).expect("set cwd");
+        let active_cwd = std::env::current_dir().expect("active cwd");
 
         let result = execute_tool(
             "Skill",
@@ -9017,7 +9016,7 @@ mod tests {
         let output: serde_json::Value = serde_json::from_str(&result).expect("valid json");
         assert_eq!(output["path"], "bundled://verify");
         let prompt = output["prompt"].as_str().expect("prompt");
-        let expected_root = tool_output_root(&root).join("skills").join("verify");
+        let expected_root = tool_output_root(&active_cwd).join("skills").join("verify");
         let expected_root_text = expected_root.display().to_string();
         assert!(prompt.contains(&format!(
             "Base directory for this skill: {expected_root_text}"

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -24,15 +24,16 @@ use runtime::{
     summary_compression::compress_summary_text,
     task_registry::TaskRegistry,
     team_cron_registry::{CronRegistry, TeamRegistry},
-    tool_result_path,
+    tool_output_root, tool_result_path,
     worker_boot::{WorkerReadySnapshot, WorkerRegistry, WorkerTaskReceipt},
-    write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, BashCommandOutput,
-    BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage, ConversationRuntime,
-    GlobSearchOutput, GrepSearchInput, GrepSearchOutput, LaneCommitProvenance, LaneEvent,
-    LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport,
-    MessageRole, OAuthConfig, PermissionMode, PermissionPolicy, PromptCacheEvent,
-    ProviderFallbackConfig, RuntimeConfig, RuntimeError, RuntimeProviderConfig,
-    RuntimeProviderKind, Session, TaskPacket, ToolError, ToolExecutor,
+    write_file, ApiClient, ApiRequest, AssistantEvent, AttachmentKind, BashCommandInput,
+    BashCommandOutput, BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage,
+    ConversationRuntime, GlobSearchOutput, GrepSearchInput, GrepSearchOutput, InvokedSkill,
+    LaneCommitProvenance, LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus,
+    LaneFailureClass, McpDegradedReport, MessageRole, OAuthConfig, PermissionMode,
+    PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig, RuntimeConfig, RuntimeError,
+    RuntimeProviderConfig, RuntimeProviderKind, Session, TaskPacket, ToolContextUpdate, ToolError,
+    ToolExecutionResult, ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -1212,6 +1213,13 @@ pub fn enforce_permission_check(
 
 pub fn execute_tool(name: &str, input: &Value) -> Result<String, String> {
     execute_tool_with_enforcer(None, name, input)
+}
+
+pub fn execute_tool_with_effects(name: &str, input: &Value) -> Result<ToolExecutionResult, String> {
+    match name {
+        "Skill" => from_value::<SkillInput>(input).and_then(execute_skill_tool_result),
+        _ => execute_tool(name, input).map(ToolExecutionResult::text),
+    }
 }
 
 fn execute_tool_with_enforcer(
@@ -2576,13 +2584,85 @@ struct TodoWriteOutput {
     verification_nudge_needed: Option<bool>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct SkillOutput {
     skill: String,
     path: String,
     args: Option<String>,
     description: Option<String>,
     prompt: String,
+    metadata: SkillMetadataOutput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(rename = "agentId", skip_serializing_if = "Option::is_none")]
+    agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ExecutedSkill {
+    output: SkillOutput,
+    prompt: String,
+    invoked_skill: InvokedSkill,
+    allowed_tools: Vec<String>,
+    model: Option<String>,
+    effort: Option<String>,
+    execution_context: Option<commands::SkillExecutionContext>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedSkillExecution {
+    document: commands::SkillDocument,
+    prompt: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SkillMetadataOutput {
+    #[serde(rename = "resolvedName")]
+    resolved_name: String,
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+    description: String,
+    #[serde(rename = "hasUserSpecifiedDescription")]
+    has_user_specified_description: bool,
+    #[serde(
+        rename = "allowedTools",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    allowed_tools: Vec<String>,
+    #[serde(rename = "argumentHint", skip_serializing_if = "Option::is_none")]
+    argument_hint: Option<String>,
+    #[serde(
+        rename = "argumentNames",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    argument_names: Vec<String>,
+    #[serde(rename = "whenToUse", skip_serializing_if = "Option::is_none")]
+    when_to_use: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(rename = "disableModelInvocation")]
+    disable_model_invocation: bool,
+    #[serde(rename = "userInvocable")]
+    user_invocable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hooks: Option<Value>,
+    #[serde(rename = "executionContext", skip_serializing_if = "Option::is_none")]
+    execution_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shell: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2621,6 +2701,22 @@ struct AgentJob {
     prompt: String,
     system_prompt: Vec<String>,
     allowed_tools: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ForkedSkillRequest {
+    name: String,
+    description: String,
+    prompt: String,
+    subagent_type: String,
+    model: Option<String>,
+    allowed_tools: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ForkedSkillExecutionResult {
+    agent_id: String,
+    result: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -3180,17 +3276,310 @@ fn execute_todo_write(input: TodoWriteInput) -> Result<TodoWriteOutput, String> 
 }
 
 fn execute_skill(input: SkillInput) -> Result<SkillOutput, String> {
-    let skill_path = resolve_skill_path(&input.skill)?;
-    let prompt = std::fs::read_to_string(&skill_path).map_err(|error| error.to_string())?;
-    let description = parse_skill_description(&prompt);
+    Ok(execute_skill_with_fork_runner(input, execute_forked_skill)?.output)
+}
 
-    Ok(SkillOutput {
+fn execute_skill_with_fork_runner<F>(
+    input: SkillInput,
+    fork_runner: F,
+) -> Result<ExecutedSkill, String>
+where
+    F: FnOnce(ForkedSkillRequest) -> Result<ForkedSkillExecutionResult, String>,
+{
+    let resolved = resolve_skill_for_execution(&input.skill, input.args.as_deref())?;
+    let document = resolved.document;
+    if document.disable_model_invocation {
+        return Err(format!(
+            "Skill {} cannot be used with Skill tool due to disable-model-invocation",
+            document.resolved_name
+        ));
+    }
+    let prompt = resolved.prompt;
+    let description = Some(document.description.clone());
+    let metadata = skill_metadata_output(document.clone());
+    let invoked_skill = InvokedSkill {
+        skill: input.skill.clone(),
+        resolved_name: Some(document.resolved_name.clone()),
+        path: Some(resolved.path.clone()),
+        description: description.clone(),
+        args: input.args.clone(),
+        prompt: prompt.clone(),
+    };
+
+    let mut output = SkillOutput {
         skill: input.skill,
-        path: skill_path.display().to_string(),
+        path: resolved.path,
         args: input.args,
         description,
+        prompt: prompt.clone(),
+        metadata,
+        status: None,
+        agent_id: None,
+        result: None,
+    };
+
+    if document.execution_context == Some(commands::SkillExecutionContext::Fork) {
+        let forked = fork_runner(build_forked_skill_request(&document, &prompt))?;
+        output.status = Some(String::from("forked"));
+        output.agent_id = Some(forked.agent_id);
+        output.result = Some(forked.result);
+    }
+
+    Ok(ExecutedSkill {
+        output,
         prompt,
+        invoked_skill,
+        allowed_tools: document.allowed_tools,
+        model: document.model,
+        effort: document.effort,
+        execution_context: document.execution_context,
     })
+}
+
+fn resolve_skill_for_execution(
+    skill: &str,
+    args: Option<&str>,
+) -> Result<ResolvedSkillExecution, String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    match commands::resolve_skill(&cwd, skill) {
+        Ok(skill) => resolve_primary_skill_for_execution(&cwd, skill, args),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            resolve_compat_skill_for_execution(skill, args)
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn resolve_primary_skill_for_execution(
+    cwd: &Path,
+    skill: commands::ResolvedSkill,
+    args: Option<&str>,
+) -> Result<ResolvedSkillExecution, String> {
+    let prompt_body = commands::render_resolved_skill_prompt(&skill, args);
+    match skill.source {
+        commands::ResolvedSkillSource::Filesystem { path } => {
+            let prompt = prepend_skill_base_directory(&prompt_body, path.parent());
+            Ok(ResolvedSkillExecution {
+                document: skill.document,
+                prompt,
+                path: path.display().to_string(),
+            })
+        }
+        commands::ResolvedSkillSource::Bundled { .. } => {
+            let reference_files = commands::resolved_skill_reference_files(&skill);
+            let prompt = if reference_files.is_empty() {
+                prompt_body
+            } else {
+                let base_dir = materialize_bundled_skill_files(
+                    cwd,
+                    skill.document.resolved_name.as_str(),
+                    &reference_files,
+                )?;
+                prepend_skill_base_directory(&prompt_body, Some(base_dir.as_path()))
+            };
+            Ok(ResolvedSkillExecution {
+                path: format!("bundled://{}", skill.document.resolved_name),
+                document: skill.document,
+                prompt,
+            })
+        }
+    }
+}
+
+fn resolve_compat_skill_for_execution(
+    skill: &str,
+    args: Option<&str>,
+) -> Result<ResolvedSkillExecution, String> {
+    let skill_path = resolve_skill_path_from_compat_roots(skill)?;
+    let document =
+        commands::load_skill_document(&skill_path, "Skill").map_err(|error| error.to_string())?;
+    let prompt_body = document.render_markdown_with_arguments(args);
+    let prompt = prepend_skill_base_directory(&prompt_body, skill_path.parent());
+    Ok(ResolvedSkillExecution {
+        document,
+        prompt,
+        path: skill_path.display().to_string(),
+    })
+}
+
+fn prepend_skill_base_directory(prompt: &str, base_dir: Option<&Path>) -> String {
+    match base_dir {
+        Some(base_dir) => format!(
+            "Base directory for this skill: {}\n\n{}",
+            base_dir.display(),
+            prompt
+        ),
+        None => prompt.to_string(),
+    }
+}
+
+fn materialize_bundled_skill_files(
+    cwd: &Path,
+    skill_name: &str,
+    files: &BTreeMap<String, String>,
+) -> Result<PathBuf, String> {
+    let base_dir = tool_output_root(cwd)
+        .join("skills")
+        .join(sanitize_bundled_skill_storage_name(skill_name));
+    fs::create_dir_all(&base_dir).map_err(|error| error.to_string())?;
+
+    for (relative_path, content) in files {
+        let target = resolve_bundled_skill_file_path(&base_dir, relative_path)?;
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        fs::write(&target, content).map_err(|error| error.to_string())?;
+    }
+
+    Ok(base_dir)
+}
+
+fn sanitize_bundled_skill_storage_name(name: &str) -> String {
+    let sanitized = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        String::from("skill")
+    } else {
+        sanitized
+    }
+}
+
+fn resolve_bundled_skill_file_path(
+    base_dir: &Path,
+    relative_path: &str,
+) -> Result<PathBuf, String> {
+    let relative = Path::new(relative_path);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(format!(
+            "bundled skill file path escapes skill dir: {relative_path}"
+        ));
+    }
+    Ok(base_dir.join(relative))
+}
+
+fn execute_skill_tool_result(input: SkillInput) -> Result<ToolExecutionResult, String> {
+    let executed = execute_skill_with_fork_runner(input, execute_forked_skill)?;
+    let output = to_pretty_json(executed.output.clone())?;
+    if executed.execution_context == Some(commands::SkillExecutionContext::Fork) {
+        return Ok(ToolExecutionResult::text(output).with_invoked_skill(executed.invoked_skill));
+    }
+
+    let context_update = ToolContextUpdate {
+        additional_allow_rules: executed.allowed_tools,
+        model_override: executed.model,
+        reasoning_effort: executed.effort,
+    };
+    let additional_messages = vec![ConversationMessage::attachment_user_text(
+        executed.prompt,
+        AttachmentKind::InvokedSkills,
+    )];
+
+    let result = ToolExecutionResult::text(output)
+        .with_additional_messages(additional_messages)
+        .with_invoked_skill(executed.invoked_skill);
+    if context_update.additional_allow_rules.is_empty()
+        && context_update.model_override.is_none()
+        && context_update.reasoning_effort.is_none()
+    {
+        Ok(result)
+    } else {
+        Ok(result.with_context_update(context_update))
+    }
+}
+
+fn build_forked_skill_request(
+    document: &commands::SkillDocument,
+    prompt: &str,
+) -> ForkedSkillRequest {
+    let subagent_type = normalize_subagent_type(document.agent.as_deref());
+    let allowed_tools = normalized_skill_allowed_tools(&document.allowed_tools)
+        .unwrap_or_else(|| allowed_tools_for_subagent(&subagent_type));
+
+    ForkedSkillRequest {
+        name: document.resolved_name.clone(),
+        description: format!("Execute skill {}", document.resolved_name),
+        prompt: prompt.to_string(),
+        subagent_type,
+        model: document.model.clone(),
+        allowed_tools,
+    }
+}
+
+fn normalized_skill_allowed_tools(raw_tools: &[String]) -> Option<BTreeSet<String>> {
+    let registry = GlobalToolRegistry::builtin();
+    let mut allowed = BTreeSet::new();
+
+    for raw_tool in raw_tools {
+        let base_name = raw_tool
+            .split_once('(')
+            .map_or(raw_tool.as_str(), |(head, _)| head)
+            .trim();
+        if base_name.is_empty() {
+            continue;
+        }
+        if let Ok(Some(normalized)) = registry.normalize_allowed_tools(&[base_name.to_string()]) {
+            allowed.extend(normalized);
+        }
+    }
+
+    (!allowed.is_empty()).then_some(allowed)
+}
+
+fn execute_forked_skill(request: ForkedSkillRequest) -> Result<ForkedSkillExecutionResult, String> {
+    let job = prepare_agent_job(
+        request.description,
+        request.prompt,
+        Some(request.subagent_type.as_str()),
+        Some(request.name.as_str()),
+        request.model.as_deref(),
+        Some(request.allowed_tools),
+    )?;
+    let result = run_agent_job(&job).inspect_err(|error| {
+        let _ = persist_agent_terminal_state(&job.manifest, "failed", None, Some(error.clone()));
+    })?;
+
+    Ok(ForkedSkillExecutionResult {
+        agent_id: job.manifest.agent_id.clone(),
+        result,
+    })
+}
+
+fn skill_metadata_output(document: commands::SkillDocument) -> SkillMetadataOutput {
+    SkillMetadataOutput {
+        resolved_name: document.resolved_name,
+        display_name: document.display_name,
+        description: document.description,
+        has_user_specified_description: document.has_user_specified_description,
+        allowed_tools: document.allowed_tools,
+        argument_hint: document.argument_hint,
+        argument_names: document.argument_names,
+        when_to_use: document.when_to_use,
+        version: document.version,
+        model: document.model,
+        disable_model_invocation: document.disable_model_invocation,
+        user_invocable: document.user_invocable,
+        hooks: document.hooks,
+        execution_context: document
+            .execution_context
+            .map(commands::SkillExecutionContext::as_str)
+            .map(ToString::to_string),
+        agent: document.agent,
+        effort: document.effort,
+        paths: document.paths,
+        shell: document.shell,
+    }
 }
 
 fn validate_todos(todos: &[TodoItem]) -> Result<(), String> {
@@ -3215,21 +3604,13 @@ fn todo_store_path() -> Result<std::path::PathBuf, String> {
     Ok(cwd.join(".clawd-todos.json"))
 }
 
-fn resolve_skill_path(skill: &str) -> Result<std::path::PathBuf, String> {
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
-    match commands::resolve_skill_path(&cwd, skill) {
-        Ok(path) => Ok(path),
-        Err(_) => resolve_skill_path_from_compat_roots(skill),
-    }
-}
-
 fn resolve_skill_path_from_compat_roots(skill: &str) -> Result<std::path::PathBuf, String> {
     let requested = skill.trim().trim_start_matches('/').trim_start_matches('$');
     if requested.is_empty() {
         return Err(String::from("skill must not be empty"));
     }
 
-    for root in skill_lookup_roots() {
+    for root in compat_skill_lookup_roots() {
         if let Some(path) = resolve_skill_path_in_root(&root, requested) {
             return Ok(path);
         }
@@ -3250,21 +3631,15 @@ struct SkillLookupRoot {
     origin: SkillLookupOrigin,
 }
 
-fn skill_lookup_roots() -> Vec<SkillLookupRoot> {
+fn compat_skill_lookup_roots() -> Vec<SkillLookupRoot> {
     let mut roots = Vec::new();
 
     if let Ok(cwd) = std::env::current_dir() {
-        push_project_skill_lookup_roots(&mut roots, &cwd);
+        push_project_compat_skill_lookup_roots(&mut roots, &cwd);
     }
 
-    if let Ok(claw_config_home) = std::env::var("CLAW_CONFIG_HOME") {
-        push_prefixed_skill_lookup_roots(&mut roots, std::path::Path::new(&claw_config_home));
-    }
-    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
-        push_prefixed_skill_lookup_roots(&mut roots, std::path::Path::new(&codex_home));
-    }
     if let Ok(home) = std::env::var("HOME") {
-        push_home_skill_lookup_roots(&mut roots, std::path::Path::new(&home));
+        push_home_compat_skill_lookup_roots(&mut roots, std::path::Path::new(&home));
     }
     if let Ok(claude_config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         let claude_config_dir = std::path::PathBuf::from(claude_config_dir);
@@ -3298,21 +3673,15 @@ fn skill_lookup_roots() -> Vec<SkillLookupRoot> {
     roots
 }
 
-fn push_project_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, cwd: &std::path::Path) {
+fn push_project_compat_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, cwd: &std::path::Path) {
     for ancestor in cwd.ancestors() {
         push_prefixed_skill_lookup_roots(roots, &ancestor.join(".omc"));
         push_prefixed_skill_lookup_roots(roots, &ancestor.join(".agents"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".claw"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".codex"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".claude"));
     }
 }
 
-fn push_home_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, home: &std::path::Path) {
+fn push_home_compat_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, home: &std::path::Path) {
     push_prefixed_skill_lookup_roots(roots, &home.join(".omc"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".claw"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".codex"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".claude"));
     push_skill_lookup_root(
         roots,
         home.join(".agents").join("skills"),
@@ -3443,37 +3812,8 @@ fn resolve_skill_path_in_legacy_commands_dir(
 fn skill_frontmatter_name_matches(path: &std::path::Path, requested: &str) -> bool {
     std::fs::read_to_string(path)
         .ok()
-        .and_then(|contents| parse_skill_name(&contents))
+        .and_then(|contents| commands::extract_skill_frontmatter_name(&contents))
         .is_some_and(|name| name.eq_ignore_ascii_case(requested))
-}
-
-fn parse_skill_name(contents: &str) -> Option<String> {
-    parse_skill_frontmatter_value(contents, "name")
-}
-
-fn parse_skill_frontmatter_value(contents: &str, key: &str) -> Option<String> {
-    let mut lines = contents.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return None;
-    }
-
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break;
-        }
-        if let Some(value) = trimmed.strip_prefix(&format!("{key}:")) {
-            let value = value
-                .trim()
-                .trim_matches(|ch| matches!(ch, '"' | '\''))
-                .trim();
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-
-    None
 }
 
 const DEFAULT_AGENT_MODEL: &str = "claude-opus-4-6";
@@ -3488,10 +3828,36 @@ fn execute_agent_with_spawn<F>(input: AgentInput, spawn_fn: F) -> Result<AgentOu
 where
     F: FnOnce(AgentJob) -> Result<(), String>,
 {
-    if input.description.trim().is_empty() {
+    let job = prepare_agent_job(
+        input.description,
+        input.prompt,
+        input.subagent_type.as_deref(),
+        input.name.as_deref(),
+        input.model.as_deref(),
+        None,
+    )?;
+    let manifest = job.manifest.clone();
+    if let Err(error) = spawn_fn(job) {
+        let error = format!("failed to spawn sub-agent: {error}");
+        persist_agent_terminal_state(&manifest, "failed", None, Some(error.clone()))?;
+        return Err(error);
+    }
+
+    Ok(manifest)
+}
+
+fn prepare_agent_job(
+    description: String,
+    prompt: String,
+    subagent_type: Option<&str>,
+    name: Option<&str>,
+    model: Option<&str>,
+    allowed_tools_override: Option<BTreeSet<String>>,
+) -> Result<AgentJob, String> {
+    if description.trim().is_empty() {
         return Err(String::from("description must not be empty"));
     }
-    if input.prompt.trim().is_empty() {
+    if prompt.trim().is_empty() {
         return Err(String::from("prompt must not be empty"));
     }
 
@@ -3500,41 +3866,39 @@ where
     std::fs::create_dir_all(&output_dir).map_err(|error| error.to_string())?;
     let output_file = output_dir.join(format!("{agent_id}.md"));
     let manifest_file = output_dir.join(format!("{agent_id}.json"));
-    let normalized_subagent_type = normalize_subagent_type(input.subagent_type.as_deref());
-    let model = resolve_agent_model(input.model.as_deref());
-    let agent_name = input
-        .name
-        .as_deref()
+    let normalized_subagent_type = normalize_subagent_type(subagent_type);
+    let resolved_model = resolve_agent_model(model);
+    let agent_name = name
         .map(slugify_agent_name)
         .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| slugify_agent_name(&input.description));
+        .unwrap_or_else(|| slugify_agent_name(&description));
     let created_at = iso8601_now();
     let system_prompt = build_agent_system_prompt(&normalized_subagent_type)?;
-    let allowed_tools = allowed_tools_for_subagent(&normalized_subagent_type);
+    let allowed_tools = allowed_tools_override
+        .unwrap_or_else(|| allowed_tools_for_subagent(&normalized_subagent_type));
 
     let output_contents = format!(
         "# Agent Task
 
-- id: {}
-- name: {}
-- description: {}
-- subagent_type: {}
-- created_at: {}
+- id: {agent_id}
+- name: {agent_name}
+- description: {description}
+- subagent_type: {normalized_subagent_type}
+- created_at: {created_at}
 
 ## Prompt
 
-{}
-",
-        agent_id, agent_name, input.description, normalized_subagent_type, created_at, input.prompt
+{prompt}
+"
     );
     std::fs::write(&output_file, output_contents).map_err(|error| error.to_string())?;
 
     let manifest = AgentOutput {
         agent_id,
         name: agent_name,
-        description: input.description,
+        description,
         subagent_type: Some(normalized_subagent_type),
-        model: Some(model),
+        model: Some(resolved_model),
         status: String::from("running"),
         output_file: output_file.display().to_string(),
         manifest_file: manifest_file.display().to_string(),
@@ -3548,20 +3912,12 @@ where
     };
     write_agent_manifest(&manifest)?;
 
-    let manifest_for_spawn = manifest.clone();
-    let job = AgentJob {
-        manifest: manifest_for_spawn,
-        prompt: input.prompt,
+    Ok(AgentJob {
+        manifest,
+        prompt,
         system_prompt,
         allowed_tools,
-    };
-    if let Err(error) = spawn_fn(job) {
-        let error = format!("failed to spawn sub-agent: {error}");
-        persist_agent_terminal_state(&manifest, "failed", None, Some(error.clone()))?;
-        return Err(error);
-    }
-
-    Ok(manifest)
+    })
 }
 
 fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
@@ -3572,7 +3928,7 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
             let result =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_agent_job(&job)));
             match result {
-                Ok(Ok(())) => {}
+                Ok(Ok(_)) => {}
                 Ok(Err(error)) => {
                     let _ =
                         persist_agent_terminal_state(&job.manifest, "failed", None, Some(error));
@@ -3591,13 +3947,14 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
-fn run_agent_job(job: &AgentJob) -> Result<(), String> {
+fn run_agent_job(job: &AgentJob) -> Result<String, String> {
     let mut runtime = build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
     let summary = runtime
         .run_turn(job.prompt.clone(), None)
         .map_err(|error| error.to_string())?;
     let final_text = final_assistant_text(&summary);
-    persist_agent_terminal_state(&job.manifest, "completed", Some(final_text.as_str()), None)
+    persist_agent_terminal_state(&job.manifest, "completed", Some(final_text.as_str()), None)?;
+    Ok(final_text)
 }
 
 fn build_agent_runtime(
@@ -3991,25 +4348,36 @@ impl ProviderRuntimeClient {
         fallback_config: &ProviderFallbackConfig,
         runtime_config: &RuntimeConfig,
     ) -> Result<Self, String> {
-        let primary_model = fallback_config.primary().map_or(model, str::to_string);
-        let primary = build_provider_entry(&primary_model, runtime_config)?;
-        let mut chain = vec![primary];
-        for fallback_model in fallback_config.fallbacks() {
-            match build_provider_entry(fallback_model, runtime_config) {
-                Ok(entry) => chain.push(entry),
-                Err(error) => {
-                    eprintln!(
-                        "warning: skipping unavailable fallback provider {fallback_model}: {error}"
-                    );
-                }
-            }
-        }
+        let chain = build_provider_chain(&model, fallback_config, runtime_config)?;
         Ok(Self {
             runtime: tokio::runtime::Runtime::new().map_err(|error| error.to_string())?,
             chain,
             allowed_tools,
         })
     }
+}
+
+fn build_provider_chain(
+    model: &str,
+    fallback_config: &ProviderFallbackConfig,
+    runtime_config: &RuntimeConfig,
+) -> Result<Vec<ProviderEntry>, String> {
+    let primary_model = fallback_config
+        .primary()
+        .map_or_else(|| model.to_string(), str::to_string);
+    let primary = build_provider_entry(&primary_model, runtime_config)?;
+    let mut chain = vec![primary];
+    for fallback_model in fallback_config.fallbacks() {
+        match build_provider_entry(fallback_model, runtime_config) {
+            Ok(entry) => chain.push(entry),
+            Err(error) => {
+                eprintln!(
+                    "warning: skipping unavailable fallback provider {fallback_model}: {error}"
+                );
+            }
+        }
+    }
+    Ok(chain)
 }
 
 fn load_runtime_config_for_cwd() -> Result<RuntimeConfig, runtime::ConfigError> {
@@ -4071,7 +4439,18 @@ impl ApiClient for ProviderRuntimeClient {
         let tool_choice = (!self.allowed_tools.is_empty()).then_some(ToolChoice::Auto);
 
         let runtime = &self.runtime;
-        let chain = &self.chain;
+        let runtime_config =
+            load_runtime_config_for_cwd().unwrap_or_else(|_| RuntimeConfig::empty());
+        let fallback_config = runtime_config.provider_fallbacks().clone();
+        let override_chain;
+        let chain = if let Some(model_override) = request.model_override.as_deref() {
+            override_chain =
+                build_provider_chain(model_override, &fallback_config, &runtime_config)
+                    .map_err(RuntimeError::new)?;
+            &override_chain
+        } else {
+            &self.chain
+        };
         let mut last_error: Option<ApiError> = None;
         for (index, entry) in chain.iter().enumerate() {
             let message_request = MessageRequest {
@@ -4081,6 +4460,7 @@ impl ApiClient for ProviderRuntimeClient {
                 system: system.clone(),
                 tools: (!tools.is_empty()).then(|| tools.clone()),
                 tool_choice: tool_choice.clone(),
+                reasoning_effort: request.reasoning_effort.clone(),
                 stream: true,
                 ..Default::default()
             };
@@ -4210,7 +4590,7 @@ impl SubagentToolExecutor {
 }
 
 impl ToolExecutor for SubagentToolExecutor {
-    fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+    fn execute(&mut self, tool_name: &str, input: &str) -> Result<ToolExecutionResult, ToolError> {
         if !self.allowed_tools.contains(tool_name) {
             return Err(ToolError::new(format!(
                 "tool `{tool_name}` is not enabled for this sub-agent"
@@ -4218,8 +4598,16 @@ impl ToolExecutor for SubagentToolExecutor {
         }
         let value = serde_json::from_str(input)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-        execute_tool_with_enforcer(self.enforcer.as_ref(), tool_name, &value)
-            .map_err(ToolError::new)
+        match tool_name {
+            "Skill" => execute_skill_tool_result(
+                serde_json::from_value(value)
+                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?,
+            )
+            .map_err(ToolError::new),
+            _ => execute_tool_with_enforcer(self.enforcer.as_ref(), tool_name, &value)
+                .map(ToolExecutionResult::text)
+                .map_err(ToolError::new),
+        }
     }
 }
 
@@ -4269,6 +4657,14 @@ fn model_visible_tool_result_with_id(
     output: &str,
     is_error: bool,
 ) -> ModelVisibleToolResult {
+    if tool_name == "Skill" {
+        if let Some((skill_output, trailing_text)) = parse_skill_tool_result(output) {
+            let mut result = skill_tool_result_to_model_visible_result(&skill_output, is_error);
+            append_trailing_tool_text(&mut result.content, trailing_text);
+            return result;
+        }
+    }
+
     if let Some((read_output, trailing_text)) = parse_read_tool_result_for_tool(tool_name, output) {
         let mut result =
             ModelVisibleToolResult::raw_text(&read_tool_result_text(&read_output), is_error);
@@ -4305,6 +4701,43 @@ fn model_visible_tool_result_with_id(
     }
 
     ModelVisibleToolResult::raw_text(output, is_error)
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillModelVisibleOutput {
+    skill: String,
+    status: Option<String>,
+    result: Option<String>,
+}
+
+fn parse_skill_tool_result(output: &str) -> Option<(SkillModelVisibleOutput, &str)> {
+    if let Ok(parsed) = serde_json::from_str::<SkillModelVisibleOutput>(output) {
+        return Some((parsed, ""));
+    }
+
+    let (json_prefix, trailing_text) = split_json_prefix(output)?;
+    let parsed = serde_json::from_str::<SkillModelVisibleOutput>(json_prefix).ok()?;
+    Some((parsed, trailing_text))
+}
+
+fn skill_tool_result_to_model_visible_result(
+    output: &SkillModelVisibleOutput,
+    is_error: bool,
+) -> ModelVisibleToolResult {
+    let text = if output.status.as_deref() == Some("forked") {
+        let result = output
+            .result
+            .as_deref()
+            .unwrap_or("Skill execution completed");
+        format!(
+            "Skill \"{}\" completed (forked execution).\n\nResult:\n{}",
+            output.skill, result
+        )
+    } else {
+        format!("Launching skill: {}", output.skill)
+    };
+
+    ModelVisibleToolResult::raw_text(&text, is_error)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6336,18 +6769,6 @@ fn make_cell_id(index: usize) -> String {
     format!("cell-{}", index + 1)
 }
 
-fn parse_skill_description(contents: &str) -> Option<String> {
-    for line in contents.lines() {
-        if let Some(value) = line.strip_prefix("description:") {
-            let trimmed = value.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
-}
-
 mod file_tools;
 pub mod lane_completion;
 pub mod pdf_extract;
@@ -6367,20 +6788,21 @@ mod tests {
 
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, classify_lane_failure,
-        derive_agent_state, execute_agent_with_spawn, execute_tool, final_assistant_text,
-        maybe_commit_provenance, model_visible_tool_result, model_visible_tool_result_with_id,
-        mvp_tool_specs, permission_mode_from_plugin, persist_agent_terminal_state,
-        push_output_block, run_task_packet, AgentInput, AgentJob, GlobalToolRegistry,
-        LaneEventName, LaneFailureClass, ModelVisibleToolResult, PowerShellCommandOutput,
-        ProviderRuntimeClient, SubagentToolExecutor,
+        derive_agent_state, execute_agent_with_spawn, execute_skill_with_fork_runner, execute_tool,
+        execute_tool_with_effects, final_assistant_text, maybe_commit_provenance,
+        model_visible_tool_result, model_visible_tool_result_with_id, mvp_tool_specs,
+        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
+        run_task_packet, AgentInput, AgentJob, ForkedSkillExecutionResult, ForkedSkillRequest,
+        GlobalToolRegistry, LaneEventName, LaneFailureClass, ModelVisibleToolResult,
+        PowerShellCommandOutput, ProviderRuntimeClient, SkillInput, SubagentToolExecutor,
     };
     use api::{OutputContentBlock, ToolResultContentBlock};
     #[cfg(windows)]
     use runtime::{bash_shell_path, set_shell_if_windows};
     use runtime::{
-        permission_enforcer::PermissionEnforcer, ApiRequest, AssistantEvent, BashCommandOutput,
-        ConversationRuntime, PermissionMode, PermissionPolicy, RuntimeError, Session, TaskPacket,
-        ToolExecutor,
+        permission_enforcer::PermissionEnforcer, tool_output_root, ApiRequest, AssistantEvent,
+        AttachmentKind, BashCommandOutput, ContentBlock, ConversationRuntime, PermissionMode,
+        PermissionPolicy, RuntimeError, Session, TaskPacket, ToolExecutor,
     };
     use runtime::{GlobSearchOutput, GrepSearchOutput, ProviderFallbackConfig};
     use serde_json::json;
@@ -6394,6 +6816,16 @@ mod tests {
         env_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn restore_cwd(original_dir: &Path) {
+        let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let target = if original_dir.is_dir() {
+            original_dir
+        } else {
+            fallback.as_path()
+        };
+        std::env::set_current_dir(target).expect("restore cwd");
     }
 
     fn windows_bash_smoke_ok() -> bool {
@@ -6583,6 +7015,58 @@ mod tests {
                     text: "not json".to_string(),
                 }],
                 is_error: true,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_inline_skill_results_like_ts() {
+        let output = serde_json::to_string_pretty(&json!({
+            "skill": "trace",
+            "path": "C:\\repo\\.agents\\skills\\trace\\SKILL.md",
+            "prompt": "# trace\n",
+            "metadata": {
+                "resolvedName": "trace",
+                "description": "trace",
+                "hasUserSpecifiedDescription": false,
+                "disableModelInvocation": false,
+                "userInvocable": true
+            }
+        }))
+        .expect("serialize skill result");
+
+        let result = model_visible_tool_result("Skill", &output, false);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "Launching skill: trace".to_string(),
+                }],
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn model_visible_tool_result_formats_forked_skill_results_like_ts() {
+        let output = serde_json::to_string_pretty(&json!({
+            "skill": "trace",
+            "status": "forked",
+            "agentId": "agent_123",
+            "result": "All checks passed"
+        }))
+        .expect("serialize forked skill result");
+
+        let result = model_visible_tool_result("Skill", &output, false);
+
+        assert_eq!(
+            result,
+            ModelVisibleToolResult {
+                content: vec![ToolResultContentBlock::Text {
+                    text: "Skill \"trace\" completed (forked execution).\n\nResult:\nAll checks passed".to_string(),
+                }],
+                is_error: false,
             }
         );
     }
@@ -6920,7 +7404,7 @@ mod tests {
         );
         assert!(!result.is_error);
 
-        std::env::set_current_dir(&restore_dir).expect("restore cwd");
+        restore_cwd(&restore_dir);
         let _ = fs::remove_dir_all(root);
     }
 
@@ -7124,7 +7608,7 @@ mod tests {
             "config-level trustedRoots should auto-resolve trust without per-call override"
         );
 
-        std::env::set_current_dir(original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         fs::remove_dir_all(&worktree).ok();
     }
 
@@ -7348,7 +7832,7 @@ mod tests {
             "is_ready must be true in state file at ready_for_prompt"
         );
 
-        std::env::set_current_dir(original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         fs::remove_dir_all(&worktree).ok();
     }
 
@@ -8099,10 +8583,17 @@ mod tests {
             .expect("path")
             .replace('\\', "/")
             .ends_with("/help/SKILL.md"));
+        assert_eq!(output["description"], "help");
         assert!(output["prompt"]
             .as_str()
             .expect("prompt")
             .contains("Guide on using oh-my-codex plugin"));
+        assert!(output["prompt"]
+            .as_str()
+            .expect("prompt")
+            .contains("ARGUMENTS: overview"));
+        assert_eq!(output["metadata"]["resolvedName"], "help");
+        assert_eq!(output["metadata"]["description"], "help");
 
         let dollar_result = execute_tool(
             "Skill",
@@ -8172,7 +8663,7 @@ mod tests {
             .replace('\\', "/")
             .ends_with(".claw/commands/handoff.md"));
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         fs::remove_dir_all(root).expect("temp project should clean up");
     }
 
@@ -8190,7 +8681,7 @@ mod tests {
         fs::create_dir_all(&nested).expect("nested cwd should exist");
         fs::write(
             skill_dir.join("SKILL.md"),
-            "---\nname: trace\ndescription: Project-local trace helper\n---\n# trace\n",
+            "---\nname: trace\ndescription: Project-local trace helper\narguments: [target]\nargument-hint: [target]\nallowed-tools: Bash, Read\neffort: high\n---\n# trace\n",
         )
         .expect("skill file should exist");
 
@@ -8213,8 +8704,18 @@ mod tests {
             .replace('\\', "/")
             .ends_with(".claude/skills/trace/SKILL.md"));
         assert_eq!(output["description"], "Project-local trace helper");
+        let prompt = output["prompt"].as_str().expect("prompt");
+        assert!(prompt.contains("Base directory for this skill: "));
+        assert!(prompt.ends_with("# trace\n"));
+        assert_eq!(output["metadata"]["argumentNames"][0], "target");
+        assert_eq!(output["metadata"]["argumentHint"], "target");
+        assert_eq!(output["metadata"]["allowedTools"][0], "Bash");
+        assert!(output["metadata"]["executionContext"].is_null());
+        assert!(output["metadata"]["agent"].is_null());
+        assert_eq!(output["metadata"]["effort"], "high");
+        assert!(output["metadata"]["paths"].is_null());
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
@@ -8228,6 +8729,356 @@ mod tests {
             None => std::env::remove_var("CODEX_HOME"),
         }
         fs::remove_dir_all(root).expect("temp tree should clean up");
+    }
+
+    #[test]
+    fn skill_tool_execution_result_injects_prompt_and_context_for_inline_skills() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = temp_path("skills-inline-effects-home");
+        let skill_dir = home.join(".agents").join("skills").join("trace");
+        fs::create_dir_all(&skill_dir).expect("skill dir should exist");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: trace\nallowed-tools: Bash(git:*), Read\nmodel: claude-sonnet-4-6\neffort: high\n---\n# trace\nFollow the traces\n",
+        )
+        .expect("skill file should exist");
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home);
+
+        let result = execute_tool_with_effects(
+            "Skill",
+            &json!({
+                "skill": "trace"
+            }),
+        )
+        .expect("Skill should succeed");
+
+        let output: serde_json::Value =
+            serde_json::from_str(&result.output).expect("valid skill output json");
+        assert_eq!(output["skill"], "trace");
+        assert_eq!(result.invoked_skills.len(), 1);
+        assert_eq!(result.invoked_skills[0].skill, "trace");
+        assert_eq!(
+            result.invoked_skills[0].resolved_name.as_deref(),
+            Some("trace")
+        );
+        assert_eq!(result.additional_messages.len(), 1);
+        assert_eq!(
+            result.additional_messages[0]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::InvokedSkills),
+        );
+        assert!(matches!(
+            result.additional_messages[0].blocks.first(),
+            Some(ContentBlock::Text { text })
+                if text.contains("Base directory for this skill: ")
+                    && text.ends_with("# trace\nFollow the traces\n")
+        ));
+        let context_update = result.context_update.expect("inline skill context update");
+        assert_eq!(
+            context_update.additional_allow_rules,
+            vec!["Bash(git:*)", "Read"]
+        );
+        assert_eq!(
+            context_update.model_override.as_deref(),
+            Some("claude-sonnet-4-6"),
+        );
+        assert_eq!(context_update.reasoning_effort.as_deref(), Some("high"));
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        fs::remove_dir_all(home).expect("temp home should clean up");
+    }
+
+    #[test]
+    fn skill_substitutes_named_and_indexed_arguments_in_prompt() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = temp_path("skills-substitution-home");
+        let skill_dir = home.join(".agents").join("skills").join("plan");
+        fs::create_dir_all(&skill_dir).expect("skill dir should exist");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\narguments: [topic, depth]\n---\nTopic: $topic\nFirst: $0\nSecond: $ARGUMENTS[1]\nRaw: $ARGUMENTS\n",
+        )
+        .expect("skill file should exist");
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home);
+
+        let result = execute_tool(
+            "Skill",
+            &json!({
+                "skill": "plan",
+                "args": "alpha \"two words\" tail"
+            }),
+        )
+        .expect("Skill should succeed");
+
+        let output: serde_json::Value = serde_json::from_str(&result).expect("valid json");
+        let prompt = output["prompt"].as_str().expect("prompt");
+        assert!(prompt.contains("Base directory for this skill: "));
+        assert!(prompt.contains("Topic: alpha"));
+        assert!(prompt.contains("First: alpha"));
+        assert!(prompt.contains("Second: two words"));
+        assert!(prompt.contains("Raw: alpha \"two words\" tail"));
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        fs::remove_dir_all(home).expect("temp home should clean up");
+    }
+
+    #[test]
+    fn forked_skill_executes_via_subagent_request() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = temp_path("skills-forked-home");
+        let skill_dir = home.join(".agents").join("skills").join("triage");
+        fs::create_dir_all(&skill_dir).expect("skill dir should exist");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: triage\ndescription: Triage the issue\narguments: [topic]\nallowed-tools: Read, Grep(Edit)\ncontext: fork\nagent: Explore\nmodel: claude-sonnet-4-6\n---\n# triage\nTopic: $topic\n",
+        )
+        .expect("skill file should exist");
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home);
+
+        let captured = Arc::new(Mutex::new(None::<ForkedSkillRequest>));
+        let captured_for_runner = Arc::clone(&captured);
+        let output = execute_skill_with_fork_runner(
+            SkillInput {
+                skill: "triage".to_string(),
+                args: Some("\"bug bash\"".to_string()),
+            },
+            move |request| {
+                *captured_for_runner
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(request);
+                Ok(ForkedSkillExecutionResult {
+                    agent_id: String::from("agent_skill_triage"),
+                    result: String::from("Triage complete"),
+                })
+            },
+        )
+        .expect("forked skill should succeed");
+
+        assert_eq!(output.output.status.as_deref(), Some("forked"));
+        assert_eq!(
+            output.output.agent_id.as_deref(),
+            Some("agent_skill_triage")
+        );
+        assert_eq!(output.output.result.as_deref(), Some("Triage complete"));
+        assert_eq!(
+            output.output.metadata.execution_context.as_deref(),
+            Some("fork")
+        );
+        assert_eq!(output.invoked_skill.skill, "triage");
+        assert_eq!(output.invoked_skill.args.as_deref(), Some("\"bug bash\""));
+        assert_eq!(
+            output.invoked_skill.resolved_name.as_deref(),
+            Some("triage")
+        );
+
+        let request = captured
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+            .expect("runner should capture request");
+        assert_eq!(request.name, "triage");
+        assert_eq!(request.subagent_type, "Explore");
+        assert_eq!(request.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert!(request.prompt.contains("Topic: bug bash"));
+        assert_eq!(
+            request.allowed_tools,
+            BTreeSet::from([String::from("read_file"), String::from("grep_search"),])
+        );
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        fs::remove_dir_all(home).expect("temp home should clean up");
+    }
+
+    #[test]
+    fn skill_rejects_disable_model_invocation_frontmatter() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = temp_path("skills-disabled-home");
+        let skill_dir = home.join(".agents").join("skills").join("internal");
+        fs::create_dir_all(&skill_dir).expect("skill dir should exist");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: internal\ndisable-model-invocation: true\n---\n# internal\n",
+        )
+        .expect("skill file should exist");
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home);
+
+        let error = execute_tool("Skill", &json!({ "skill": "internal" }))
+            .expect_err("disabled model invocation should be rejected");
+        assert!(error.contains("disable-model-invocation"));
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        fs::remove_dir_all(home).expect("temp home should clean up");
+    }
+
+    #[test]
+    fn read_file_activates_conditional_skill_visibility() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let root = temp_path("conditional-skill-activation");
+        let home = root.join("home");
+        let source_file = root.join("src").join("lib.rs");
+        let skill_dir = root.join(".claw").join("skills").join("rustacean");
+        fs::create_dir_all(
+            source_file
+                .parent()
+                .expect("source file should have parent"),
+        )
+        .expect("source dir should exist");
+        fs::create_dir_all(&skill_dir).expect("skill dir should exist");
+        fs::write(&source_file, "fn helper() {}\n").expect("write source file");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: rustacean\ndescription: Rust path guidance\npaths: src/**\n---\n\n# rustacean\n",
+        )
+        .expect("skill file should exist");
+
+        let original_home = std::env::var("HOME").ok();
+        let original_dir = std::env::current_dir().expect("cwd");
+        std::env::set_var("HOME", &home);
+        std::env::set_current_dir(&root).expect("set cwd");
+
+        let hidden = execute_tool("Skill", &json!({ "skill": "rustacean" }))
+            .expect_err("conditional skill should be hidden before file touch");
+        assert!(hidden.contains("unknown skill"));
+
+        execute_tool("read_file", &json!({ "path": "src/lib.rs" }))
+            .expect("read_file should activate conditional skills");
+
+        let activated = execute_tool("Skill", &json!({ "skill": "rustacean" }))
+            .expect("conditional skill should be visible after read");
+        let activated_output: serde_json::Value =
+            serde_json::from_str(&activated).expect("valid json");
+        assert_eq!(activated_output["metadata"]["paths"][0], "src");
+        let prompt = activated_output["prompt"].as_str().expect("prompt");
+        assert!(prompt.contains("Base directory for this skill: "));
+        assert!(prompt.ends_with("\n# rustacean\n"));
+
+        restore_cwd(&original_dir);
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        fs::remove_dir_all(root).expect("temp tree should clean up");
+    }
+
+    #[test]
+    fn bundled_skill_extracts_reference_files_under_tool_output_root() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let root = temp_path("bundled-skill-output");
+        fs::create_dir_all(&root).expect("root dir should exist");
+        let original_dir = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&root).expect("set cwd");
+
+        let result = execute_tool(
+            "Skill",
+            &json!({
+                "skill": "verify",
+                "args": "check the login flow"
+            }),
+        )
+        .expect("bundled verify should execute");
+
+        let output: serde_json::Value = serde_json::from_str(&result).expect("valid json");
+        assert_eq!(output["path"], "bundled://verify");
+        let prompt = output["prompt"].as_str().expect("prompt");
+        let expected_root = tool_output_root(&root).join("skills").join("verify");
+        let expected_root_text = expected_root.display().to_string();
+        assert!(prompt.contains(&format!(
+            "Base directory for this skill: {expected_root_text}"
+        )));
+        assert!(prompt.contains("## User Request\n\ncheck the login flow"));
+        assert!(expected_root.join("examples").join("cli.md").is_file());
+        assert!(expected_root.join("examples").join("server.md").is_file());
+
+        restore_cwd(&original_dir);
+        fs::remove_dir_all(root).expect("temp root should clean up");
+    }
+
+    #[test]
+    fn bundled_skillify_uses_session_snapshot_context() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let root = temp_path("bundled-skillify");
+        fs::create_dir_all(&root).expect("root dir should exist");
+        let original_dir = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&root).expect("set cwd");
+
+        let messages = vec![
+            runtime::ConversationMessage::user_text("older guidance"),
+            runtime::ConversationMessage::compact_boundary(runtime::CompactBoundaryMetadata {
+                trigger: runtime::CompactTrigger::Manual,
+                pre_tokens: 200,
+                user_context: None,
+                messages_summarized: Some(3),
+                pre_compact_discovered_tools: Vec::new(),
+                preserved_segment: None,
+            }),
+            runtime::ConversationMessage::compact_summary_user_text("summarized turn", false),
+            runtime::ConversationMessage::user_text("keep the repo-local save option"),
+        ];
+
+        let result = runtime::with_tool_session_snapshot(
+            &messages,
+            Some("Compacted workflow summary"),
+            || {
+                execute_tool(
+                    "Skill",
+                    &json!({
+                        "skill": "skillify",
+                        "args": "capture this repo workflow"
+                    }),
+                )
+            },
+        )
+        .expect("bundled skillify should execute");
+
+        let output: serde_json::Value = serde_json::from_str(&result).expect("valid json");
+        assert_eq!(output["path"], "bundled://skillify");
+        let prompt = output["prompt"].as_str().expect("prompt");
+        assert!(prompt.contains("Compacted workflow summary"));
+        assert!(prompt.contains("keep the repo-local save option"));
+        assert!(prompt.contains("capture this repo workflow"));
+        assert!(!prompt.contains("older guidance"));
+        assert!(!prompt.contains("summarized turn"));
+        assert!(!prompt.contains("Base directory for this skill: "));
+
+        restore_cwd(&original_dir);
+        fs::remove_dir_all(root).expect("temp root should clean up");
     }
 
     #[test]
@@ -8288,7 +9139,7 @@ mod tests {
             "Project-local agents compatibility helper"
         );
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
@@ -8476,7 +9327,7 @@ mod tests {
             .ends_with(".claude/commands/team.md"));
         assert_eq!(output["description"], "Legacy team workflow");
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
@@ -9229,7 +10080,7 @@ mod tests {
             "fix: unblock workspace tests"
         );
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -9263,7 +10114,7 @@ mod tests {
             "preflight_blocked:branch_divergence"
         );
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -9302,7 +10153,7 @@ mod tests {
             .contains("branch divergence detected before workspace tests"));
         assert!(output_json.get("structuredContent").is_none());
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -9572,7 +10423,7 @@ mod tests {
         .expect_err("invalid regex should fail");
         assert!(!grep_error.is_empty());
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         let _ = fs::remove_dir_all(root);
     }
 
@@ -9688,7 +10539,7 @@ mod tests {
         let unknown_output: serde_json::Value = serde_json::from_str(&unknown).expect("json");
         assert_eq!(unknown_output["success"], false);
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
@@ -9761,7 +10612,7 @@ mod tests {
             .join("plan-mode.json")
             .exists());
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
@@ -9822,7 +10673,7 @@ mod tests {
             .join("plan-mode.json")
             .exists());
 
-        std::env::set_current_dir(&original_dir).expect("restore cwd");
+        restore_cwd(&original_dir);
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7574,6 +7574,7 @@ mod tests {
 
     #[test]
     fn worker_create_merges_config_trusted_roots_without_per_call_override() {
+        let _guard = env_guard();
         use std::fs;
         // Write a .claw/settings.json in a temp dir with trustedRoots
         let worktree = temp_path("config-trust-worktree");
@@ -7750,6 +7751,7 @@ mod tests {
 
     #[test]
     fn recovery_loop_state_file_reflects_transitions() {
+        let _guard = env_guard();
         // End-to-end proof: .claw/worker-state.json reflects every transition
         // through the stall-detect -> resolve-trust -> ready loop.
         use std::fs;


### PR DESCRIPTION
## Summary
- port the TS-style full compact flow into Rust, including compact boundary + summary layout, preserved tail metadata, and resume/compact parity paths
- add a shared skill registry plus bundled skill execution plumbing, including `verify`, `remember`, `stuck`, and the new session-aware `skillify` bundled skill
- thread tool-session snapshots into skill execution, align transcript/message handling needed by the migrated paths, and harden tool tests around cwd restoration

## Why
Rust still had a few high-value TS parity gaps around full compaction and bundled skills. This change closes the biggest runtime-facing gaps so `/compact`, `--resume`, and bundled skill invocation behave much closer to the original TS implementation.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
