### PR TITLE
Add AppFS root skill listing and cwd overrides

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -16,11 +16,11 @@ use plugins::{
     PluginError, PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry, PluginSummary,
 };
 use runtime::{
-    load_system_prompt, tool_output_root, AssistantEvent, CompactionConfig, ConfigLoader,
-    ConfigSource, ConversationMessage, ConversationRuntime, McpOAuthConfig, McpServerConfig,
-    MessageRole, PermissionMode, PermissionPolicy, RuntimeConfig, RuntimeFeatureConfig,
-    RuntimeHookConfig, RuntimeProviderConfig, RuntimeProviderKind, ScopedMcpServerConfig, Session,
-    StaticToolExecutor,
+    detect_appfs_environment, load_system_prompt, tool_output_root, AssistantEvent,
+    CompactionConfig, ConfigLoader, ConfigSource, ConversationMessage, ConversationRuntime,
+    McpOAuthConfig, McpServerConfig, MessageRole, PermissionMode, PermissionPolicy, RuntimeConfig,
+    RuntimeFeatureConfig, RuntimeHookConfig, RuntimeProviderConfig, RuntimeProviderKind,
+    ScopedMcpServerConfig, Session, StaticToolExecutor,
 };
 use serde_json::{json, Value};
 
@@ -44,8 +44,16 @@ pub struct ResolvedSkill {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolvedSkillSource {
-    Filesystem { path: PathBuf },
-    Bundled { id: BundledSkillId },
+    Filesystem {
+        path: PathBuf,
+    },
+    Bundled {
+        id: BundledSkillId,
+    },
+    Generated {
+        id: String,
+        base_dir: Option<PathBuf>,
+    },
 }
 
 #[must_use]
@@ -61,6 +69,9 @@ pub fn render_resolved_skill_prompt(skill: &ResolvedSkill, args: Option<&str>) -
             },
             args,
         ),
+        ResolvedSkillSource::Generated { .. } => {
+            skill.document.render_markdown_with_arguments(args)
+        }
     }
 }
 
@@ -72,6 +83,7 @@ pub fn resolved_skill_reference_files(skill: &ResolvedSkill) -> BTreeMap<String,
             id: *id,
             document: skill.document.clone(),
         }),
+        ResolvedSkillSource::Generated { .. } => BTreeMap::new(),
     }
 }
 
@@ -2120,6 +2132,13 @@ struct SkillSummary {
 enum SkillLocation {
     Filesystem(PathBuf),
     Bundled(BundledSkillId),
+    Generated(GeneratedSkill),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GeneratedSkill {
+    id: String,
+    base_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2461,6 +2480,10 @@ pub fn resolve_skill(cwd: &Path, skill: &str) -> std::io::Result<ResolvedSkill> 
             let source = match skill.location {
                 SkillLocation::Filesystem(path) => ResolvedSkillSource::Filesystem { path },
                 SkillLocation::Bundled(id) => ResolvedSkillSource::Bundled { id },
+                SkillLocation::Generated(generated) => ResolvedSkillSource::Generated {
+                    id: generated.id,
+                    base_dir: generated.base_dir,
+                },
             };
             return Ok(ResolvedSkill {
                 document: skill.document,
@@ -2491,6 +2514,10 @@ pub fn resolve_skill_path(cwd: &Path, skill: &str) -> std::io::Result<PathBuf> {
                 SkillLocation::Bundled(_) => Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!("skill `{requested}` is bundled and has no filesystem path"),
+                )),
+                SkillLocation::Generated(generated) => Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("skill `{}` is generated for the current AppFS app and has no filesystem path", generated.id),
                 )),
             };
         }
@@ -3243,6 +3270,14 @@ fn load_skills_from_roots_impl(
 
     merge_skill_summaries(&mut skills, &mut active_sources, bundled_skill_summaries());
 
+    if let Some(cwd) = activation_cwd {
+        merge_skill_summaries(
+            &mut skills,
+            &mut active_sources,
+            generated_appfs_skill_summaries(cwd),
+        );
+    }
+
     for root in roots {
         merge_skill_summaries(
             &mut skills,
@@ -3269,6 +3304,474 @@ fn bundled_skill_summaries() -> Vec<SkillSummary> {
         .collect::<Vec<_>>();
     bundled_skills.sort_by(|left, right| left.name.cmp(&right.name));
     bundled_skills
+}
+
+fn generated_appfs_skill_summaries(cwd: &Path) -> Vec<SkillSummary> {
+    let Some(environment) = detect_appfs_environment(cwd) else {
+        return Vec::new();
+    };
+
+    let mut candidates = BTreeMap::<String, PathBuf>::new();
+    for app in &environment.registered_apps {
+        candidates
+            .entry(app.app_id.clone())
+            .or_insert_with(|| environment.mount_root.join(&app.app_id));
+    }
+
+    if let (Some(app_id), Some(app_root)) = (
+        environment.current_app_id.as_ref(),
+        environment.current_app_root.as_ref(),
+    ) {
+        candidates
+            .entry(app_id.clone())
+            .or_insert_with(|| app_root.clone());
+    }
+
+    if candidates.is_empty() {
+        for child in discover_app_roots_under_mount(&environment.mount_root) {
+            if let Some(app_id) = child
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .filter(|name| !name.is_empty())
+            {
+                candidates.entry(app_id).or_insert(child);
+            }
+        }
+    }
+
+    let mut summaries = candidates
+        .into_iter()
+        .filter_map(|(app_id, app_root)| synthesize_appfs_skill_for_app(&app_id, &app_root))
+        .collect::<Vec<_>>();
+    summaries.sort_by(|left, right| left.name.cmp(&right.name));
+    summaries
+}
+
+fn discover_app_roots_under_mount(mount_root: &Path) -> Vec<PathBuf> {
+    fs::read_dir(mount_root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let file_type = entry.file_type().ok()?;
+            if !file_type.is_dir() {
+                return None;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if matches!(name.as_str(), "_appfs" | ".well-known") {
+                return None;
+            }
+            let looks_like_app =
+                path.join("_app").is_dir() || path.join("_stream").is_dir();
+            looks_like_app.then_some(path)
+        })
+        .collect()
+}
+
+fn synthesize_appfs_skill_for_app(fallback_app_id: &str, app_root: &Path) -> Option<SkillSummary> {
+    let skill_doc = read_json_value(&app_root.join("_app").join("skill.res.json"));
+    let control_doc = read_json_value(&app_root.join("_app").join("control.res.json"));
+    let actions_doc = read_json_value(&app_root.join("_app").join("actions.res.json"));
+    let current_scope_doc = read_json_value(&app_root.join("_app").join("current_scope.res.json"));
+    let available_scopes_doc =
+        read_json_value(&app_root.join("_app").join("available_scopes.res.json"));
+
+    let app_id = skill_doc
+        .as_ref()
+        .and_then(|doc| doc.get("app_id").and_then(Value::as_str))
+        .or_else(|| {
+            actions_doc
+                .as_ref()
+                .and_then(|doc| doc.get("app_id").and_then(Value::as_str))
+        })
+        .or_else(|| {
+            control_doc
+                .as_ref()
+                .and_then(|doc| doc.get("app_id").and_then(Value::as_str))
+        })
+        .unwrap_or(&fallback_app_id)
+        .to_string();
+
+    if skill_doc.is_none()
+        && control_doc.is_none()
+        && actions_doc.is_none()
+        && current_scope_doc.is_none()
+        && available_scopes_doc.is_none()
+    {
+        return None;
+    }
+
+    let skill_name = format!("appfs-{app_id}");
+    let description = appfs_skill_override_description(skill_doc.as_ref()).unwrap_or_else(|| {
+        format!("Operate the current {app_id} AppFS app through append-only action files and event streams.")
+    });
+    let when_to_use = appfs_skill_override_when_to_use(skill_doc.as_ref()).unwrap_or_else(|| {
+        build_appfs_skill_when_to_use(&app_id, control_doc.as_ref(), actions_doc.as_ref())
+    });
+    let markdown_content = build_appfs_skill_markdown(
+        &app_id,
+        skill_doc.as_ref(),
+        control_doc.as_ref(),
+        actions_doc.as_ref(),
+        current_scope_doc.as_ref(),
+        available_scopes_doc.as_ref(),
+    );
+    let allowed_tools = appfs_skill_allowed_tools(skill_doc.as_ref())
+        .unwrap_or_else(|| "bash, read_file, glob_search".to_string());
+    let contents = format!(
+        "---\nname: {}\ndescription: {}\nwhen_to_use: {}\nallowed-tools: {}\n---\n\n{markdown_content}\n",
+        yaml_quote_scalar(&skill_name),
+        yaml_quote_scalar(&description),
+        yaml_quote_scalar(&when_to_use),
+        yaml_quote_scalar(&allowed_tools),
+    );
+    let document = parse_skill_document(&contents, skill_name.clone(), "Skill");
+
+    Some(SkillSummary {
+        name: document.user_facing_name().to_string(),
+        description: Some(document.description.clone()),
+        location: SkillLocation::Generated(GeneratedSkill {
+            id: skill_name.clone(),
+            base_dir: Some(app_root.to_path_buf()),
+        }),
+        document,
+        source: DefinitionSource::ProjectClaw,
+        shadowed_by: None,
+        origin: SkillOrigin::SkillsDir,
+    })
+}
+
+fn appfs_skill_override_description(skill_doc: Option<&Value>) -> Option<String> {
+    skill_doc
+        .and_then(|doc| doc.get("description"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn appfs_skill_override_when_to_use(skill_doc: Option<&Value>) -> Option<String> {
+    let doc = skill_doc?;
+    if let Some(text) = doc
+        .get("when_to_use")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        return Some(text.to_string());
+    }
+
+    let clauses = doc
+        .get("when_to_use")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>();
+    if clauses.is_empty() {
+        None
+    } else {
+        Some(clauses.join(" "))
+    }
+}
+
+fn appfs_skill_allowed_tools(skill_doc: Option<&Value>) -> Option<String> {
+    let tools = skill_doc
+        .and_then(|doc| doc.get("allowed_tools"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|tool| !tool.is_empty())
+        .collect::<Vec<_>>();
+    if tools.is_empty() {
+        None
+    } else {
+        Some(tools.join(", "))
+    }
+}
+
+fn appfs_skill_overview_markdown(skill_doc: Option<&Value>, app_id: &str) -> (String, bool) {
+    if let Some(overview) = skill_doc
+        .and_then(|doc| doc.get("overview_markdown"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|overview| !overview.is_empty())
+    {
+        return (overview.to_string(), true);
+    }
+
+    if let Some(description) = appfs_skill_override_description(skill_doc) {
+        return (description, true);
+    }
+
+    (
+        format!(
+            "Operate the mounted `{app_id}` AppFS app by reading resource files and appending one JSON object line to `*.act` sinks."
+        ),
+        false,
+    )
+}
+
+fn appfs_skill_generated_section_enabled(skill_doc: Option<&Value>, section: &str) -> bool {
+    skill_doc
+        .and_then(|doc| doc.get("include_generated_sections"))
+        .and_then(|sections| sections.get(section))
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+fn build_appfs_skill_when_to_use(
+    app_id: &str,
+    control_doc: Option<&Value>,
+    actions_doc: Option<&Value>,
+) -> String {
+    let mut clauses = vec![format!(
+        "Use when the user wants to work with the current {app_id} AppFS app."
+    )];
+    clauses.push(
+        "Load it before performing app-specific control or action-file operations.".to_string(),
+    );
+
+    if let Some(description) = control_doc
+        .and_then(|doc| doc.get("description"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+    {
+        clauses.push(format!("App context: {description}"));
+    }
+
+    let mentions = actions_doc
+        .and_then(|doc| doc.get("contact_routes"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|route| route.get("mention_tokens").and_then(Value::as_array))
+        .flatten()
+        .filter_map(Value::as_str)
+        .take(4)
+        .collect::<Vec<_>>();
+    if !mentions.is_empty() {
+        clauses.push(format!(
+            "Especially use it when the user asks to message {}.",
+            mentions.join(" / ")
+        ));
+    }
+
+    let actions = actions_doc
+        .and_then(|doc| doc.get("recommended_actions"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|action| action.get("use_when").and_then(Value::as_array))
+        .flatten()
+        .filter_map(Value::as_str)
+        .take(2)
+        .collect::<Vec<_>>();
+    if !actions.is_empty() {
+        clauses.push(actions.join(" "));
+    }
+
+    clauses.join(" ")
+}
+
+fn build_appfs_skill_markdown(
+    app_id: &str,
+    skill_doc: Option<&Value>,
+    control_doc: Option<&Value>,
+    actions_doc: Option<&Value>,
+    current_scope_doc: Option<&Value>,
+    available_scopes_doc: Option<&Value>,
+) -> String {
+    let (overview_markdown, uses_skill_narrative) =
+        appfs_skill_overview_markdown(skill_doc, app_id);
+    let mut lines = vec![
+        format!("# appfs-{app_id}"),
+        String::new(),
+        overview_markdown,
+        String::new(),
+        "## AppFS action rules".to_string(),
+        "- Every `*.act` file is an append-only JSONL sink.".to_string(),
+        "- Never use `write_file` or `edit_file` on `*.act` paths because those tools overwrite the sink.".to_string(),
+        "- Use `bash` to append exactly one JSON object plus a trailing newline.".to_string(),
+        "- After appending to an action, inspect `_stream/events.evt.jsonl` for `action.completed` or `action.failed`.".to_string(),
+        "- A reliable check is `tail -n 20 _stream/events.evt.jsonl`.".to_string(),
+    ];
+
+    if !uses_skill_narrative {
+        if let Some(description) = control_doc
+            .and_then(|doc| doc.get("description"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|description| !description.is_empty())
+        {
+            lines.push(String::new());
+            lines.push("## App overview".to_string());
+            lines.push(format!("- {description}"));
+        }
+    }
+
+    if appfs_skill_generated_section_enabled(skill_doc, "scope_summary") {
+        if let Some(scope_doc) = current_scope_doc {
+            if let Some(active_scope) = scope_doc.get("active_scope").and_then(Value::as_str) {
+                lines.push(String::new());
+                lines.push("## Current scope".to_string());
+                lines.push(format!("- Active scope: `{active_scope}`."));
+            }
+            if let Some(resource) = scope_doc.get("primary_resource").and_then(Value::as_str) {
+                lines.push(format!("- Primary resource: `{resource}`."));
+            }
+        }
+
+        if let Some(scopes_doc) = available_scopes_doc {
+            let scopes = scopes_doc
+                .get("scopes")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|scope| scope.get("scope_id").and_then(Value::as_str))
+                .map(|scope| format!("`{scope}`"))
+                .collect::<Vec<_>>();
+            if !scopes.is_empty() {
+                lines.push(format!("- Known scopes: {}.", scopes.join(", ")));
+            }
+        }
+    }
+
+    if appfs_skill_generated_section_enabled(skill_doc, "control_actions") {
+        if let Some(actions) = control_doc
+            .and_then(|doc| doc.get("actions"))
+            .and_then(Value::as_array)
+        {
+            append_appfs_skill_action_section(&mut lines, "## App control actions", actions);
+        }
+    }
+
+    if appfs_skill_generated_section_enabled(skill_doc, "recommended_actions") {
+        if let Some(actions) = actions_doc
+            .and_then(|doc| doc.get("recommended_actions"))
+            .and_then(Value::as_array)
+        {
+            lines.push(String::new());
+            lines.push("## Recommended actions".to_string());
+            for action in actions {
+                let path = action
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<unknown>");
+                let summary = action
+                    .get("summary")
+                    .and_then(Value::as_str)
+                    .unwrap_or("App action");
+                let mut line = format!("- `{path}`: {summary}");
+                if let Some(example) = action.get("example_payload") {
+                    if let Ok(example_text) = serde_json::to_string(example) {
+                        line.push_str(&format!(
+                            " Append with: `printf '%s\\n' '{}' >> {path}`.",
+                            example_text.replace('\'', r"'\''")
+                        ));
+                    }
+                }
+                lines.push(line);
+                if let Some(use_when) = action.get("use_when").and_then(Value::as_array) {
+                    let reasons = use_when
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>();
+                    if !reasons.is_empty() {
+                        lines.push(format!("  Use when: {}", reasons.join(" ")));
+                    }
+                }
+            }
+        }
+    }
+
+    if appfs_skill_generated_section_enabled(skill_doc, "contact_routing") {
+        if let Some(routes) = actions_doc
+            .and_then(|doc| doc.get("contact_routes"))
+            .and_then(Value::as_array)
+        {
+            lines.push(String::new());
+            lines.push("## Contact routing".to_string());
+            for route in routes {
+                let mention_tokens = route
+                    .get("mention_tokens")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Value::as_str)
+                    .map(|token| format!("`{token}`"))
+                    .collect::<Vec<_>>();
+                let path = route
+                    .get("send_message_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<unknown>");
+                let mentions = if mention_tokens.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    mention_tokens.join(", ")
+                };
+                lines.push(format!("- {mentions} -> `{path}`."));
+            }
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("When the task matches this app, load this skill first, then follow the action rules above.".to_string());
+    lines.join("\n")
+}
+
+fn append_appfs_skill_action_section(lines: &mut Vec<String>, title: &str, actions: &[Value]) {
+    if actions.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push(title.to_string());
+    for action in actions {
+        let path = action
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let summary = action
+            .get("summary")
+            .and_then(Value::as_str)
+            .unwrap_or("App action");
+        let mut line = format!("- `{path}`: {summary}");
+        if let Some(example) = action.get("example_payload") {
+            if let Ok(example_text) = serde_json::to_string(example) {
+                line.push_str(&format!(
+                    " Append with: `printf '%s\\n' '{}' >> {path}`.",
+                    example_text.replace('\'', r"'\''")
+                ));
+            }
+        }
+        lines.push(line);
+        if let Some(use_when) = action.get("use_when").and_then(Value::as_array) {
+            let reasons = use_when
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>();
+            if !reasons.is_empty() {
+                lines.push(format!("  Use when: {}", reasons.join(" ")));
+            }
+        }
+    }
+}
+
+fn read_json_value(path: &Path) -> Option<Value> {
+    let bytes = fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn yaml_quote_scalar(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 fn load_skills_from_root(
@@ -3769,6 +4272,89 @@ fn render_skills_usage_json(unexpected: Option<&str>) -> Value {
         },
         "unexpected": unexpected,
     })
+}
+
+const DEFAULT_MODEL_SKILL_LISTING_CHAR_BUDGET: usize = 8_000;
+const MAX_MODEL_SKILL_ENTRY_CHARS: usize = 320;
+
+pub fn render_model_facing_skill_listing(cwd: &Path) -> std::io::Result<Option<String>> {
+    render_model_facing_skill_listing_with_budget(cwd, DEFAULT_MODEL_SKILL_LISTING_CHAR_BUDGET)
+}
+
+pub fn render_model_facing_skill_listing_with_budget(
+    cwd: &Path,
+    budget_chars: usize,
+) -> std::io::Result<Option<String>> {
+    let roots = discover_skill_roots(cwd);
+    let mut skills = load_skills_from_roots_for_context(&roots, cwd)?;
+    skills.retain(|skill| skill.shadowed_by.is_none() && !skill.document.disable_model_invocation);
+    if skills.is_empty() {
+        return Ok(None);
+    }
+
+    skills.sort_by(|left, right| {
+        skill_listing_sort_key(left)
+            .cmp(&skill_listing_sort_key(right))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    let mut lines = vec![
+        "Available skills. When one matches the user's request, invoke the `Skill` tool before responding. Use only the exact skill names listed below.".to_string(),
+        "If none of these fit, you may use `ToolSearch` to search for more specialized tools.".to_string(),
+        String::new(),
+    ];
+    let mut used_chars = lines.iter().map(|line| line.len()).sum::<usize>() + (lines.len() - 1);
+    let mut omitted = 0usize;
+
+    for skill in skills {
+        let entry = format_model_facing_skill_entry(&skill);
+        let separator_chars = usize::from(!lines.is_empty());
+        if used_chars + separator_chars + entry.len() > budget_chars {
+            omitted += 1;
+            continue;
+        }
+        used_chars += separator_chars + entry.len();
+        lines.push(entry);
+    }
+
+    if omitted > 0 {
+        lines.push(format!(
+            "_{omitted} additional skills omitted to stay within the context budget._"
+        ));
+    }
+
+    Ok(Some(lines.join("\n")))
+}
+
+fn skill_listing_sort_key(skill: &SkillSummary) -> (u8, String) {
+    let priority = match skill.location {
+        SkillLocation::Generated(_) => 0,
+        SkillLocation::Bundled(_) => 1,
+        SkillLocation::Filesystem(_) => 2,
+    };
+    (priority, skill.name.to_ascii_lowercase())
+}
+
+fn format_model_facing_skill_entry(skill: &SkillSummary) -> String {
+    let mut description = skill.document.description.trim().to_string();
+    if let Some(when_to_use) = skill
+        .document
+        .when_to_use
+        .as_deref()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        description.push_str(" Use when: ");
+        description.push_str(when_to_use);
+    }
+    if description.chars().count() > MAX_MODEL_SKILL_ENTRY_CHARS {
+        let truncated = description
+            .chars()
+            .take(MAX_MODEL_SKILL_ENTRY_CHARS - 1)
+            .collect::<String>();
+        description = format!("{truncated}…");
+    }
+    format!("- {}: {}", skill.name, description)
 }
 
 fn render_mcp_usage(unexpected: Option<&str>) -> String {
@@ -4436,10 +5022,11 @@ mod tests {
         handle_slash_command_with_compactor, load_agents_from_roots, load_skills_from_roots,
         load_skills_from_roots_for_context, normalize_relative_match_path, render_agents_report,
         render_agents_report_json, render_mcp_report_json_for, render_plugins_report,
-        render_skills_report, render_slash_command_help, render_slash_command_help_detail,
-        resolve_skill, resolve_skill_path, resume_supported_slash_commands, slash_command_specs,
-        suggest_slash_commands, validate_slash_command_input, DefinitionSource, SkillOrigin,
-        SkillRoot, SkillSlashDispatch, SlashCommand,
+        render_resolved_skill_prompt, render_skills_report, render_slash_command_help,
+        render_slash_command_help_detail, resolve_skill, resolve_skill_path,
+        resume_supported_slash_commands, slash_command_specs, suggest_slash_commands,
+        validate_slash_command_input, DefinitionSource, SkillOrigin, SkillRoot, SkillSlashDispatch,
+        SlashCommand,
     };
     use plugins::{PluginKind, PluginManager, PluginManagerConfig, PluginMetadata, PluginSummary};
     use runtime::{
@@ -4511,10 +5098,242 @@ mod tests {
         .expect("write command");
     }
 
+    fn seed_appfs_skill_mount(root: &Path) -> PathBuf {
+        let mount_root = root.join("mnt");
+        let app_root = mount_root.join("aiim");
+        fs::create_dir_all(mount_root.join("_appfs")).expect("control dir");
+        fs::create_dir_all(app_root.join("_app")).expect("app control dir");
+        fs::create_dir_all(app_root.join("_stream")).expect("stream dir");
+        fs::write(mount_root.join("_appfs").join("register_app.act"), "").expect("register act");
+        fs::write(
+            app_root.join("_app").join("skill.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "description": "一个 AI 专用的聊天软件，用于收发消息。",
+  "when_to_use": [
+    "当用户想要向某人发送消息、查看聊天记录，或者处理其他与聊天相关的任务时使用。",
+    "在当前挂载的 AIIM app 上执行专用 act 或控制操作之前，先加载这个 skill。"
+  ],
+  "overview_markdown": "AIIM 是当前挂载出来的聊天软件。你可以用它查看聊天记录、给联系人发送消息，并在需要时切换不同聊天 scope 后再继续读取或操作。",
+  "allowed_tools": [
+    "bash",
+    "read_file",
+    "glob_search"
+  ],
+  "include_generated_sections": {
+    "scope_summary": true,
+    "control_actions": true,
+    "recommended_actions": true,
+    "contact_routing": true
+  }
+}"#,
+        )
+        .expect("write skill doc");
+        fs::write(
+            app_root.join("_app").join("actions.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "recommended_actions": [
+    {
+      "name": "send_message",
+      "path": "contacts/zhangsan/send_message.act",
+      "summary": "Send a direct message to 张三 / zhangsan.",
+      "use_when": [
+        "User asks to tell 张三 / zhangsan / 老张 something."
+      ],
+      "example_payload": {
+        "text": "明天上午十点开会",
+        "priority": "normal"
+      }
+    }
+  ],
+  "contact_routes": [
+    {
+      "contact_id": "zhangsan",
+      "send_message_path": "contacts/zhangsan/send_message.act",
+      "mention_tokens": ["张三", "老张", "zhangsan"]
+    }
+  ]
+}"#,
+        )
+        .expect("write actions doc");
+        fs::write(
+            app_root.join("_app").join("current_scope.res.json"),
+            r#"{"app_id":"aiim","active_scope":"chat-001","primary_resource":"chats/chat-001/messages.res.jsonl"}"#,
+        )
+        .expect("write current scope");
+        fs::write(
+            app_root.join("_app").join("available_scopes.res.json"),
+            r#"{"app_id":"aiim","active_scope":"chat-001","scopes":[{"scope_id":"chat-001"},{"scope_id":"chat-long"}]}"#,
+        )
+        .expect("write scopes");
+        app_root
+    }
+
+    fn seed_control_only_appfs_skill_mount(root: &Path) -> PathBuf {
+        let mount_root = root.join("mnt");
+        let app_root = mount_root.join("scheduler");
+        fs::create_dir_all(mount_root.join("_appfs")).expect("control dir");
+        fs::create_dir_all(app_root.join("_app")).expect("app control dir");
+        fs::create_dir_all(app_root.join("_stream")).expect("stream dir");
+        fs::write(mount_root.join("_appfs").join("register_app.act"), "").expect("register act");
+        fs::write(
+            app_root.join("_app").join("control.res.json"),
+            r#"{
+  "app_id": "scheduler",
+  "description": "Manage meeting scheduling flows inside the current scheduler app.",
+  "events_path": "_stream/events.evt.jsonl",
+  "current_scope_path": "_app/current_scope.res.json",
+  "available_scopes_path": "_app/available_scopes.res.json",
+  "actions": [
+    {
+      "name": "enter_scope",
+      "path": "_app/enter_scope.act",
+      "summary": "Switch to a named scheduling scope.",
+      "example_payload": {
+        "target_scope": "meeting-room-a"
+      }
+    },
+    {
+      "name": "schedule_meeting",
+      "path": "meetings/create.act",
+      "summary": "Create a new meeting with room and attendees.",
+      "example_payload": {
+        "topic": "Design review",
+        "room": "A-301"
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("write control doc");
+        fs::write(
+            app_root.join("_app").join("current_scope.res.json"),
+            r#"{"app_id":"scheduler","active_scope":"meeting-room-a","primary_resource":"meetings/today.res.jsonl"}"#,
+        )
+        .expect("write current scope");
+        fs::write(
+            app_root.join("_app").join("available_scopes.res.json"),
+            r#"{"app_id":"scheduler","active_scope":"meeting-room-a","scopes":[{"scope_id":"meeting-room-a"},{"scope_id":"meeting-room-b"}]}"#,
+        )
+        .expect("write scopes");
+        app_root
+    }
+
     fn parse_error_message(input: &str) -> String {
         SlashCommand::parse(input)
             .expect_err("slash command should be rejected")
             .to_string()
+    }
+
+    #[test]
+    fn resolves_generated_appfs_skill_for_current_app() {
+        let workspace = temp_dir("generated-appfs-skill");
+        let app_root = seed_appfs_skill_mount(&workspace);
+        let cwd = app_root.join("workspace");
+        fs::create_dir_all(&cwd).expect("workspace dir");
+
+        let resolved = resolve_skill(&cwd, "appfs-aiim").expect("generated appfs skill");
+        let prompt = render_resolved_skill_prompt(&resolved, None);
+
+        assert!(prompt.contains("AIIM 是当前挂载出来的聊天软件。"));
+        assert!(prompt.contains("append-only JSONL"));
+        assert!(prompt.contains("contacts/zhangsan/send_message.act"));
+        assert!(prompt.contains("张三"));
+        assert!(prompt.contains("tail -n"));
+    }
+
+    #[test]
+    fn resolves_generated_appfs_skill_from_mount_root() {
+        let workspace = temp_dir("generated-appfs-skill-root");
+        let app_root = seed_appfs_skill_mount(&workspace);
+        let mount_root = app_root
+            .parent()
+            .expect("app root should have mount root parent");
+
+        let resolved = resolve_skill(mount_root, "appfs-aiim").expect("generated appfs skill");
+        let prompt = render_resolved_skill_prompt(&resolved, None);
+
+        assert!(prompt.contains("AIIM 是当前挂载出来的聊天软件。"));
+        assert!(prompt.contains("contacts/zhangsan/send_message.act"));
+    }
+
+    #[test]
+    fn resolves_generated_appfs_skill_from_control_doc_without_actions_doc() {
+        let workspace = temp_dir("generated-appfs-skill-control-only");
+        let app_root = seed_control_only_appfs_skill_mount(&workspace);
+        let cwd = app_root.join("workspace");
+        fs::create_dir_all(&cwd).expect("workspace dir");
+
+        let resolved = resolve_skill(&cwd, "appfs-scheduler").expect("generated scheduler skill");
+        let prompt = render_resolved_skill_prompt(&resolved, None);
+
+        assert!(prompt.contains("Manage meeting scheduling flows"));
+        assert!(prompt.contains("`_app/enter_scope.act`"));
+        assert!(prompt.contains("`meetings/create.act`"));
+        assert!(prompt.contains("meeting-room-b"));
+        assert!(!prompt.contains("contacts/zhangsan/send_message.act"));
+    }
+
+    #[test]
+    fn render_model_facing_skill_listing_includes_regular_and_appfs_skills() {
+        let workspace = temp_dir("model-facing-skill-listing");
+        let app_root = seed_appfs_skill_mount(&workspace);
+        let cwd = app_root.join("workspace");
+        fs::create_dir_all(&cwd).expect("workspace dir");
+        write_skill(
+            &workspace.join(".claw").join("skills"),
+            "trace",
+            "Trace repository state",
+        );
+
+        let listing = super::render_model_facing_skill_listing_with_budget(&cwd, 8_000)
+            .expect("listing should render")
+            .expect("listing should exist");
+
+        assert!(listing.contains("- appfs-aiim:"));
+        assert!(listing.contains("一个 AI 专用的聊天软件，用于收发消息。"));
+        assert!(listing.contains("当用户想要向某人发送消息、查看聊天记录"));
+        assert!(listing.contains("- trace:"));
+        assert!(listing.contains("invoke the `Skill` tool before responding"));
+    }
+
+    #[test]
+    fn render_model_facing_skill_listing_includes_appfs_skills_from_mount_root() {
+        let workspace = temp_dir("model-facing-skill-listing-root");
+        let app_root = seed_appfs_skill_mount(&workspace);
+        let mount_root = app_root
+            .parent()
+            .expect("app root should have mount root parent");
+
+        let listing = super::render_model_facing_skill_listing_with_budget(mount_root, 8_000)
+            .expect("listing should render")
+            .expect("listing should exist");
+
+        assert!(listing.contains("- appfs-aiim:"));
+        assert!(listing.contains("一个 AI 专用的聊天软件，用于收发消息。"));
+        assert!(listing.contains("当用户想要向某人发送消息、查看聊天记录"));
+    }
+
+    #[test]
+    fn render_model_facing_skill_listing_skips_disable_model_invocation_skills() {
+        let workspace = temp_dir("model-facing-skill-disable");
+        let skills_root = workspace.join(".claw").join("skills");
+        write_skill(&skills_root, "trace", "Trace repository state");
+        let internal_root = skills_root.join("internal");
+        fs::create_dir_all(&internal_root).expect("internal root");
+        fs::write(
+            internal_root.join("SKILL.md"),
+            "---\nname: internal\ndescription: Internal only\ndisable-model-invocation: true\n---\n\n# internal\n",
+        )
+        .expect("write internal skill");
+
+        let listing = super::render_model_facing_skill_listing_with_budget(&workspace, 8_000)
+            .expect("listing should render")
+            .expect("listing should exist");
+
+        assert!(listing.contains("- trace:"));
+        assert!(!listing.contains("- internal:"));
     }
 
     #[allow(clippy::too_many_lines)]

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -3363,8 +3363,7 @@ fn discover_app_roots_under_mount(mount_root: &Path) -> Vec<PathBuf> {
             if matches!(name.as_str(), "_appfs" | ".well-known") {
                 return None;
             }
-            let looks_like_app =
-                path.join("_app").is_dir() || path.join("_stream").is_dir();
+            let looks_like_app = path.join("_app").is_dir() || path.join("_stream").is_dir();
             looks_like_app.then_some(path)
         })
         .collect()

--- a/rust/crates/runtime/src/appfs.rs
+++ b/rust/crates/runtime/src/appfs.rs
@@ -1228,7 +1228,8 @@ mod tests {
 
         assert!(prompt.contains("AppFS mounts bridge-backed software into a filesystem"));
         assert!(prompt.contains("Do not guess act schemas or payload shapes"));
-        assert!(prompt.contains("Mounted app skills are listed separately in the skill listing attachment"));
+        assert!(prompt
+            .contains("Mounted app skills are listed separately in the skill listing attachment"));
         assert!(prompt.contains("Never use `write_file` or `edit_file` on `*.act` files"));
         assert!(prompt.contains("chat-long"));
         assert!(prompt.contains("_stream/events.evt.jsonl"));
@@ -1248,7 +1249,8 @@ mod tests {
 
         let prompt = build_appfs_prompt_section(&cwd).expect("expected appfs prompt section");
 
-        assert!(prompt.contains("Mounted app skills are listed separately in the skill listing attachment"));
+        assert!(prompt
+            .contains("Mounted app skills are listed separately in the skill listing attachment"));
         assert!(prompt.contains("Scheduler app for room bookings and meeting setup."));
         assert!(prompt.contains("meeting-room-b"));
         assert!(prompt.contains("Never use `write_file` or `edit_file` on `*.act` files"));
@@ -1265,10 +1267,15 @@ mod tests {
         seed_heuristic_mount(&mount_root);
         seed_aiim_prompt_files(&app_root);
 
-        let prompt = build_appfs_prompt_section(&mount_root).expect("expected appfs prompt section");
+        let prompt =
+            build_appfs_prompt_section(&mount_root).expect("expected appfs prompt section");
 
-        assert!(prompt.contains("You are inside an AppFS mount, but not currently inside a specific app root."));
-        assert!(prompt.contains("Mounted apps currently detected under this root: `aiim`, `notion`."));
+        assert!(prompt.contains(
+            "You are inside an AppFS mount, but not currently inside a specific app root."
+        ));
+        assert!(
+            prompt.contains("Mounted apps currently detected under this root: `aiim`, `notion`.")
+        );
         assert!(prompt.contains("Use the skill listing to load the matching `appfs-<app>` skill"));
         assert!(!prompt.contains("## Mounted apps"));
         assert!(!prompt.contains("`aiim` -> skill `appfs-aiim`"));

--- a/rust/crates/runtime/src/appfs.rs
+++ b/rust/crates/runtime/src/appfs.rs
@@ -5,7 +5,7 @@ use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
 const CONTROL_DIR_NAME: &str = "_appfs";
@@ -108,6 +108,38 @@ pub struct AppfsEnvironment {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct AppfsPromptControlDoc {
+    app_id: String,
+    description: Option<String>,
+    events_path: Option<String>,
+    current_scope_path: Option<String>,
+    available_scopes_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AppfsPromptCurrentScopeDoc {
+    app_id: String,
+    active_scope: String,
+    display_name: Option<String>,
+    primary_resource: Option<String>,
+    structure_revision_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AppfsPromptAvailableScopeEntry {
+    scope_id: String,
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AppfsPromptAvailableScopesDoc {
+    app_id: String,
+    active_scope: Option<String>,
+    #[serde(default)]
+    scopes: Vec<AppfsPromptAvailableScopeEntry>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct AppfsAttachEnv {
     schema: Option<String>,
@@ -162,6 +194,12 @@ pub fn detect_appfs_environment(cwd: &Path) -> Option<AppfsEnvironment> {
 #[must_use]
 pub fn resolve_appfs_environment(cwd: &Path) -> Option<AppfsEnvironment> {
     resolve_appfs_environment_with_attach_env(cwd, load_attach_env())
+}
+
+#[must_use]
+pub fn build_appfs_prompt_section(cwd: &Path) -> Option<String> {
+    let environment = detect_appfs_environment(cwd)?;
+    Some(render_appfs_prompt_section(&environment))
 }
 
 fn resolve_appfs_environment_with_attach_env(
@@ -576,13 +614,237 @@ fn generate_ephemeral_attach_id() -> String {
     format!("attach-{now:x}-{}-{seq:x}", process::id())
 }
 
+fn render_appfs_prompt_section(environment: &AppfsEnvironment) -> String {
+    if let (Some(app_id), Some(app_root)) = (
+        environment.current_app_id.as_deref(),
+        environment.current_app_root.as_deref(),
+    ) {
+        return render_current_app_prompt_section(environment, app_id, app_root);
+    }
+
+    render_mount_prompt_section(environment)
+}
+
+fn render_mount_prompt_section(environment: &AppfsEnvironment) -> String {
+    let register_path = environment
+        .register_app_path
+        .as_deref()
+        .map(|path| display_virtualish_path(&environment.mount_root, path))
+        .unwrap_or_else(|| "_appfs/register_app.act".to_string());
+    let list_path = environment
+        .list_apps_path
+        .as_deref()
+        .map(|path| display_virtualish_path(&environment.mount_root, path))
+        .unwrap_or_else(|| "_appfs/list_apps.act".to_string());
+    let events_path = environment
+        .control_events_path
+        .as_deref()
+        .map(|path| display_virtualish_path(&environment.mount_root, path))
+        .unwrap_or_else(|| "_appfs/_stream/events.evt.jsonl".to_string());
+    let lines = render_appfs_overview_lines(
+        environment,
+        None,
+        None,
+        &events_path,
+        Some(&register_path),
+        Some(&list_path),
+    );
+    lines.join("\n")
+}
+
+fn summarize_registered_app_ids(environment: &AppfsEnvironment) -> Option<String> {
+    let app_ids = environment
+        .registered_apps
+        .iter()
+        .map(|app| format!("`{}`", app.app_id))
+        .collect::<Vec<_>>();
+    (!app_ids.is_empty()).then(|| app_ids.join(", "))
+}
+
+fn render_current_app_prompt_section(
+    environment: &AppfsEnvironment,
+    app_id: &str,
+    app_root: &Path,
+) -> String {
+    let control_doc: Option<AppfsPromptControlDoc> =
+        read_json_file(&app_root.join("_app").join("control.res.json"));
+    let current_scope_doc: Option<AppfsPromptCurrentScopeDoc> =
+        read_json_file(&app_root.join("_app").join("current_scope.res.json"));
+    let available_scopes_doc: Option<AppfsPromptAvailableScopesDoc> =
+        read_json_file(&app_root.join("_app").join("available_scopes.res.json"));
+    let events_path = control_doc
+        .as_ref()
+        .and_then(|doc| doc.events_path.clone())
+        .or_else(|| {
+            environment
+                .current_app_events_path
+                .as_deref()
+                .map(|path| display_virtualish_path(app_root, path))
+        })
+        .unwrap_or_else(|| "_stream/events.evt.jsonl".to_string());
+
+    let current_app_id = control_doc
+        .as_ref()
+        .map_or(app_id, |doc| doc.app_id.as_str());
+    let mut lines = render_appfs_overview_lines(
+        environment,
+        Some(current_app_id),
+        Some(app_root),
+        &events_path,
+        None,
+        None,
+    );
+
+    if let Some(doc) = control_doc
+        .as_ref()
+        .and_then(|doc| doc.description.as_deref())
+    {
+        lines.push(format!("- Current app purpose: {doc}"));
+    }
+
+    if let Some(scope_doc) = current_scope_doc.as_ref() {
+        let scope_label = scope_doc
+            .display_name
+            .as_deref()
+            .map_or_else(String::new, |name| format!(" ({name})"));
+        lines.push(format!(
+            "- You are currently inside app `{}` rooted at `{}` with active scope `{}`{scope_label}.",
+            scope_doc.app_id,
+            app_root.display(),
+            scope_doc.active_scope
+        ));
+        lines.push(format!(
+            "- Current scope details for app `{}`: `{}`{scope_label}.",
+            scope_doc.app_id, scope_doc.active_scope
+        ));
+        if let Some(resource) = scope_doc.primary_resource.as_deref() {
+            lines.push(format!(
+                "- Primary resource for the current scope: `{resource}`."
+            ));
+        }
+        if let Some(revision) = scope_doc.structure_revision_hint.as_deref() {
+            lines.push(format!("- Structure revision hint: `{revision}`."));
+        }
+    } else if let Some(doc) = control_doc
+        .as_ref()
+        .and_then(|doc| doc.current_scope_path.as_deref())
+    {
+        lines.push(format!("- Current scope details are described in `{doc}`."));
+    }
+
+    if let Some(scopes_doc) = available_scopes_doc.as_ref() {
+        let scope_names = scopes_doc
+            .scopes
+            .iter()
+            .take(6)
+            .map(|scope| {
+                scope.display_name.as_deref().map_or_else(
+                    || format!("`{}`", scope.scope_id),
+                    |display_name| format!("`{}` ({display_name})", scope.scope_id),
+                )
+            })
+            .collect::<Vec<_>>();
+        if !scope_names.is_empty() {
+            lines.push(format!(
+                "- Known scopes for app `{}` (active `{}`): {}.",
+                scopes_doc.app_id,
+                scopes_doc.active_scope.as_deref().unwrap_or("<unknown>"),
+                scope_names.join(", ")
+            ));
+        }
+    } else if let Some(doc) = control_doc
+        .as_ref()
+        .and_then(|doc| doc.available_scopes_path.as_deref())
+    {
+        lines.push(format!("- Alternate scopes are listed in `{doc}`."));
+    }
+
+    lines.join("\n")
+}
+
+fn render_appfs_overview_lines(
+    environment: &AppfsEnvironment,
+    current_app_id: Option<&str>,
+    current_app_root: Option<&Path>,
+    events_path: &str,
+    register_path: Option<&str>,
+    list_path: Option<&str>,
+) -> Vec<String> {
+    let mut lines = vec![
+        "# AppFS workspace guidance".to_string(),
+        "- AppFS mounts bridge-backed software into a filesystem. After an app implements the AppFS bridge contract, reading and writing inside the mount interacts with the underlying software."
+            .to_string(),
+        "- Each mounted app appears as a directory under the AppFS mount root. The platform control plane lives under `/_appfs`."
+            .to_string(),
+        format!(
+            "- AppFS `*.act` files are append-only JSONL action sinks: append exactly one JSON object line to trigger an operation, then inspect `{events_path}` for `action.completed` or `action.failed`."
+        ),
+        "- Never use `write_file` or `edit_file` on `*.act` files because those tools overwrite the sink. Use `bash` (or another append-capable tool) to append exactly one JSON object plus a trailing newline."
+            .to_string(),
+        "- Do not guess act schemas or payload shapes. For each mounted app, load its `appfs-<app>` skill to learn what actions exist, what parameters each action expects, and when to use them."
+            .to_string(),
+        "- Mounted app skills are listed separately in the skill listing attachment. Use the `Skill` tool to load the matching app skill before doing app-specific work."
+            .to_string(),
+        format!("- Current AppFS mount root: `{}`.", environment.mount_root.display()),
+    ];
+
+    if let (Some(app_id), Some(app_root)) = (current_app_id, current_app_root) {
+        lines.push(format!(
+            "- Your current working area is inside app `{app_id}` rooted at `{}`.",
+            app_root.display()
+        ));
+    } else {
+        lines.push(
+            "- You are inside an AppFS mount, but not currently inside a specific app root."
+                .to_string(),
+        );
+        if let Some(app_ids) = summarize_registered_app_ids(environment) {
+            lines.push(format!(
+                "- Mounted apps currently detected under this root: {app_ids}. Use the skill listing to load the matching `appfs-<app>` skill before doing app-specific work."
+            ));
+        }
+    }
+
+    if let Some(register_path) = register_path {
+        lines.push(format!(
+            "- Platform registration actions are available at `{register_path}`."
+        ));
+    }
+    if let Some(list_path) = list_path {
+        lines.push(format!(
+            "- To inspect the mounted app registry from the filesystem, use `{list_path}` and the platform event stream."
+        ));
+    }
+
+    lines
+}
+fn display_virtualish_path(base: &Path, path: &Path) -> String {
+    if let Ok(relative) = path.strip_prefix(base) {
+        let rendered = relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .join("/");
+        if !rendered.is_empty() {
+            return rendered;
+        }
+    }
+    path.display().to_string()
+}
+
+fn read_json_file<T: DeserializeOwned>(path: &Path) -> Option<T> {
+    let bytes = fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        detect_appfs_environment, resolve_appfs_environment_with_attach_env, AppfsAttachEnv,
-        AppfsAttachSource, AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities,
-        AppfsRuntimeManifestControlPlane, APPFS_MULTI_AGENT_MODE_SHARED, APPFS_RUNTIME_KIND,
-        APPFS_RUNTIME_MANIFEST_REL_PATH, APPFS_SCHEMA_VERSION,
+        build_appfs_prompt_section, detect_appfs_environment,
+        resolve_appfs_environment_with_attach_env, AppfsAttachEnv, AppfsAttachSource,
+        AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities, AppfsRuntimeManifestControlPlane,
+        APPFS_MULTI_AGENT_MODE_SHARED, APPFS_RUNTIME_KIND, APPFS_RUNTIME_MANIFEST_REL_PATH,
+        APPFS_SCHEMA_VERSION,
     };
     use std::env;
     use std::fs;
@@ -634,6 +896,138 @@ mod tests {
         )
         .expect("write registry");
         fs::write(app_root.join("_stream").join("events.evt.jsonl"), "").expect("write events");
+    }
+
+    fn seed_aiim_prompt_files(app_root: &Path) {
+        fs::create_dir_all(app_root.join("_app")).expect("create _app dir");
+        fs::write(
+            app_root.join("_app").join("control.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "description": "AIIM demo app for incident chat, contact messaging, and scope switching.",
+  "events_path": "_stream/events.evt.jsonl",
+  "current_scope_path": "_app/current_scope.res.json",
+  "available_scopes_path": "_app/available_scopes.res.json",
+  "actions": [
+    {
+      "name": "enter_scope",
+      "path": "_app/enter_scope.act",
+      "summary": "Switch the app structure to a named scope such as chat-001 or chat-long.",
+      "input_schema": "_meta/schemas/enter_scope.input.schema.json",
+      "example_payload": {
+        "target_scope": "chat-long"
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("write control doc");
+        fs::write(
+            app_root.join("_app").join("actions.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "recommended_actions": [
+    {
+      "name": "send_message",
+      "path": "contacts/zhangsan/send_message.act",
+      "summary": "Send a direct message to 张三 / zhangsan.",
+      "input_schema": "_meta/schemas/send_message.input.schema.json",
+      "use_when": [
+        "User asks to tell 张三 / zhangsan / 老张 something."
+      ],
+      "example_payload": {
+        "text": "明天上午十点开会",
+        "priority": "normal"
+      }
+    }
+  ],
+  "contact_routes": [
+    {
+      "contact_id": "zhangsan",
+      "profile_path": "contacts/zhangsan/profile.res.json",
+      "send_message_path": "contacts/zhangsan/send_message.act",
+      "mention_tokens": [
+        "张三",
+        "老张",
+        "zhangsan"
+      ]
+    }
+  ]
+}"#,
+        )
+        .expect("write actions doc");
+        fs::write(
+            app_root.join("_app").join("current_scope.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "active_scope": "chat-001",
+  "display_name": "Default chat view",
+  "primary_resource": "chats/chat-001/messages.res.jsonl",
+  "entered_via": "_app/enter_scope.act"
+}"#,
+        )
+        .expect("write current scope");
+        fs::write(
+            app_root.join("_app").join("available_scopes.res.json"),
+            r#"{
+  "app_id": "aiim",
+  "active_scope": "chat-001",
+  "scopes": [
+    {
+      "scope_id": "chat-001",
+      "display_name": "Default chat view"
+    },
+    {
+      "scope_id": "chat-long",
+      "display_name": "Long chat stress view"
+    }
+  ]
+}"#,
+        )
+        .expect("write available scopes");
+    }
+
+    fn seed_scheduler_prompt_files(app_root: &Path) {
+        fs::create_dir_all(app_root.join("_app")).expect("create _app dir");
+        fs::write(
+            app_root.join("_app").join("control.res.json"),
+            r#"{
+  "app_id": "scheduler",
+  "description": "Scheduler app for room bookings and meeting setup.",
+  "events_path": "_stream/events.evt.jsonl",
+  "current_scope_path": "_app/current_scope.res.json",
+  "available_scopes_path": "_app/available_scopes.res.json"
+}"#,
+        )
+        .expect("write control doc");
+        fs::write(
+            app_root.join("_app").join("current_scope.res.json"),
+            r#"{
+  "app_id": "scheduler",
+  "active_scope": "meeting-room-a",
+  "display_name": "Room A",
+  "primary_resource": "meetings/today.res.jsonl"
+}"#,
+        )
+        .expect("write current scope");
+        fs::write(
+            app_root.join("_app").join("available_scopes.res.json"),
+            r#"{
+  "app_id": "scheduler",
+  "active_scope": "meeting-room-a",
+  "scopes": [
+    {
+      "scope_id": "meeting-room-a",
+      "display_name": "Room A"
+    },
+    {
+      "scope_id": "meeting-room-b",
+      "display_name": "Room B"
+    }
+  ]
+}"#,
+        )
+        .expect("write available scopes");
     }
 
     fn write_manifest(mount_root: &Path, runtime_session_id: &str) -> PathBuf {
@@ -818,6 +1212,66 @@ mod tests {
         assert!(detected.runtime_session_id.is_none());
         assert!(detected.attach_id.starts_with("attach-"));
         assert_eq!(detected.current_app_id.as_deref(), Some("aiim"));
+    }
+
+    #[test]
+    fn appfs_prompt_section_surfaces_current_app_guidance() {
+        let temp = TempDirGuard::new("appfs-prompt");
+        let mount_root = temp.path().join("mnt");
+        let app_root = mount_root.join("aiim");
+        let cwd = app_root.join("workspace");
+        seed_heuristic_mount(&mount_root);
+        seed_aiim_prompt_files(&app_root);
+        fs::create_dir_all(&cwd).expect("create cwd");
+
+        let prompt = build_appfs_prompt_section(&cwd).expect("expected appfs prompt section");
+
+        assert!(prompt.contains("AppFS mounts bridge-backed software into a filesystem"));
+        assert!(prompt.contains("Do not guess act schemas or payload shapes"));
+        assert!(prompt.contains("Mounted app skills are listed separately in the skill listing attachment"));
+        assert!(prompt.contains("Never use `write_file` or `edit_file` on `*.act` files"));
+        assert!(prompt.contains("chat-long"));
+        assert!(prompt.contains("_stream/events.evt.jsonl"));
+        assert!(!prompt.contains("## Mounted apps"));
+        assert!(!prompt.contains("`aiim` -> skill `appfs-aiim`"));
+    }
+
+    #[test]
+    fn appfs_prompt_section_surfaces_generated_skill_without_actions_doc() {
+        let temp = TempDirGuard::new("appfs-prompt-control-only");
+        let mount_root = temp.path().join("mnt");
+        let app_root = mount_root.join("scheduler");
+        let cwd = app_root.join("workspace");
+        seed_heuristic_mount(&mount_root);
+        seed_scheduler_prompt_files(&app_root);
+        fs::create_dir_all(&cwd).expect("create cwd");
+
+        let prompt = build_appfs_prompt_section(&cwd).expect("expected appfs prompt section");
+
+        assert!(prompt.contains("Mounted app skills are listed separately in the skill listing attachment"));
+        assert!(prompt.contains("Scheduler app for room bookings and meeting setup."));
+        assert!(prompt.contains("meeting-room-b"));
+        assert!(prompt.contains("Never use `write_file` or `edit_file` on `*.act` files"));
+        assert!(!prompt.contains("## Mounted apps"));
+        assert!(!prompt.contains("`scheduler` -> skill `appfs-scheduler`"));
+        assert!(!prompt.contains("message 张三 / 老张 / zhangsan"));
+    }
+
+    #[test]
+    fn appfs_prompt_section_surfaces_registered_apps_from_mount_root() {
+        let temp = TempDirGuard::new("appfs-prompt-mount-root");
+        let mount_root = temp.path().join("mnt");
+        let app_root = mount_root.join("aiim");
+        seed_heuristic_mount(&mount_root);
+        seed_aiim_prompt_files(&app_root);
+
+        let prompt = build_appfs_prompt_section(&mount_root).expect("expected appfs prompt section");
+
+        assert!(prompt.contains("You are inside an AppFS mount, but not currently inside a specific app root."));
+        assert!(prompt.contains("Mounted apps currently detected under this root: `aiim`, `notion`."));
+        assert!(prompt.contains("Use the skill listing to load the matching `appfs-<app>` skill"));
+        assert!(!prompt.contains("## Mounted apps"));
+        assert!(!prompt.contains("`aiim` -> skill `appfs-aiim`"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -140,8 +140,9 @@ pub use policy_engine::{
     PolicyEngine, PolicyRule, ReconcileReason, ReviewStatus,
 };
 pub use prompt::{
-    load_system_prompt, prepend_bullets, ContextFile, ProjectContext, PromptBuildError,
-    SystemPromptBuilder, FRONTIER_MODEL_NAME, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    load_system_prompt, load_system_prompt_with_appfs, prepend_bullets, ContextFile,
+    ProjectContext, PromptBuildError, SystemPromptBuilder, FRONTIER_MODEL_NAME,
+    SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -3,6 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::appfs::build_appfs_prompt_section;
 use crate::config::{ConfigError, ConfigLoader, RuntimeConfig};
 use crate::git_context::GitContext;
 
@@ -435,6 +436,20 @@ pub fn load_system_prompt(
         .with_project_context(project_context)
         .with_runtime_config(config)
         .build())
+}
+
+pub fn load_system_prompt_with_appfs(
+    cwd: impl Into<PathBuf>,
+    current_date: impl Into<String>,
+    os_name: impl Into<String>,
+    os_version: impl Into<String>,
+) -> Result<Vec<String>, PromptBuildError> {
+    let cwd = cwd.into();
+    let mut sections = load_system_prompt(&cwd, current_date, os_name, os_version)?;
+    if let Some(section) = build_appfs_prompt_section(&cwd) {
+        sections.push(section);
+    }
+    Ok(sections)
 }
 
 fn render_config_section(config: &RuntimeConfig) -> String {

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -53,6 +53,7 @@ pub enum AttachmentKind {
     RunningAgents,
     TodoList,
     PlanMode,
+    SkillListing,
     InvokedSkills,
     HookAdditionalContext,
 }
@@ -1166,6 +1167,7 @@ impl AttachmentKind {
             Self::RunningAgents => "running_agents",
             Self::TodoList => "todo_list",
             Self::PlanMode => "plan_mode",
+            Self::SkillListing => "skill_listing",
             Self::InvokedSkills => "invoked_skills",
             Self::HookAdditionalContext => "hook_additional_context",
         }
@@ -1179,6 +1181,7 @@ impl AttachmentKind {
             "running_agents" => Ok(Self::RunningAgents),
             "todo_list" => Ok(Self::TodoList),
             "plan_mode" => Ok(Self::PlanMode),
+            "skill_listing" => Ok(Self::SkillListing),
             "invoked_skills" => Ok(Self::InvokedSkills),
             "hook_additional_context" => Ok(Self::HookAdditionalContext),
             other => Err(SessionError::Format(format!(

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -59,8 +59,8 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tools::{
     execute_tool, execute_tool_with_effects, model_visible_tool_result, mvp_tool_specs,
-    should_inject_model_facing_skill_listing, sync_model_facing_skill_listing,
-    GlobalToolRegistry, RuntimeToolDefinition, ToolSearchOutput,
+    should_inject_model_facing_skill_listing, sync_model_facing_skill_listing, GlobalToolRegistry,
+    RuntimeToolDefinition, ToolSearchOutput,
 };
 
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
@@ -220,8 +220,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 // prompter may invoke CliPermissionPrompter::decide(), stdin
                 // must remain available for interactive approval; otherwise the
                 // prompter's read_line() would hit EOF and deny every request.
-                let stdin_context = if matches!(permission_mode, PermissionMode::DangerFullAccess)
-                {
+                let stdin_context = if matches!(permission_mode, PermissionMode::DangerFullAccess) {
                     read_piped_stdin()
                 } else {
                     None

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -45,7 +45,7 @@ use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
     check_base_commit, clear_oauth_credentials, detect_appfs_environment,
     format_stale_base_warning, format_usd, generate_pkce_pair, generate_state,
-    load_oauth_credentials, load_system_prompt, parse_oauth_callback_request_target,
+    load_oauth_credentials, load_system_prompt_with_appfs, parse_oauth_callback_request_target,
     pricing_for_model, resolve_expected_base, resolve_sandbox_status, save_oauth_credentials,
     set_shell_if_windows, ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader,
     ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
@@ -59,6 +59,7 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tools::{
     execute_tool, execute_tool_with_effects, model_visible_tool_result, mvp_tool_specs,
+    should_inject_model_facing_skill_listing, sync_model_facing_skill_listing,
     GlobalToolRegistry, RuntimeToolDefinition, ToolSearchOutput,
 };
 
@@ -179,8 +180,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => LiveCli::print_mcp(args.as_deref(), output_format)?,
         CliAction::Skills {
             args,
+            cwd,
             output_format,
-        } => LiveCli::print_skills(args.as_deref(), output_format)?,
+        } => LiveCli::print_skills_in(cwd.as_deref(), args.as_deref(), output_format)?,
         CliAction::PrintSystemPrompt {
             cwd,
             date,
@@ -208,25 +210,29 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             permission_mode,
             compact,
             base_commit,
+            cwd,
             ..
         } => {
-            run_stale_base_preflight(base_commit.as_deref());
-            // Only consume piped stdin as prompt context when the permission
-            // mode is fully unattended. In modes where the permission
-            // prompter may invoke CliPermissionPrompter::decide(), stdin
-            // must remain available for interactive approval; otherwise the
-            // prompter's read_line() would hit EOF and deny every request.
-            let stdin_context = if matches!(permission_mode, PermissionMode::DangerFullAccess) {
-                read_piped_stdin()
-            } else {
-                None
-            };
-            let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
-            LiveCli::new(model, true, allowed_tools, permission_mode)?.run_turn_with_output(
-                &effective_prompt,
-                output_format,
-                compact,
-            )?;
+            run_with_optional_cwd(cwd.as_deref(), || {
+                run_stale_base_preflight(base_commit.as_deref());
+                // Only consume piped stdin as prompt context when the permission
+                // mode is fully unattended. In modes where the permission
+                // prompter may invoke CliPermissionPrompter::decide(), stdin
+                // must remain available for interactive approval; otherwise the
+                // prompter's read_line() would hit EOF and deny every request.
+                let stdin_context = if matches!(permission_mode, PermissionMode::DangerFullAccess)
+                {
+                    read_piped_stdin()
+                } else {
+                    None
+                };
+                let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
+                LiveCli::new(model, true, allowed_tools, permission_mode)?.run_turn_with_output(
+                    &effective_prompt,
+                    output_format,
+                    compact,
+                )
+            })?;
         }
         CliAction::Login { output_format } => run_login(output_format)?,
         CliAction::Logout { output_format } => run_logout(output_format)?,
@@ -275,6 +281,7 @@ enum CliAction {
     },
     Skills {
         args: Option<String>,
+        cwd: Option<PathBuf>,
         output_format: CliOutputFormat,
     },
     PrintSystemPrompt {
@@ -302,6 +309,7 @@ enum CliAction {
     },
     Prompt {
         prompt: String,
+        cwd: Option<PathBuf>,
         model: String,
         output_format: CliOutputFormat,
         allowed_tools: Option<AllowedToolSet>,
@@ -453,6 +461,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 }
                 return Ok(CliAction::Prompt {
                     prompt,
+                    cwd: None,
                     model: resolve_model_alias_with_config(&model),
                     output_format,
                     allowed_tools: normalize_allowed_tools(&allowed_tool_values)?,
@@ -549,10 +558,12 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             output_format,
         }),
         "skills" => {
-            let args = join_optional_args(&rest[1..]);
+            let (cwd, args_vec) = parse_optional_cwd_prefix(&rest[1..])?;
+            let args = join_optional_args(&args_vec);
             match classify_skills_slash_command(args.as_deref()) {
                 SkillSlashDispatch::Invoke(prompt) => Ok(CliAction::Prompt {
                     prompt,
+                    cwd,
                     model,
                     output_format,
                     allowed_tools,
@@ -563,6 +574,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,
+                    cwd,
                     output_format,
                 }),
             }
@@ -576,12 +588,14 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         "branch" => parse_branch_args(&rest[1..]),
         "export" => parse_export_args(&rest[1..], output_format),
         "prompt" => {
-            let prompt = rest[1..].join(" ");
+            let (cwd, prompt_args) = parse_optional_cwd_prefix(&rest[1..])?;
+            let prompt = prompt_args.join(" ");
             if prompt.trim().is_empty() {
                 return Err("prompt subcommand requires a prompt string".to_string());
             }
             Ok(CliAction::Prompt {
                 prompt,
+                cwd,
                 model,
                 output_format,
                 allowed_tools,
@@ -602,6 +616,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         ),
         _other => Ok(CliAction::Prompt {
             prompt: rest.join(" "),
+            cwd: None,
             model,
             output_format,
             allowed_tools,
@@ -723,6 +738,7 @@ fn parse_direct_slash_cli_action(
             match classify_skills_slash_command(args.as_deref()) {
                 SkillSlashDispatch::Invoke(prompt) => Ok(CliAction::Prompt {
                     prompt,
+                    cwd: None,
                     model,
                     output_format,
                     allowed_tools,
@@ -733,6 +749,7 @@ fn parse_direct_slash_cli_action(
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,
+                    cwd: None,
                     output_format,
                 }),
             }
@@ -1069,6 +1086,37 @@ fn parse_system_prompt_args(
         date,
         output_format,
     })
+}
+
+fn parse_optional_cwd_prefix(args: &[String]) -> Result<(Option<PathBuf>, Vec<String>), String> {
+    if args.len() >= 2 && args[0] == "--cwd" {
+        return Ok((Some(PathBuf::from(&args[1])), args[2..].to_vec()));
+    }
+    if let Some(value) = args
+        .first()
+        .and_then(|arg| arg.strip_prefix("--cwd="))
+        .filter(|value| !value.is_empty())
+    {
+        return Ok((Some(PathBuf::from(value)), args[1..].to_vec()));
+    }
+    Ok((None, args.to_vec()))
+}
+
+fn run_with_optional_cwd<T, F>(
+    cwd: Option<&Path>,
+    action: F,
+) -> Result<T, Box<dyn std::error::Error>>
+where
+    F: FnOnce() -> Result<T, Box<dyn std::error::Error>>,
+{
+    let Some(target_cwd) = cwd else {
+        return action();
+    };
+    let previous_cwd = env::current_dir()?;
+    env::set_current_dir(target_cwd)?;
+    let result = action();
+    let _ = env::set_current_dir(previous_cwd);
+    result
 }
 
 fn parse_config_args(args: &[String]) -> Result<CliAction, String> {
@@ -2208,7 +2256,7 @@ fn print_system_prompt(
     date: String,
     output_format: CliOutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let sections = load_system_prompt(cwd, date, env::consts::OS, "unknown")?;
+    let sections = load_system_prompt_with_appfs(cwd, date, env::consts::OS, "unknown")?;
     let message = sections.join("\n\n");
     match output_format {
         CliOutputFormat::Text => println!("{message}"),
@@ -4027,7 +4075,7 @@ impl LiveCli {
                 match classify_skills_slash_command(args.as_deref()) {
                     SkillSlashDispatch::Invoke(prompt) => self.run_turn(&prompt)?,
                     SkillSlashDispatch::Local => {
-                        Self::print_skills(args.as_deref(), CliOutputFormat::Text)?;
+                        Self::print_skills_in(None, args.as_deref(), CliOutputFormat::Text)?;
                     }
                 }
                 false
@@ -4397,19 +4445,22 @@ impl LiveCli {
         Ok(())
     }
 
-    fn print_skills(
+    fn print_skills_in(
+        cwd_override: Option<&Path>,
         args: Option<&str>,
         output_format: CliOutputFormat,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let cwd = env::current_dir()?;
-        match output_format {
-            CliOutputFormat::Text => println!("{}", handle_skills_slash_command(args, &cwd)?),
-            CliOutputFormat::Json => println!(
-                "{}",
-                serde_json::to_string_pretty(&handle_skills_slash_command_json(args, &cwd)?)?
-            ),
-        }
-        Ok(())
+        run_with_optional_cwd(cwd_override, || {
+            let cwd = env::current_dir()?;
+            match output_format {
+                CliOutputFormat::Text => println!("{}", handle_skills_slash_command(args, &cwd)?),
+                CliOutputFormat::Json => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&handle_skills_slash_command_json(args, &cwd)?)?
+                ),
+            }
+            Ok(())
+        })
     }
 
     fn print_diff() -> Result<(), Box<dyn std::error::Error>> {
@@ -6606,7 +6657,7 @@ fn short_tool_id(id: &str) -> String {
 }
 
 fn build_system_prompt() -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    Ok(load_system_prompt(
+    Ok(load_system_prompt_with_appfs(
         env::current_dir()?,
         DEFAULT_DATE,
         env::consts::OS,
@@ -7069,6 +7120,11 @@ fn build_runtime_with_plugin_state(
         mcp_state,
     } = runtime_plugin_state;
     plugin_registry.initialize()?;
+    let cwd = env::current_dir()?;
+    let mut session = session;
+    if should_inject_model_facing_skill_listing(enable_tools, allowed_tools.as_ref()) {
+        sync_model_facing_skill_listing(&mut session, &cwd).map_err(std::io::Error::other)?;
+    }
     let policy = permission_policy(permission_mode, &feature_config, &tool_registry)
         .map_err(std::io::Error::other)?;
     let mut runtime = ConversationRuntime::new_with_features(
@@ -9298,6 +9354,7 @@ mod tests {
             parse_args(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "hello world".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -9434,6 +9491,7 @@ mod tests {
             parse_args(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "explain this".to_string(),
+                cwd: None,
                 model: "claude-opus".to_string(),
                 output_format: CliOutputFormat::Json,
                 allowed_tools: None,
@@ -9464,6 +9522,7 @@ mod tests {
             parsed,
             CliAction::Prompt {
                 prompt: "summarize this".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -9506,6 +9565,7 @@ mod tests {
             parse_args(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "explain this".to_string(),
+                cwd: None,
                 model: "claude-opus-4-6".to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -9633,6 +9693,7 @@ mod tests {
             parsed,
             CliAction::Prompt {
                 prompt: "do the thing".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -9697,6 +9758,50 @@ mod tests {
     }
 
     #[test]
+    fn parses_prompt_subcommand_with_cwd_override() {
+        let _guard = env_lock();
+        std::env::remove_var("RUSTY_CLAUDE_PERMISSION_MODE");
+        let args = vec![
+            "prompt".to_string(),
+            "--cwd".to_string(),
+            "/tmp/project".to_string(),
+            "hello".to_string(),
+        ];
+        assert_eq!(
+            parse_args(&args).expect("prompt cwd args should parse"),
+            CliAction::Prompt {
+                prompt: "hello".to_string(),
+                cwd: Some(PathBuf::from("/tmp/project")),
+                model: DEFAULT_MODEL.to_string(),
+                output_format: CliOutputFormat::Text,
+                allowed_tools: None,
+                permission_mode: PermissionMode::DangerFullAccess,
+                compact: false,
+                base_commit: None,
+                reasoning_effort: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_skills_subcommand_with_cwd_override() {
+        let args = vec![
+            "skills".to_string(),
+            "--cwd".to_string(),
+            "/tmp/project".to_string(),
+            "help".to_string(),
+        ];
+        assert_eq!(
+            parse_args(&args).expect("skills cwd args should parse"),
+            CliAction::Skills {
+                args: Some("help".to_string()),
+                cwd: Some(PathBuf::from("/tmp/project")),
+                output_format: CliOutputFormat::Text,
+            }
+        );
+    }
+
+    #[test]
     fn parses_login_and_logout_subcommands() {
         assert_eq!(
             parse_args(&["login".to_string()]).expect("login should parse"),
@@ -9740,6 +9845,7 @@ mod tests {
             parse_args(&["skills".to_string()]).expect("skills should parse"),
             CliAction::Skills {
                 args: None,
+                cwd: None,
                 output_format: CliOutputFormat::Text,
             }
         );
@@ -9752,6 +9858,7 @@ mod tests {
             .expect("skills help overview should invoke"),
             CliAction::Prompt {
                 prompt: "$help overview".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -10158,6 +10265,7 @@ mod tests {
             .expect("json /skills help should parse"),
             CliAction::Skills {
                 args: Some("help".to_string()),
+                cwd: None,
                 output_format: CliOutputFormat::Json,
             }
         );
@@ -10182,6 +10290,7 @@ mod tests {
                 .expect("prompt shorthand should still work"),
             CliAction::Prompt {
                 prompt: "help me debug".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -10214,6 +10323,7 @@ mod tests {
             parse_args(&["/skills".to_string()]).expect("/skills should parse"),
             CliAction::Skills {
                 args: None,
+                cwd: None,
                 output_format: CliOutputFormat::Text,
             }
         );
@@ -10222,6 +10332,7 @@ mod tests {
                 .expect("/skills help should parse"),
             CliAction::Skills {
                 args: Some("help".to_string()),
+                cwd: None,
                 output_format: CliOutputFormat::Text,
             }
         );
@@ -10234,6 +10345,7 @@ mod tests {
             .expect("/skills help overview should invoke"),
             CliAction::Prompt {
                 prompt: "$help overview".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
@@ -10252,6 +10364,7 @@ mod tests {
             .expect("/skills install should parse"),
             CliAction::Skills {
                 args: Some("install ./fixtures/help-skill".to_string()),
+                cwd: None,
                 output_format: CliOutputFormat::Text,
             }
         );
@@ -10260,6 +10373,7 @@ mod tests {
                 .expect("/skills /test should normalize to a single skill prompt prefix"),
             CliAction::Prompt {
                 prompt: "$test".to_string(),
+                cwd: None,
                 model: DEFAULT_MODEL.to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -92,7 +92,10 @@ fn latest_skill_listing_content(session: &Session) -> Option<String> {
         .iter()
         .rev()
         .find(|message| {
-            message.attachment_metadata.as_ref().map(|metadata| metadata.kind)
+            message
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind)
                 == Some(AttachmentKind::SkillListing)
         })
         .map(conversation_message_text)
@@ -6867,10 +6870,9 @@ mod tests {
         execute_tool_with_effects, final_assistant_text, maybe_commit_provenance,
         model_visible_tool_result, model_visible_tool_result_with_id, mvp_tool_specs,
         permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_task_packet, should_inject_model_facing_skill_listing,
-        sync_model_facing_skill_listing, AgentInput, AgentJob,
-        ForkedSkillExecutionResult, ForkedSkillRequest, GlobalToolRegistry, LaneEventName,
-        LaneFailureClass, ModelVisibleToolResult, PowerShellCommandOutput,
+        run_task_packet, should_inject_model_facing_skill_listing, sync_model_facing_skill_listing,
+        AgentInput, AgentJob, ForkedSkillExecutionResult, ForkedSkillRequest, GlobalToolRegistry,
+        LaneEventName, LaneFailureClass, ModelVisibleToolResult, PowerShellCommandOutput,
         ProviderRuntimeClient, SkillInput, SubagentToolExecutor,
     };
     use api::{OutputContentBlock, ToolResultContentBlock};
@@ -7565,7 +7567,10 @@ mod tests {
         ));
         assert!(should_inject_model_facing_skill_listing(
             true,
-            Some(&BTreeSet::from([String::from("Skill"), String::from("bash")]))
+            Some(&BTreeSet::from([
+                String::from("Skill"),
+                String::from("bash")
+            ]))
         ));
         assert!(should_inject_model_facing_skill_listing(true, None));
     }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -15,7 +15,7 @@ use plugins::PluginTool;
 use reqwest::blocking::Client;
 use runtime::{
     check_freshness, dedupe_superseded_commit_events, edit_file, execute_bash, glob_search,
-    grep_search, load_system_prompt,
+    grep_search, load_system_prompt_with_appfs,
     lsp_client::LspRegistry,
     mcp_tool_bridge::McpToolRegistry,
     permission_enforcer::{EnforcementResult, PermissionEnforcer},
@@ -43,6 +43,71 @@ use crate::file_tools::{
     prepare_edit, prepare_read, prepare_write, read_tool_result_text, record_edit_result,
     record_read_result, record_write_result, write_tool_result_text,
 };
+
+#[cfg(test)]
+pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub fn sync_model_facing_skill_listing(session: &mut Session, cwd: &Path) -> Result<(), String> {
+    let Some(content) =
+        commands::render_model_facing_skill_listing(cwd).map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+
+    if latest_skill_listing_content(session)
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|existing| existing == content.trim())
+    {
+        return Ok(());
+    }
+
+    session
+        .push_message(ConversationMessage::attachment_user_text(
+            content,
+            AttachmentKind::SkillListing,
+        ))
+        .map_err(|error| error.to_string())
+}
+
+#[must_use]
+pub fn should_inject_model_facing_skill_listing(
+    enable_tools: bool,
+    allowed_tools: Option<&BTreeSet<String>>,
+) -> bool {
+    enable_tools
+        && allowed_tools
+            .map(|tools| tools.contains("Skill"))
+            .unwrap_or(true)
+}
+
+fn latest_skill_listing_content(session: &Session) -> Option<String> {
+    session
+        .messages
+        .iter()
+        .rev()
+        .find(|message| {
+            message.attachment_metadata.as_ref().map(|metadata| metadata.kind)
+                == Some(AttachmentKind::SkillListing)
+        })
+        .map(conversation_message_text)
+}
+
+fn conversation_message_text(message: &ConversationMessage) -> String {
+    message
+        .blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => None,
+        })
+        .collect()
+}
 
 /// Global task registry shared across tool invocations within a session.
 fn global_lsp_registry() -> &'static LspRegistry {
@@ -3383,6 +3448,11 @@ fn resolve_primary_skill_for_execution(
                 prompt,
             })
         }
+        commands::ResolvedSkillSource::Generated { id, base_dir } => Ok(ResolvedSkillExecution {
+            path: format!("generated://{id}"),
+            document: skill.document,
+            prompt: prepend_skill_base_directory(&prompt_body, base_dir.as_deref()),
+        }),
     }
 }
 
@@ -3970,8 +4040,13 @@ fn build_agent_runtime(
     let permission_policy = agent_permission_policy();
     let tool_executor = SubagentToolExecutor::new(allowed_tools)
         .with_enforcer(PermissionEnforcer::new(permission_policy.clone()));
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let mut session = Session::new();
+    if should_inject_model_facing_skill_listing(true, Some(&job.allowed_tools)) {
+        sync_model_facing_skill_listing(&mut session, &cwd)?;
+    }
     Ok(ConversationRuntime::new(
-        Session::new(),
+        session,
         api_client,
         tool_executor,
         permission_policy,
@@ -3981,7 +4056,7 @@ fn build_agent_runtime(
 
 fn build_agent_system_prompt(subagent_type: &str) -> Result<Vec<String>, String> {
     let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
-    let mut prompt = load_system_prompt(
+    let mut prompt = load_system_prompt_with_appfs(
         cwd,
         DEFAULT_AGENT_SYSTEM_DATE.to_string(),
         std::env::consts::OS,
@@ -6792,9 +6867,11 @@ mod tests {
         execute_tool_with_effects, final_assistant_text, maybe_commit_provenance,
         model_visible_tool_result, model_visible_tool_result_with_id, mvp_tool_specs,
         permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_task_packet, AgentInput, AgentJob, ForkedSkillExecutionResult, ForkedSkillRequest,
-        GlobalToolRegistry, LaneEventName, LaneFailureClass, ModelVisibleToolResult,
-        PowerShellCommandOutput, ProviderRuntimeClient, SkillInput, SubagentToolExecutor,
+        run_task_packet, should_inject_model_facing_skill_listing,
+        sync_model_facing_skill_listing, AgentInput, AgentJob,
+        ForkedSkillExecutionResult, ForkedSkillRequest, GlobalToolRegistry, LaneEventName,
+        LaneFailureClass, ModelVisibleToolResult, PowerShellCommandOutput,
+        ProviderRuntimeClient, SkillInput, SubagentToolExecutor,
     };
     use api::{OutputContentBlock, ToolResultContentBlock};
     #[cfg(windows)]
@@ -6808,8 +6885,7 @@ mod tests {
     use serde_json::json;
 
     fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::shared_test_env_lock()
     }
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -7414,6 +7490,84 @@ mod tests {
             .expect("time")
             .as_nanos();
         std::env::temp_dir().join(format!("clawd-tools-{unique}-{name}"))
+    }
+
+    fn write_skill(root: &Path, name: &str, contents: &str) {
+        let skill_dir = root.join(".claw").join("skills").join(name);
+        fs::create_dir_all(&skill_dir).expect("skill dir");
+        fs::write(skill_dir.join("SKILL.md"), contents).expect("skill file");
+    }
+
+    fn remove_dir_all_with_retry(path: &Path, label: &str) {
+        for attempt in 0..10 {
+            match fs::remove_dir_all(path) {
+                Ok(()) => return,
+                Err(error) if attempt < 9 => {
+                    #[cfg(windows)]
+                    if error.raw_os_error() == Some(32) {
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        continue;
+                    }
+
+                    #[cfg(not(windows))]
+                    {
+                        let _ = error;
+                    }
+
+                    panic!("{label}: {error}");
+                }
+                Err(error) => panic!("{label}: {error}"),
+            }
+        }
+    }
+
+    #[test]
+    fn syncs_model_facing_skill_listing_into_session_without_duplicates() {
+        let _guard = env_guard();
+        let workspace = temp_path("skill-listing-sync");
+        let cwd = workspace.join("project");
+        fs::create_dir_all(&cwd).expect("workspace dir");
+        write_skill(
+            &workspace,
+            "trace",
+            "---\nname: trace\ndescription: Trace repository state\nwhen_to_use: Use when tracing repository context.\n---\n\n# trace\n",
+        );
+        let original_dir = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&cwd).expect("set cwd");
+
+        let mut session = Session::new();
+        sync_model_facing_skill_listing(&mut session, &cwd).expect("sync should succeed");
+        sync_model_facing_skill_listing(&mut session, &cwd).expect("second sync should dedupe");
+
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(
+            session.messages[0]
+                .attachment_metadata
+                .as_ref()
+                .map(|metadata| metadata.kind),
+            Some(AttachmentKind::SkillListing)
+        );
+        let ContentBlock::Text { text } = &session.messages[0].blocks[0] else {
+            panic!("expected listing text");
+        };
+        assert!(text.contains("- trace: Trace repository state"));
+
+        restore_cwd(&original_dir);
+        remove_dir_all_with_retry(&workspace, "cleanup skill listing workspace");
+    }
+
+    #[test]
+    fn skips_skill_listing_when_skill_tool_is_unavailable() {
+        assert!(!should_inject_model_facing_skill_listing(false, None));
+        assert!(!should_inject_model_facing_skill_listing(
+            true,
+            Some(&BTreeSet::from([String::from("bash")]))
+        ));
+        assert!(should_inject_model_facing_skill_listing(
+            true,
+            Some(&BTreeSet::from([String::from("Skill"), String::from("bash")]))
+        ));
+        assert!(should_inject_model_facing_skill_listing(true, None));
     }
 
     fn run_git(cwd: &Path, args: &[&str]) {
@@ -8664,7 +8818,7 @@ mod tests {
             .ends_with(".claw/commands/handoff.md"));
 
         restore_cwd(&original_dir);
-        fs::remove_dir_all(root).expect("temp project should clean up");
+        remove_dir_all_with_retry(&root, "temp project should clean up");
     }
 
     #[test]
@@ -8728,7 +8882,7 @@ mod tests {
             Some(value) => std::env::set_var("CODEX_HOME", value),
             None => std::env::remove_var("CODEX_HOME"),
         }
-        fs::remove_dir_all(root).expect("temp tree should clean up");
+        remove_dir_all_with_retry(&root, "temp tree should clean up");
     }
 
     #[test]
@@ -8990,7 +9144,7 @@ mod tests {
         } else {
             std::env::remove_var("HOME");
         }
-        fs::remove_dir_all(root).expect("temp tree should clean up");
+        remove_dir_all_with_retry(&root, "temp tree should clean up");
     }
 
     #[test]
@@ -9026,7 +9180,7 @@ mod tests {
         assert!(expected_root.join("examples").join("server.md").is_file());
 
         restore_cwd(&original_dir);
-        fs::remove_dir_all(root).expect("temp root should clean up");
+        remove_dir_all_with_retry(&root, "temp root should clean up");
     }
 
     #[test]
@@ -9079,7 +9233,7 @@ mod tests {
         assert!(!prompt.contains("Base directory for this skill: "));
 
         restore_cwd(&original_dir);
-        fs::remove_dir_all(root).expect("temp root should clean up");
+        remove_dir_all_with_retry(&root, "temp root should clean up");
     }
 
     #[test]
@@ -9153,7 +9307,7 @@ mod tests {
             Some(value) => std::env::set_var("CODEX_HOME", value),
             None => std::env::remove_var("CODEX_HOME"),
         }
-        fs::remove_dir_all(root).expect("temp tree should clean up");
+        remove_dir_all_with_retry(&root, "temp tree should clean up");
     }
 
     #[test]
@@ -9211,7 +9365,7 @@ mod tests {
             Some(value) => std::env::set_var("CLAUDE_CONFIG_DIR", value),
             None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
         }
-        fs::remove_dir_all(root).expect("temp tree should clean up");
+        remove_dir_all_with_retry(&root, "temp tree should clean up");
     }
 
     #[test]
@@ -9287,7 +9441,7 @@ mod tests {
             Some(value) => std::env::set_var("CLAUDE_CONFIG_DIR", value),
             None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
         }
-        fs::remove_dir_all(root).expect("temp tree should clean up");
+        remove_dir_all_with_retry(&root, "temp tree should clean up");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add AppFS mount-root skill discovery so mounted apps surface from the root directory
- add model-facing skill listing support for generated AppFS skills and prompt/session wiring
- add CLI cwd overrides and AppFS-aware prompt loading for root-level testing

## Testing
- cargo test --manifest-path rust/Cargo.toml -p commands resolves_generated_appfs_skill -- --nocapture
- cargo test --manifest-path rust/Cargo.toml -p runtime appfs_prompt_section_surfaces -- --nocapture
- cargo test --manifest-path rust/Cargo.toml -p rusty-claude-cli parses_prompt_subcommand_with_cwd_override -- --nocapture
- cargo check --manifest-path rust/Cargo.toml -p commands -p tools -p runtime -p rusty-claude-cli