### PR TITLE
Backfill AppFS principal support

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -307,6 +307,15 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: false,
     },
     SlashCommandSpec {
+        name: "principal",
+        aliases: &[],
+        summary: "List, create, or fork AppFS semantic principals",
+        argument_hint: Some(
+            "[list|create <principal-id> [description]|fork <principal-id> [task]]",
+        ),
+        resume_supported: false,
+    },
+    SlashCommandSpec {
         name: "plugin",
         aliases: &["plugins", "marketplace"],
         summary: "Manage Claw Code plugins",
@@ -1183,6 +1192,11 @@ pub enum SlashCommand {
         action: Option<String>,
         target: Option<String>,
     },
+    Principal {
+        action: Option<String>,
+        target: Option<String>,
+        description: Option<String>,
+    },
     Plugins {
         action: Option<String>,
         target: Option<String>,
@@ -1392,6 +1406,7 @@ pub fn validate_slash_command_input(
         }
         "export" => SlashCommand::Export { path: remainder },
         "session" => parse_session_command(&args)?,
+        "principal" => parse_principal_command(&args)?,
         "plugin" | "plugins" | "marketplace" => parse_plugin_command(&args)?,
         "agents" => SlashCommand::Agents {
             args: parse_list_or_help_args(command, remainder)?,
@@ -1658,6 +1673,52 @@ fn parse_session_command(args: &[&str]) -> Result<SlashCommand, SlashCommandPars
             ),
             "session",
             "/session [list|switch <session-id>|fork [branch-name]|delete <session-id> [--force]]",
+        )),
+    }
+}
+
+fn parse_principal_command(args: &[&str]) -> Result<SlashCommand, SlashCommandParseError> {
+    match args {
+        [] | ["list"] => Ok(SlashCommand::Principal {
+            action: Some("list".to_string()),
+            target: None,
+            description: None,
+        }),
+        ["list", ..] => Err(usage_error(
+            "principal",
+            "[list|create <principal-id> [description]|fork <principal-id> [task]]",
+        )),
+        ["create"] => Err(usage_error(
+            "principal create",
+            "<principal-id> [description]",
+        )),
+        ["create", target] => Ok(SlashCommand::Principal {
+            action: Some("create".to_string()),
+            target: Some((*target).to_string()),
+            description: None,
+        }),
+        ["create", target, description @ ..] => Ok(SlashCommand::Principal {
+            action: Some("create".to_string()),
+            target: Some((*target).to_string()),
+            description: Some(description.join(" ")),
+        }),
+        ["fork"] => Err(usage_error("principal fork", "<principal-id> [task]")),
+        ["fork", target] => Ok(SlashCommand::Principal {
+            action: Some("fork".to_string()),
+            target: Some((*target).to_string()),
+            description: None,
+        }),
+        ["fork", target, description @ ..] => Ok(SlashCommand::Principal {
+            action: Some("fork".to_string()),
+            target: Some((*target).to_string()),
+            description: Some(description.join(" ")),
+        }),
+        [action, ..] => Err(command_error(
+            &format!(
+                "Unknown /principal action '{action}'. Use list, create <principal-id> [description], or fork <principal-id> [task]."
+            ),
+            "principal",
+            "/principal [list|create <principal-id> [description]|fork <principal-id> [task]]",
         )),
     }
 }
@@ -3313,9 +3374,14 @@ fn generated_appfs_skill_summaries(cwd: &Path) -> Vec<SkillSummary> {
 
     let mut candidates = BTreeMap::<String, PathBuf>::new();
     for app in &environment.registered_apps {
-        candidates
-            .entry(app.app_id.clone())
-            .or_insert_with(|| environment.mount_root.join(&app.app_id));
+        candidates.entry(app.app_id.clone()).or_insert_with(|| {
+            let trimmed = app.path.trim().trim_start_matches(['/', '\\']);
+            if trimmed.is_empty() {
+                environment.mount_root.clone()
+            } else {
+                environment.mount_root.join(trimmed)
+            }
+        });
     }
 
     if let (Some(app_id), Some(app_root)) = (
@@ -5000,6 +5066,7 @@ where
         | SlashCommand::Version
         | SlashCommand::Export { .. }
         | SlashCommand::Session { .. }
+        | SlashCommand::Principal { .. }
         | SlashCommand::Plugins { .. }
         | SlashCommand::Agents { .. }
         | SlashCommand::Skills { .. }
@@ -5069,8 +5136,8 @@ mod tests {
         render_resolved_skill_prompt, render_skills_report, render_slash_command_help,
         render_slash_command_help_detail, resolve_skill, resolve_skill_path,
         resume_supported_slash_commands, slash_command_specs, suggest_slash_commands,
-        validate_slash_command_input, DefinitionSource, SkillOrigin, SkillRoot, SkillSlashDispatch,
-        SlashCommand,
+        validate_slash_command_input, DefinitionSource, ResolvedSkillSource, SkillOrigin,
+        SkillRoot, SkillSlashDispatch, SlashCommand,
     };
     use plugins::{PluginKind, PluginManager, PluginManagerConfig, PluginMetadata, PluginSummary};
     use runtime::{
@@ -5212,6 +5279,42 @@ mod tests {
         )
         .expect("write scopes");
         app_root
+    }
+
+    fn seed_appfs_private_skill_mount(root: &Path) -> PathBuf {
+        let mount_root = root.join("mnt");
+        let aiim_root = mount_root.join("aiim");
+        let tinode_root = mount_root.join("private").join("default").join("tinode");
+        let secret_root = mount_root
+            .join("private")
+            .join("incident-reporter")
+            .join("secret");
+        fs::create_dir_all(mount_root.join("_appfs")).expect("control dir");
+        fs::create_dir_all(aiim_root.join("_app")).expect("aiim control dir");
+        fs::create_dir_all(tinode_root.join("_app")).expect("tinode control dir");
+        fs::create_dir_all(secret_root.join("_app")).expect("secret control dir");
+        fs::write(mount_root.join("_appfs").join("register_app.act"), "").expect("register act");
+        fs::write(
+            mount_root.join("_appfs").join("apps.registry.json"),
+            r#"{"version":1,"apps":[{"instance_id":"aiim","app_id":"aiim","visibility":"public","path":"aiim","session_id":"sess-aiim","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}},{"instance_id":"tinode--default","app_id":"tinode","visibility":"private_instance","parent_app_id":"tinode","principal_id":"default","profile_id":"tinode:default","path":"private/default/tinode","session_id":"sess-tinode-default","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}},{"instance_id":"secret--incident-reporter","app_id":"secret","visibility":"private_instance","parent_app_id":"secret","principal_id":"incident-reporter","profile_id":"secret:incident-reporter","path":"private/incident-reporter/secret","session_id":"sess-secret-incident","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}}]}"#,
+        )
+        .expect("write registry");
+        fs::write(
+            aiim_root.join("_app").join("skill.res.json"),
+            r#"{"app_id":"aiim","description":"AIIM public chat app.","when_to_use":"Use for public AIIM chat."}"#,
+        )
+        .expect("write aiim skill");
+        fs::write(
+            tinode_root.join("_app").join("skill.res.json"),
+            r#"{"app_id":"tinode","description":"Tinode private chat app.","when_to_use":"Use for the current principal's Tinode chat."}"#,
+        )
+        .expect("write tinode skill");
+        fs::write(
+            secret_root.join("_app").join("skill.res.json"),
+            r#"{"app_id":"secret","description":"Incident-only private app.","when_to_use":"Use only for incident reporter."}"#,
+        )
+        .expect("write secret skill");
+        mount_root
     }
 
     fn seed_control_only_appfs_skill_mount(root: &Path) -> PathBuf {
@@ -5379,6 +5482,31 @@ mod tests {
         assert!(listing.contains("- appfs-aiim:"));
         assert!(listing.contains("一个 AI 专用的聊天软件，用于收发消息。"));
         assert!(listing.contains("当用户想要向某人发送消息、查看聊天记录"));
+    }
+
+    #[test]
+    fn generated_appfs_skills_filter_private_apps_by_current_principal() {
+        let workspace = temp_dir("model-facing-skill-listing-private");
+        let mount_root = seed_appfs_private_skill_mount(&workspace);
+
+        let listing = super::render_model_facing_skill_listing_with_budget(&mount_root, 8_000)
+            .expect("listing should render")
+            .expect("listing should exist");
+
+        assert!(listing.contains("- appfs-aiim: AIIM public chat app."));
+        assert!(listing.contains("- appfs-tinode: Tinode private chat app."));
+        assert!(!listing.contains("appfs-secret"));
+
+        let resolved = resolve_skill(&mount_root, "appfs-tinode").expect("generated tinode skill");
+        assert_eq!(
+            resolved.source,
+            ResolvedSkillSource::Generated {
+                id: "appfs-tinode".to_string(),
+                base_dir: Some(mount_root.join("private").join("default").join("tinode")),
+            }
+        );
+        let prompt = render_resolved_skill_prompt(&resolved, None);
+        assert!(prompt.contains("Tinode private chat app."));
     }
 
     #[test]
@@ -5607,6 +5735,30 @@ mod tests {
             Ok(Some(SlashCommand::Session {
                 action: Some("fork".to_string()),
                 target: Some("incident-review".to_string())
+            }))
+        );
+        assert_eq!(
+            SlashCommand::parse("/principal list"),
+            Ok(Some(SlashCommand::Principal {
+                action: Some("list".to_string()),
+                target: None,
+                description: None,
+            }))
+        );
+        assert_eq!(
+            SlashCommand::parse("/principal create incident-reporter handles incident updates"),
+            Ok(Some(SlashCommand::Principal {
+                action: Some("create".to_string()),
+                target: Some("incident-reporter".to_string()),
+                description: Some("handles incident updates".to_string()),
+            }))
+        );
+        assert_eq!(
+            SlashCommand::parse("/principal fork code-implementer implement the plan"),
+            Ok(Some(SlashCommand::Principal {
+                action: Some("fork".to_string()),
+                target: Some("code-implementer".to_string()),
+                description: Some("implement the plan".to_string()),
             }))
         );
     }
@@ -6059,6 +6211,9 @@ mod tests {
         assert!(help.contains("/version"));
         assert!(help.contains("/export [file]"));
         assert!(help.contains("/session"), "help must mention /session");
+        assert!(help.contains(
+            "/principal [list|create <principal-id> [description]|fork <principal-id> [task]]"
+        ));
         assert!(help.contains("/sandbox"));
         assert!(help.contains(
             "/plugin [list|install <path>|enable <name>|disable <name>|uninstall <id>|update <id>]"
@@ -6066,7 +6221,7 @@ mod tests {
         assert!(help.contains("aliases: /plugins, /marketplace"));
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help]"));
-        assert_eq!(slash_command_specs().len(), 141);
+        assert_eq!(slash_command_specs().len(), 142);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/runtime/src/appfs.rs
+++ b/rust/crates/runtime/src/appfs.rs
@@ -1,10 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::session::{AttachmentKind, ConversationMessage, Session, SessionError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -15,6 +17,8 @@ const REGISTER_APP_ACTION: &str = "register_app.act";
 const UNREGISTER_APP_ACTION: &str = "unregister_app.act";
 const LIST_APPS_ACTION: &str = "list_apps.act";
 const REGISTRY_FILE: &str = "apps.registry.json";
+const PRINCIPALS_FILE: &str = "principals.registry.json";
+const APP_POLICIES_FILE: &str = "app-policies.registry.json";
 const APP_CONTROL_DIR_NAME: &str = "_app";
 const APP_STREAM_DIR_NAME: &str = "_stream";
 const EVENTS_FILE: &str = "events.evt.jsonl";
@@ -27,8 +31,10 @@ pub const APPFS_RUNTIME_MANIFEST_ENV: &str = "APPFS_RUNTIME_MANIFEST";
 pub const APPFS_MOUNT_ROOT_ENV: &str = "APPFS_MOUNT_ROOT";
 pub const APPFS_RUNTIME_SESSION_ID_ENV: &str = "APPFS_RUNTIME_SESSION_ID";
 pub const APPFS_ATTACH_ID_ENV: &str = "APPFS_ATTACH_ID";
+pub const APPFS_PRINCIPAL_ID_ENV: &str = "APPFS_PRINCIPAL_ID";
 pub const APPFS_AGENT_ROLE_ENV: &str = "APPFS_AGENT_ROLE";
 pub const APPFS_MULTI_AGENT_MODE_SHARED: &str = "shared_mount_distinct_attach";
+pub const APPFS_DEFAULT_PRINCIPAL_ID: &str = "default";
 pub const APPFS_RUNTIME_KIND: &str = "appfs";
 pub const APPFS_SCHEMA_VERSION: u32 = 1;
 
@@ -55,8 +61,40 @@ impl AppfsAttachSource {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppfsRegisteredApp {
+    pub instance_id: String,
     pub app_id: String,
+    pub visibility: AppfsRegisteredAppVisibility,
+    pub parent_app_id: Option<String>,
+    pub principal_id: Option<String>,
+    pub profile_id: Option<String>,
+    pub path: String,
     pub active_scope: Option<String>,
+}
+
+impl AppfsRegisteredApp {
+    fn app_root(&self, mount_root: &Path) -> PathBuf {
+        absolute_mount_path(mount_root, &self.path)
+    }
+
+    #[must_use]
+    pub fn is_public(&self) -> bool {
+        self.visibility == AppfsRegisteredAppVisibility::Public
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppfsRegisteredAppVisibility {
+    Public,
+    PrivateInstance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppfsPrincipalSummary {
+    pub principal_id: String,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+    pub kind: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -97,6 +135,7 @@ pub struct AppfsEnvironment {
     pub mount_root: PathBuf,
     pub runtime_session_id: Option<String>,
     pub attach_id: String,
+    pub principal_id: String,
     pub attach_role: Option<String>,
     pub multi_agent_mode: String,
     pub manifest_path: Option<PathBuf>,
@@ -110,7 +149,32 @@ pub struct AppfsEnvironment {
     pub current_app_root: Option<PathBuf>,
     pub current_app_events_path: Option<PathBuf>,
     pub registered_apps: Vec<AppfsRegisteredApp>,
+    pub known_principals: Vec<AppfsPrincipalSummary>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppfsPrincipalCreateRequest {
+    pub principal_id: String,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppfsPrincipalCreateStatus {
+    Created,
+    Exists,
+    Submitted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppfsPrincipalCreateOutcome {
+    pub principal_id: String,
+    pub status: AppfsPrincipalCreateStatus,
+    pub action_path: PathBuf,
+    pub registry_path: PathBuf,
+    pub visible_private_apps: Vec<AppfsRegisteredApp>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -152,6 +216,7 @@ struct AppfsAttachEnv {
     mount_root: Option<PathBuf>,
     runtime_session_id: Option<String>,
     attach_id: Option<String>,
+    principal_id: Option<String>,
     attach_role: Option<String>,
 }
 
@@ -162,6 +227,7 @@ impl AppfsAttachEnv {
             || self.mount_root.is_some()
             || self.runtime_session_id.is_some()
             || self.attach_id.is_some()
+            || self.principal_id.is_some()
             || self.attach_role.is_some()
     }
 }
@@ -179,6 +245,7 @@ struct HeuristicDetection {
     current_app_root: Option<PathBuf>,
     current_app_events_path: Option<PathBuf>,
     registered_apps: Vec<AppfsRegisteredApp>,
+    known_principals: Vec<AppfsPrincipalSummary>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -198,7 +265,99 @@ pub fn detect_appfs_environment(cwd: &Path) -> Option<AppfsEnvironment> {
 
 #[must_use]
 pub fn resolve_appfs_environment(cwd: &Path) -> Option<AppfsEnvironment> {
-    resolve_appfs_environment_with_attach_env(cwd, load_attach_env())
+    let attach_env = load_attach_env();
+    let environment = resolve_appfs_environment_with_attach_env(cwd, attach_env.clone())?;
+    if should_auto_create_default_principal(&environment) {
+        if let Some(control_dir) = environment.control_dir.as_deref() {
+            if has_pending_default_principal_create_action(control_dir) {
+                let _ = wait_for_principal_ready(
+                    control_dir,
+                    &control_dir.join(PRINCIPALS_FILE),
+                    environment.registry_path.as_deref(),
+                    APPFS_DEFAULT_PRINCIPAL_ID,
+                );
+            } else {
+                let request = AppfsPrincipalCreateRequest {
+                    principal_id: APPFS_DEFAULT_PRINCIPAL_ID.to_string(),
+                    display_name: Some("Default agent".to_string()),
+                    description: Some("The default AppFS agent principal.".to_string()),
+                    kind: Some("agent".to_string()),
+                };
+                let _ = create_appfs_principal_from_environment(request, environment.clone());
+            }
+        }
+        return resolve_appfs_environment_with_attach_env(cwd, attach_env).or(Some(environment));
+    }
+    Some(environment)
+}
+
+pub fn create_appfs_principal(
+    cwd: &Path,
+    request: AppfsPrincipalCreateRequest,
+) -> Result<AppfsPrincipalCreateOutcome, String> {
+    let environment = resolve_appfs_environment_with_attach_env(cwd, load_attach_env())
+        .ok_or_else(|| "AppFS mount was not detected from the current directory".to_string())?;
+    create_appfs_principal_from_environment(request, environment)
+}
+
+fn create_appfs_principal_from_environment(
+    request: AppfsPrincipalCreateRequest,
+    environment: AppfsEnvironment,
+) -> Result<AppfsPrincipalCreateOutcome, String> {
+    let principal_id = request.principal_id.trim();
+    if !is_safe_principal_id(principal_id) {
+        return Err(
+            "principal_id must use ASCII letters, digits, '.', '_' or '-' and cannot be empty"
+                .to_string(),
+        );
+    }
+
+    let control_dir = environment
+        .control_dir
+        .clone()
+        .ok_or_else(|| "AppFS control directory was not detected".to_string())?;
+    let principal_dir = control_dir.join("principals");
+    let action_path = principal_dir.join("create_principal.act");
+    let registry_path = control_dir.join(PRINCIPALS_FILE);
+
+    if environment
+        .known_principals
+        .iter()
+        .any(|principal| principal.principal_id == principal_id)
+    {
+        return Ok(principal_create_outcome_from_environment(
+            principal_id,
+            AppfsPrincipalCreateStatus::Exists,
+            action_path,
+            registry_path,
+            &environment,
+        ));
+    }
+
+    fs::create_dir_all(&principal_dir).map_err(|err| {
+        format!(
+            "failed to create AppFS principal control directory {}: {err}",
+            principal_dir.display()
+        )
+    })?;
+    append_create_principal_action(&action_path, principal_id, &request)?;
+
+    let status = wait_for_principal_ready(
+        &control_dir,
+        &registry_path,
+        environment.registry_path.as_deref(),
+        principal_id,
+    )
+    .map_or(AppfsPrincipalCreateStatus::Submitted, |_| {
+        AppfsPrincipalCreateStatus::Created
+    });
+    Ok(principal_create_outcome_from_environment(
+        principal_id,
+        status,
+        action_path,
+        registry_path,
+        &environment,
+    ))
 }
 
 #[must_use]
@@ -311,18 +470,15 @@ fn collect_appfs_event_streams(environment: &AppfsEnvironment) -> Vec<AppfsEvent
     }
 
     for app in &environment.registered_apps {
+        let app_root = app.app_root(&environment.mount_root);
         push_appfs_event_stream(
             &mut streams,
             &mut seen,
             AppfsEventStream {
-                stream_id: format!("app:{}", app.app_id),
-                label: format!("AppFS app `{}`", app.app_id),
+                stream_id: format!("app:{}", app.instance_id),
+                label: app_event_label(app),
                 app_id: Some(app.app_id.clone()),
-                path: environment
-                    .mount_root
-                    .join(&app.app_id)
-                    .join(APP_STREAM_DIR_NAME)
-                    .join(EVENTS_FILE),
+                path: app_root.join(APP_STREAM_DIR_NAME).join(EVENTS_FILE),
             },
         );
     }
@@ -331,19 +487,30 @@ fn collect_appfs_event_streams(environment: &AppfsEnvironment) -> Vec<AppfsEvent
         environment.current_app_id.as_ref(),
         environment.current_app_events_path.as_ref(),
     ) {
-        push_appfs_event_stream(
-            &mut streams,
-            &mut seen,
-            AppfsEventStream {
-                stream_id: format!("app:{app_id}"),
-                label: format!("AppFS app `{app_id}`"),
-                app_id: Some(app_id.clone()),
-                path: path.clone(),
-            },
-        );
+        if !streams.iter().any(|stream| stream.path == *path) {
+            push_appfs_event_stream(
+                &mut streams,
+                &mut seen,
+                AppfsEventStream {
+                    stream_id: format!("app:{app_id}"),
+                    label: format!("AppFS app `{app_id}`"),
+                    app_id: Some(app_id.clone()),
+                    path: path.clone(),
+                },
+            );
+        }
     }
 
     streams
+}
+
+fn app_event_label(app: &AppfsRegisteredApp) -> String {
+    match (app.visibility, app.principal_id.as_deref()) {
+        (AppfsRegisteredAppVisibility::PrivateInstance, Some(principal_id)) => {
+            format!("AppFS app `{}` for principal `{principal_id}`", app.app_id)
+        }
+        _ => format!("AppFS app `{}`", app.app_id),
+    }
 }
 
 fn push_appfs_event_stream(
@@ -696,6 +863,7 @@ fn build_env_environment(
         .attach_id
         .clone()
         .unwrap_or_else(generate_ephemeral_attach_id);
+    let principal_id = effective_principal_id(attach_env.principal_id.as_deref());
     let multi_agent_mode = manifest.map_or_else(
         || APPFS_MULTI_AGENT_MODE_SHARED.to_string(),
         |doc| doc.multi_agent_mode.clone(),
@@ -704,12 +872,17 @@ fn build_env_environment(
         .map(|doc| resolve_control_plane_paths(&mount_root, &doc.control_plane))
         .or_else(|| heuristic.map(control_plane_from_heuristic))
         .unwrap_or_default();
-    let current_detection = detect_current_app(&mount_root, cwd);
     let registered_apps = load_registered_apps_from_paths(
         control_paths
             .registry_path
             .as_deref()
             .or_else(|| heuristic.as_ref().map(|d| d.registry_path.as_path())),
+        &principal_id,
+    );
+    let current_detection = detect_current_registered_app(&mount_root, cwd, &registered_apps)
+        .unwrap_or_else(|| detect_current_app(&mount_root, cwd));
+    let known_principals = load_principal_summaries_from_paths(
+        principal_registry_path_from_control_paths(&control_paths).as_deref(),
     );
 
     Some(AppfsEnvironment {
@@ -717,6 +890,7 @@ fn build_env_environment(
         mount_root,
         runtime_session_id,
         attach_id,
+        principal_id,
         attach_role: attach_env.attach_role,
         multi_agent_mode,
         manifest_path,
@@ -730,6 +904,7 @@ fn build_env_environment(
         current_app_root: current_detection.current_app_root,
         current_app_events_path: current_detection.current_app_events_path,
         registered_apps,
+        known_principals,
         warnings,
     })
 }
@@ -747,14 +922,21 @@ fn build_manifest_environment(
     }
 
     let control_paths = resolve_control_plane_paths(&mount_root, &manifest.control_plane);
-    let current_detection = detect_current_app(&mount_root, cwd);
-    let registered_apps = load_registered_apps_from_paths(control_paths.registry_path.as_deref());
+    let principal_id = APPFS_DEFAULT_PRINCIPAL_ID.to_string();
+    let registered_apps =
+        load_registered_apps_from_paths(control_paths.registry_path.as_deref(), &principal_id);
+    let current_detection = detect_current_registered_app(&mount_root, cwd, &registered_apps)
+        .unwrap_or_else(|| detect_current_app(&mount_root, cwd));
+    let known_principals = load_principal_summaries_from_paths(
+        principal_registry_path_from_control_paths(&control_paths).as_deref(),
+    );
 
     Some(AppfsEnvironment {
         attach_source: AppfsAttachSource::Manifest,
         mount_root,
         runtime_session_id: Some(manifest.runtime_session_id.clone()),
         attach_id: generate_ephemeral_attach_id(),
+        principal_id,
         attach_role: None,
         multi_agent_mode: manifest.multi_agent_mode.clone(),
         manifest_path,
@@ -768,6 +950,7 @@ fn build_manifest_environment(
         current_app_root: current_detection.current_app_root,
         current_app_events_path: current_detection.current_app_events_path,
         registered_apps,
+        known_principals,
         warnings,
     })
 }
@@ -781,6 +964,7 @@ fn build_heuristic_environment(
         mount_root: detection.mount_root,
         runtime_session_id: None,
         attach_id: generate_ephemeral_attach_id(),
+        principal_id: APPFS_DEFAULT_PRINCIPAL_ID.to_string(),
         attach_role: None,
         multi_agent_mode: APPFS_MULTI_AGENT_MODE_SHARED.to_string(),
         manifest_path: None,
@@ -794,6 +978,7 @@ fn build_heuristic_environment(
         current_app_root: detection.current_app_root,
         current_app_events_path: detection.current_app_events_path,
         registered_apps: detection.registered_apps,
+        known_principals: detection.known_principals,
         warnings,
     }
 }
@@ -832,6 +1017,32 @@ fn detect_current_app(mount_root: &Path, cwd: &Path) -> CurrentAppDetection {
     }
 }
 
+fn detect_current_registered_app(
+    mount_root: &Path,
+    cwd: &Path,
+    registered_apps: &[AppfsRegisteredApp],
+) -> Option<CurrentAppDetection> {
+    let mut matches = registered_apps
+        .iter()
+        .filter_map(|app| {
+            let app_root = app.app_root(mount_root);
+            cwd.strip_prefix(&app_root).ok()?;
+            let depth = app_root.components().count();
+            let events_path = app_root.join(APP_STREAM_DIR_NAME).join(EVENTS_FILE);
+            Some((
+                depth,
+                CurrentAppDetection {
+                    current_app_id: Some(app.app_id.clone()),
+                    current_app_root: Some(app_root),
+                    current_app_events_path: events_path.exists().then_some(events_path),
+                },
+            ))
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by_key(|(depth, _)| *depth);
+    matches.pop().map(|(_, detection)| detection)
+}
+
 fn control_plane_from_heuristic(detection: &HeuristicDetection) -> ResolvedControlPlanePaths {
     ResolvedControlPlanePaths {
         control_dir: Some(detection.control_dir.clone()),
@@ -841,6 +1052,15 @@ fn control_plane_from_heuristic(detection: &HeuristicDetection) -> ResolvedContr
         unregister_app_path: Some(detection.unregister_app_path.clone()),
         list_apps_path: Some(detection.list_apps_path.clone()),
     }
+}
+
+fn principal_registry_path_from_control_paths(
+    control_paths: &ResolvedControlPlanePaths,
+) -> Option<PathBuf> {
+    control_paths
+        .control_dir
+        .as_ref()
+        .map(|control_dir| control_dir.join(PRINCIPALS_FILE))
 }
 
 fn resolve_control_plane_paths(
@@ -862,6 +1082,14 @@ fn resolve_control_plane_paths(
         unregister_app_path: Some(unregister_app_path),
         list_apps_path: Some(list_apps_path),
     }
+}
+
+fn effective_principal_id(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(APPFS_DEFAULT_PRINCIPAL_ID)
+        .to_string()
 }
 
 fn absolute_mount_path(mount_root: &Path, virtual_path: &str) -> PathBuf {
@@ -886,6 +1114,7 @@ fn load_attach_env() -> AppfsAttachEnv {
         mount_root: env::var_os(APPFS_MOUNT_ROOT_ENV).map(PathBuf::from),
         runtime_session_id: env::var(APPFS_RUNTIME_SESSION_ID_ENV).ok(),
         attach_id: env::var(APPFS_ATTACH_ID_ENV).ok(),
+        principal_id: env::var(APPFS_PRINCIPAL_ID_ENV).ok(),
         attach_role: env::var(APPFS_AGENT_ROLE_ENV).ok(),
     }
 }
@@ -926,7 +1155,13 @@ fn detect_heuristic_environment(cwd: &Path) -> Option<HeuristicDetection> {
     let unregister_app_path = control_dir.join(UNREGISTER_APP_ACTION);
     let list_apps_path = control_dir.join(LIST_APPS_ACTION);
     let control_events_path = control_dir.join(APP_STREAM_DIR_NAME).join(EVENTS_FILE);
-    let current_detection = detect_current_app(&mount_root, cwd);
+    let principal_id = APPFS_DEFAULT_PRINCIPAL_ID;
+    let registered_apps =
+        load_registered_apps_from_paths(Some(registry_path.as_path()), principal_id);
+    let current_detection = detect_current_registered_app(&mount_root, cwd, &registered_apps)
+        .unwrap_or_else(|| detect_current_app(&mount_root, cwd));
+    let known_principals =
+        load_principal_summaries_from_paths(Some(control_dir.join(PRINCIPALS_FILE).as_path()));
 
     Some(HeuristicDetection {
         mount_root,
@@ -939,7 +1174,8 @@ fn detect_heuristic_environment(cwd: &Path) -> Option<HeuristicDetection> {
         current_app_id: current_detection.current_app_id,
         current_app_root: current_detection.current_app_root,
         current_app_events_path: current_detection.current_app_events_path,
-        registered_apps: load_registered_apps_from_paths(Some(registry_path.as_path())),
+        registered_apps,
+        known_principals,
     })
 }
 
@@ -963,14 +1199,20 @@ fn looks_like_app_root(candidate: &Path) -> bool {
     candidate.join(APP_CONTROL_DIR_NAME).is_dir() || candidate.join(APP_STREAM_DIR_NAME).is_dir()
 }
 
-fn load_registered_apps_from_paths(registry_path: Option<&Path>) -> Vec<AppfsRegisteredApp> {
+fn load_registered_apps_from_paths(
+    registry_path: Option<&Path>,
+    principal_id: &str,
+) -> Vec<AppfsRegisteredApp> {
     let Some(registry_path) = registry_path else {
         return Vec::new();
     };
-    load_registered_apps(registry_path)
+    load_registered_apps(registry_path, principal_id)
 }
 
-fn load_registered_apps(registry_path: &Path) -> Vec<AppfsRegisteredApp> {
+fn load_registered_apps(
+    registry_path: &Path,
+    current_principal_id: &str,
+) -> Vec<AppfsRegisteredApp> {
     let Ok(contents) = fs::read_to_string(registry_path) else {
         return Vec::new();
     };
@@ -984,25 +1226,259 @@ fn load_registered_apps(registry_path: &Path) -> Vec<AppfsRegisteredApp> {
     apps.iter()
         .filter_map(|entry| {
             let object = entry.as_object()?;
+            let instance_id = object.get("instance_id")?.as_str()?.to_string();
             let app_id = object.get("app_id")?.as_str()?.to_string();
+            let visibility = match object.get("visibility")?.as_str()? {
+                "public" => AppfsRegisteredAppVisibility::Public,
+                "private_instance" => AppfsRegisteredAppVisibility::PrivateInstance,
+                _ => return None,
+            };
+            let parent_app_id = object
+                .get("parent_app_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let principal_id = object
+                .get("principal_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            if visibility == AppfsRegisteredAppVisibility::PrivateInstance
+                && principal_id.as_deref() != Some(current_principal_id)
+            {
+                return None;
+            }
+            let profile_id = object
+                .get("profile_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let path = object.get("path")?.as_str()?.to_string();
             let active_scope = object
                 .get("active_scope")
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
             Some(AppfsRegisteredApp {
+                instance_id,
                 app_id,
+                visibility,
+                parent_app_id,
+                principal_id,
+                profile_id,
+                path,
                 active_scope,
             })
         })
         .collect()
 }
 
-fn generate_ephemeral_attach_id() -> String {
-    let seq = ATTACH_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
-    let now = SystemTime::now()
+fn load_principal_summaries_from_paths(registry_path: Option<&Path>) -> Vec<AppfsPrincipalSummary> {
+    let Some(registry_path) = registry_path else {
+        return Vec::new();
+    };
+    load_principal_summaries(registry_path)
+}
+
+fn load_principal_summaries(registry_path: &Path) -> Vec<AppfsPrincipalSummary> {
+    let Ok(contents) = fs::read_to_string(registry_path) else {
+        return Vec::new();
+    };
+    let Ok(doc) = serde_json::from_str::<Value>(&contents) else {
+        return Vec::new();
+    };
+    let Some(principals) = doc.get("principals").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    principals
+        .iter()
+        .filter_map(|entry| {
+            let object = entry.as_object()?;
+            let principal_id = object.get("principal_id")?.as_str()?.to_string();
+            Some(AppfsPrincipalSummary {
+                principal_id,
+                display_name: object
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                description: object
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                kind: object
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+            })
+        })
+        .collect()
+}
+
+fn append_create_principal_action(
+    action_path: &Path,
+    principal_id: &str,
+    request: &AppfsPrincipalCreateRequest,
+) -> Result<(), String> {
+    let client_token = format!("principal-create-{}", now_millis());
+    let payload = serde_json::json!({
+        "principal_id": principal_id,
+        "display_name": request
+            .display_name
+            .as_deref()
+            .unwrap_or(principal_id),
+        "description": request.description.as_deref(),
+        "kind": request.kind.as_deref().unwrap_or("agent"),
+        "client_token": client_token,
+    });
+    let mut line = serde_json::to_string(&payload)
+        .map_err(|err| format!("failed to encode principal create action: {err}"))?;
+    line.push('\n');
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(action_path)
+        .map_err(|err| {
+            format!(
+                "failed to open AppFS principal create action {}: {err}",
+                action_path.display()
+            )
+        })?;
+    file.write_all(line.as_bytes()).map_err(|err| {
+        format!(
+            "failed to append AppFS principal create action {}: {err}",
+            action_path.display()
+        )
+    })
+}
+
+fn wait_for_principal_ready(
+    control_dir: &Path,
+    registry_path: &Path,
+    apps_registry_path: Option<&Path>,
+    principal_id: &str,
+) -> Option<AppfsPrincipalSummary> {
+    let expected_private_apps = private_app_policy_count(&control_dir.join(APP_POLICIES_FILE));
+    let mut found_principal = None;
+    for _ in 0..40 {
+        if let Some(principal) = load_principal_summaries(registry_path)
+            .into_iter()
+            .find(|principal| principal.principal_id == principal_id)
+        {
+            found_principal = Some(principal);
+            if expected_private_apps == 0
+                || apps_registry_path
+                    .map(|path| private_app_count_for_principal(path, principal_id))
+                    .unwrap_or(0)
+                    >= expected_private_apps
+            {
+                return found_principal;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    found_principal
+}
+
+fn principal_create_outcome_from_environment(
+    principal_id: &str,
+    status: AppfsPrincipalCreateStatus,
+    action_path: PathBuf,
+    registry_path: PathBuf,
+    environment: &AppfsEnvironment,
+) -> AppfsPrincipalCreateOutcome {
+    let visible_private_apps =
+        load_registered_apps_from_paths(environment.registry_path.as_deref(), principal_id)
+            .into_iter()
+            .filter(|app| {
+                app.visibility == AppfsRegisteredAppVisibility::PrivateInstance
+                    && app.principal_id.as_deref() == Some(principal_id)
+            })
+            .collect();
+    AppfsPrincipalCreateOutcome {
+        principal_id: principal_id.to_string(),
+        status,
+        action_path,
+        registry_path,
+        visible_private_apps,
+    }
+}
+
+fn should_auto_create_default_principal(environment: &AppfsEnvironment) -> bool {
+    environment.principal_id == APPFS_DEFAULT_PRINCIPAL_ID
+        && environment.control_dir.is_some()
+        && environment.known_principals.is_empty()
+}
+
+fn has_pending_default_principal_create_action(control_dir: &Path) -> bool {
+    fs::read_to_string(control_dir.join("principals").join("create_principal.act"))
+        .ok()
+        .is_some_and(|contents| contents.contains(r#""principal_id":"default""#))
+}
+
+fn private_app_policy_count(path: &Path) -> usize {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return 0;
+    };
+    let Ok(doc) = serde_json::from_str::<Value>(&contents) else {
+        return 0;
+    };
+    doc.get("apps")
+        .and_then(Value::as_array)
+        .map(|apps| {
+            apps.iter()
+                .filter(|entry| {
+                    entry
+                        .get("visibility")
+                        .and_then(Value::as_str)
+                        .is_some_and(|visibility| visibility == "private")
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn private_app_count_for_principal(path: &Path, principal_id: &str) -> usize {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return 0;
+    };
+    let Ok(doc) = serde_json::from_str::<Value>(&contents) else {
+        return 0;
+    };
+    doc.get("apps")
+        .and_then(Value::as_array)
+        .map(|apps| {
+            apps.iter()
+                .filter(|entry| {
+                    entry
+                        .get("visibility")
+                        .and_then(Value::as_str)
+                        .is_some_and(|visibility| visibility == "private_instance")
+                        && entry
+                            .get("principal_id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|value| value == principal_id)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn is_safe_principal_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis();
+        .as_millis()
+}
+
+fn generate_ephemeral_attach_id() -> String {
+    let seq = ATTACH_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+    let now = now_millis();
     format!("attach-{now:x}-{}-{seq:x}", process::id())
 }
 
@@ -1048,9 +1524,33 @@ fn summarize_registered_app_ids(environment: &AppfsEnvironment) -> Option<String
     let app_ids = environment
         .registered_apps
         .iter()
-        .map(|app| format!("`{}`", app.app_id))
+        .map(|app| match (app.visibility, app.principal_id.as_deref()) {
+            (AppfsRegisteredAppVisibility::PrivateInstance, Some(principal_id)) => format!(
+                "`{}` at `{}` (private for principal `{principal_id}`)",
+                app.app_id, app.path
+            ),
+            _ => format!("`{}` at `{}` (public)", app.app_id, app.path),
+        })
         .collect::<Vec<_>>();
     (!app_ids.is_empty()).then(|| app_ids.join(", "))
+}
+
+fn summarize_known_principals(environment: &AppfsEnvironment) -> Option<String> {
+    let principals = environment
+        .known_principals
+        .iter()
+        .map(|principal| {
+            let mut label = format!("`{}`", principal.principal_id);
+            if let Some(display_name) = principal.display_name.as_deref() {
+                label.push_str(&format!(" ({display_name})"));
+            }
+            if let Some(description) = principal.description.as_deref() {
+                label.push_str(&format!(": {description}"));
+            }
+            label
+        })
+        .collect::<Vec<_>>();
+    (!principals.is_empty()).then(|| principals.join("; "))
 }
 
 fn render_current_app_prompt_section(
@@ -1166,7 +1666,7 @@ fn render_appfs_overview_lines(
         "# AppFS workspace guidance".to_string(),
         "- AppFS mounts bridge-backed software into a filesystem. After an app implements the AppFS bridge contract, reading and writing inside the mount interacts with the underlying software."
             .to_string(),
-        "- Each mounted app appears as a directory under the AppFS mount root. The platform control plane lives under `/_appfs`."
+        "- Mounted apps appear as directories under the AppFS mount root. Public apps usually live at the root or under `public/`; private app instances live under `private/<principal-id>/`. The platform control plane lives under `/_appfs`."
             .to_string(),
         format!(
             "- AppFS `*.act` files are append-only JSONL action sinks: append exactly one JSON object line to trigger an operation. Prefer the AppFS event reminder injected into the next model call to confirm `action.completed` or `action.failed`; only inspect `{events_path}` manually for debugging or if no reminder appears."
@@ -1178,7 +1678,18 @@ fn render_appfs_overview_lines(
         "- Mounted app skills are listed separately in the skill listing attachment. Use the `Skill` tool to load the matching app skill before doing app-specific work."
             .to_string(),
         format!("- Current AppFS mount root: `{}`.", environment.mount_root.display()),
+        format!("- Current AppFS attach id: `{}`.", environment.attach_id),
+        format!(
+            "- Current AppFS principal id: `{}`. Treat this as your app-side identity.",
+            environment.principal_id
+        ),
     ];
+
+    if let Some(principals) = summarize_known_principals(environment) {
+        lines.push(format!(
+            "- Known AppFS principals in this project: {principals}."
+        ));
+    }
 
     if let (Some(app_id), Some(app_root)) = (current_app_id, current_app_root) {
         lines.push(format!(
@@ -1196,6 +1707,11 @@ fn render_appfs_overview_lines(
             ));
         }
     }
+
+    lines.push(format!(
+        "- Private apps for your current identity live under `private/{}/...`; avoid using another principal's private app unless the user explicitly asks for cross-agent coordination.",
+        environment.principal_id
+    ));
 
     if let Some(register_path) = register_path {
         lines.push(format!(
@@ -1232,9 +1748,10 @@ fn read_json_file<T: DeserializeOwned>(path: &Path) -> Option<T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_appfs_prompt_section, detect_appfs_environment,
+        build_appfs_prompt_section, create_appfs_principal, detect_appfs_environment,
         resolve_appfs_environment_with_attach_env, sync_appfs_event_reminders, AppfsAttachEnv,
-        AppfsAttachSource, AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities,
+        AppfsAttachSource, AppfsPrincipalCreateRequest, AppfsPrincipalCreateStatus,
+        AppfsRegisteredAppVisibility, AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities,
         AppfsRuntimeManifestControlPlane, APPFS_MULTI_AGENT_MODE_SHARED, APPFS_RUNTIME_KIND,
         APPFS_RUNTIME_MANIFEST_REL_PATH, APPFS_SCHEMA_VERSION,
     };
@@ -1243,7 +1760,8 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     struct TempDirGuard {
         path: PathBuf,
@@ -1285,10 +1803,90 @@ mod tests {
         fs::write(control_dir.join("list_apps.act"), "").expect("write list action");
         fs::write(
             control_dir.join("apps.registry.json"),
-            r#"{"version":1,"apps":[{"app_id":"aiim","active_scope":"chat-long"},{"app_id":"notion"}]}"#,
+            r#"{"version":1,"apps":[{"instance_id":"aiim","app_id":"aiim","visibility":"public","path":"aiim","session_id":"sess-aiim","registered_at":"2026-04-07T00:00:00Z","active_scope":"chat-long","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}},{"instance_id":"notion","app_id":"notion","visibility":"public","path":"notion","session_id":"sess-notion","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}}]}"#,
         )
         .expect("write registry");
+        fs::write(
+            control_dir.join("principals.registry.json"),
+            r#"{"version":1,"default_principal_id":"default","principals":[{"principal_id":"default","display_name":"Default agent","description":"The default project agent.","kind":"agent","created_at":"2026-04-07T00:00:00Z","updated_at":"2026-04-07T00:00:00Z"}]}"#,
+        )
+        .expect("write principals registry");
         fs::write(app_root.join("_stream").join("events.evt.jsonl"), "").expect("write events");
+    }
+
+    fn seed_private_principal_mount(mount_root: &Path) {
+        let control_dir = mount_root.join("_appfs");
+        let aiim_root = mount_root.join("aiim");
+        let default_tinode_root = mount_root.join("private").join("default").join("tinode");
+        let incident_tinode_root = mount_root
+            .join("private")
+            .join("incident-reporter")
+            .join("tinode");
+        fs::create_dir_all(control_dir.join("_stream")).expect("create control stream");
+        for app_root in [&aiim_root, &default_tinode_root, &incident_tinode_root] {
+            fs::create_dir_all(app_root.join("_app")).expect("create app control dir");
+            fs::create_dir_all(app_root.join("_stream")).expect("create app stream dir");
+            fs::write(app_root.join("_stream").join("events.evt.jsonl"), "")
+                .expect("write app events");
+        }
+        fs::write(control_dir.join("register_app.act"), "").expect("write register action");
+        fs::write(control_dir.join("list_apps.act"), "").expect("write list action");
+        fs::write(
+            control_dir.join("apps.registry.json"),
+            r#"{"version":1,"apps":[{"instance_id":"aiim","app_id":"aiim","visibility":"public","path":"aiim","session_id":"sess-aiim","registered_at":"2026-04-07T00:00:00Z","active_scope":"chat-long","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}},{"instance_id":"tinode--default","app_id":"tinode","visibility":"private_instance","parent_app_id":"tinode","principal_id":"default","profile_id":"tinode:default","path":"private/default/tinode","session_id":"sess-tinode-default","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}},{"instance_id":"tinode--incident-reporter","app_id":"tinode","visibility":"private_instance","parent_app_id":"tinode","principal_id":"incident-reporter","profile_id":"tinode:incident-reporter","path":"private/incident-reporter/tinode","session_id":"sess-tinode-incident","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}}]}"#,
+        )
+        .expect("write registry");
+        fs::write(
+            control_dir.join("principals.registry.json"),
+            r#"{"version":1,"default_principal_id":"default","principals":[{"principal_id":"default","display_name":"Default agent","description":"The default project agent.","kind":"agent","created_at":"2026-04-07T00:00:00Z","updated_at":"2026-04-07T00:00:00Z"},{"principal_id":"incident-reporter","display_name":"Incident reporter","description":"Summarizes incident updates.","kind":"agent","created_at":"2026-04-07T00:00:00Z","updated_at":"2026-04-07T00:00:00Z"}]}"#,
+        )
+        .expect("write principals registry");
+    }
+
+    fn seed_mount_without_principals(mount_root: &Path) {
+        let control_dir = mount_root.join("_appfs");
+        fs::create_dir_all(control_dir.join("_stream")).expect("create control stream");
+        fs::write(control_dir.join("register_app.act"), "").expect("write register action");
+        fs::write(control_dir.join("list_apps.act"), "").expect("write list action");
+        fs::write(
+            control_dir.join("app-policies.registry.json"),
+            r#"{"version":1,"apps":[{"app_id":"tinode","visibility":"private","connector":"tinode-in-process","path_template":"private/{principal_id}/tinode","profile_template":"tinode:{principal_id}","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}}]}"#,
+        )
+        .expect("write app policy registry");
+        fs::write(
+            control_dir.join("apps.registry.json"),
+            r#"{"version":1,"apps":[]}"#,
+        )
+        .expect("write empty apps registry");
+    }
+
+    fn spawn_default_principal_supervisor_stub(mount_root: &Path) -> thread::JoinHandle<()> {
+        let control_dir = mount_root.join("_appfs");
+        let action_path = control_dir.join("principals").join("create_principal.act");
+        let principal_registry = control_dir.join("principals.registry.json");
+        let apps_registry = control_dir.join("apps.registry.json");
+        thread::spawn(move || {
+            for _ in 0..80 {
+                if fs::read_to_string(&action_path)
+                    .ok()
+                    .is_some_and(|contents| contents.contains(r#""principal_id":"default""#))
+                {
+                    fs::write(
+                        &principal_registry,
+                        r#"{"version":1,"default_principal_id":"default","principals":[{"principal_id":"default","display_name":"Default agent","description":"The default project agent.","kind":"agent","created_at":"2026-04-07T00:00:00Z","updated_at":"2026-04-07T00:00:00Z"}]}"#,
+                    )
+                    .expect("write principal registry");
+                    thread::sleep(Duration::from_millis(150));
+                    fs::write(
+                        &apps_registry,
+                        r#"{"version":1,"apps":[{"instance_id":"tinode--default","app_id":"tinode","visibility":"private_instance","parent_app_id":"tinode","principal_id":"default","profile_id":"tinode:default","path":"private/default/tinode","session_id":"sess-tinode-default","registered_at":"2026-04-07T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":3,"bridge_initial_backoff_ms":50,"bridge_max_backoff_ms":500,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":1000}}]}"#,
+                    )
+                    .expect("write apps registry");
+                    return;
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        })
     }
 
     fn seed_aiim_prompt_files(app_root: &Path) {
@@ -1499,6 +2097,7 @@ mod tests {
                 mount_root: Some(override_root.clone()),
                 runtime_session_id: Some("rt-env-01".to_string()),
                 attach_id: Some("agent-a".to_string()),
+                principal_id: Some("incident-reporter".to_string()),
                 attach_role: Some("planner".to_string()),
             },
         )
@@ -1508,6 +2107,7 @@ mod tests {
         assert_eq!(detected.mount_root, override_root);
         assert_eq!(detected.runtime_session_id.as_deref(), Some("rt-env-01"));
         assert_eq!(detected.attach_id, "agent-a");
+        assert_eq!(detected.principal_id, "incident-reporter");
         assert_eq!(detected.attach_role.as_deref(), Some("planner"));
         assert!(detected
             .warnings
@@ -1535,6 +2135,7 @@ mod tests {
                 mount_root: None,
                 runtime_session_id: None,
                 attach_id: None,
+                principal_id: None,
                 attach_role: Some("planner".to_string()),
             },
         )
@@ -1543,6 +2144,7 @@ mod tests {
         assert_eq!(detected.attach_source, AppfsAttachSource::Env);
         assert_eq!(detected.runtime_session_id.as_deref(), Some("rt-shared-02"));
         assert!(detected.attach_id.starts_with("attach-"));
+        assert_eq!(detected.principal_id, "default");
         assert_eq!(detected.attach_role.as_deref(), Some("planner"));
     }
 
@@ -1560,6 +2162,7 @@ mod tests {
             mount_root: Some(mount_root),
             runtime_session_id: Some("rt-shared-03".to_string()),
             attach_id: None,
+            principal_id: Some("default".to_string()),
             attach_role: Some("worker".to_string()),
         };
         let detected_a = resolve_appfs_environment_with_attach_env(
@@ -1591,6 +2194,100 @@ mod tests {
     }
 
     #[test]
+    fn detect_appfs_environment_auto_creates_default_principal() {
+        let temp = TempDirGuard::new("appfs-auto-default-principal");
+        let mount_root = temp.path().join("mnt");
+        seed_mount_without_principals(&mount_root);
+        let supervisor = spawn_default_principal_supervisor_stub(&mount_root);
+
+        let detected =
+            detect_appfs_environment(&mount_root).expect("expected appfs environment to be found");
+        supervisor.join().expect("supervisor stub should finish");
+
+        assert_eq!(detected.principal_id, "default");
+        assert!(detected
+            .known_principals
+            .iter()
+            .any(|principal| principal.principal_id == "default"));
+        assert!(detected.registered_apps.iter().any(|app| {
+            app.app_id == "tinode"
+                && app.visibility == AppfsRegisteredAppVisibility::PrivateInstance
+                && app.principal_id.as_deref() == Some("default")
+        }));
+        let create_action = fs::read_to_string(
+            mount_root
+                .join("_appfs")
+                .join("principals")
+                .join("create_principal.act"),
+        )
+        .expect("read create principal action");
+        assert!(create_action.contains(r#""principal_id":"default""#));
+    }
+
+    #[test]
+    fn detect_appfs_environment_waits_for_pending_default_principal_action() {
+        let temp = TempDirGuard::new("appfs-auto-default-principal-pending");
+        let mount_root = temp.path().join("mnt");
+        seed_mount_without_principals(&mount_root);
+        let create_action_path = mount_root
+            .join("_appfs")
+            .join("principals")
+            .join("create_principal.act");
+        fs::create_dir_all(create_action_path.parent().expect("action path parent"))
+            .expect("create principals control dir");
+        fs::write(
+            &create_action_path,
+            r#"{"principal_id":"default","display_name":"Default agent"}"#,
+        )
+        .expect("write pending create principal action");
+        let supervisor = spawn_default_principal_supervisor_stub(&mount_root);
+
+        let detected =
+            detect_appfs_environment(&mount_root).expect("expected appfs environment to be found");
+        supervisor.join().expect("supervisor stub should finish");
+
+        assert!(detected
+            .registered_apps
+            .iter()
+            .any(|app| app.instance_id == "tinode--default"));
+        let create_action =
+            fs::read_to_string(create_action_path).expect("read create principal action");
+        assert_eq!(
+            create_action
+                .match_indices(r#""principal_id":"default""#)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn create_appfs_principal_waits_for_private_app_materialization() {
+        let temp = TempDirGuard::new("appfs-principal-create-waits");
+        let mount_root = temp.path().join("mnt");
+        seed_mount_without_principals(&mount_root);
+        let supervisor = spawn_default_principal_supervisor_stub(&mount_root);
+
+        let outcome = create_appfs_principal(
+            &mount_root,
+            AppfsPrincipalCreateRequest {
+                principal_id: "default".to_string(),
+                display_name: Some("Default agent".to_string()),
+                description: Some("The default project agent.".to_string()),
+                kind: Some("agent".to_string()),
+            },
+        )
+        .expect("create default principal");
+        supervisor.join().expect("supervisor stub should finish");
+
+        assert_eq!(outcome.status, AppfsPrincipalCreateStatus::Created);
+        assert!(outcome.visible_private_apps.iter().any(|app| {
+            app.instance_id == "tinode--default"
+                && app.visibility == AppfsRegisteredAppVisibility::PrivateInstance
+                && app.principal_id.as_deref() == Some("default")
+        }));
+    }
+
+    #[test]
     fn heuristic_attach_falls_back_when_manifest_is_missing() {
         let temp = TempDirGuard::new("appfs-heuristic");
         let mount_root = temp.path().join("mnt");
@@ -1605,6 +2302,54 @@ mod tests {
         assert!(detected.runtime_session_id.is_none());
         assert!(detected.attach_id.starts_with("attach-"));
         assert_eq!(detected.current_app_id.as_deref(), Some("aiim"));
+    }
+
+    #[test]
+    fn principal_id_filters_private_apps_and_detects_nested_current_app() {
+        let temp = TempDirGuard::new("appfs-private-principal");
+        let mount_root = temp.path().join("mnt");
+        let cwd = mount_root
+            .join("private")
+            .join("default")
+            .join("tinode")
+            .join("workspace");
+        seed_private_principal_mount(&mount_root);
+        fs::create_dir_all(&cwd).expect("create cwd");
+
+        let detected = resolve_appfs_environment_with_attach_env(
+            &cwd,
+            AppfsAttachEnv {
+                schema: Some("1".to_string()),
+                manifest_path: None,
+                mount_root: Some(mount_root.clone()),
+                runtime_session_id: Some("rt-private-01".to_string()),
+                attach_id: Some("agent-default".to_string()),
+                principal_id: Some("default".to_string()),
+                attach_role: Some("planner".to_string()),
+            },
+        )
+        .expect("expected appfs environment to be found");
+
+        assert_eq!(detected.principal_id, "default");
+        assert_eq!(detected.current_app_id.as_deref(), Some("tinode"));
+        let expected_app_root = mount_root.join("private").join("default").join("tinode");
+        assert_eq!(
+            detected.current_app_root.as_deref(),
+            Some(expected_app_root.as_path())
+        );
+        let visible_instances = detected
+            .registered_apps
+            .iter()
+            .map(|app| app.instance_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(visible_instances, vec!["aiim", "tinode--default"]);
+        assert_eq!(detected.known_principals.len(), 2);
+
+        let prompt = build_appfs_prompt_section(&cwd).expect("expected prompt");
+        assert!(prompt.contains("Current AppFS principal id: `default`"));
+        assert!(prompt.contains("Known AppFS principals"));
+        assert!(prompt.contains("private/default/..."));
+        assert!(!prompt.contains("tinode--incident-reporter"));
     }
 
     #[test]
@@ -1667,9 +2412,9 @@ mod tests {
         assert!(prompt.contains(
             "You are inside an AppFS mount, but not currently inside a specific app root."
         ));
-        assert!(
-            prompt.contains("Mounted apps currently detected under this root: `aiim`, `notion`.")
-        );
+        assert!(prompt.contains(
+            "Mounted apps currently detected under this root: `aiim` at `aiim` (public), `notion` at `notion` (public)."
+        ));
         assert!(prompt.contains("Use the skill listing to load the matching `appfs-<app>` skill"));
         assert!(!prompt.contains("## Mounted apps"));
         assert!(!prompt.contains("`aiim` -> skill `appfs-aiim`"));
@@ -1802,6 +2547,91 @@ mod tests {
 
         sync_appfs_event_reminders(&mut session, &mount_root).expect("empty sync should succeed");
         assert_eq!(session.messages.len(), 1);
+    }
+
+    #[test]
+    fn sync_appfs_event_reminders_filters_private_streams_by_principal() {
+        let temp = TempDirGuard::new("appfs-event-private-principal");
+        let mount_root = temp.path().join("mnt");
+        seed_private_principal_mount(&mount_root);
+
+        let write_cursor = |stream_dir: &Path, max_seq: i64| {
+            fs::write(
+                stream_dir.join("cursor.res.json"),
+                format!(r#"{{"min_seq":0,"max_seq":{max_seq},"retention_hint_sec":86400}}"#),
+            )
+            .expect("write stream cursor");
+        };
+
+        let default_stream = mount_root
+            .join("private")
+            .join("default")
+            .join("tinode")
+            .join("_stream");
+        let incident_stream = mount_root
+            .join("private")
+            .join("incident-reporter")
+            .join("tinode")
+            .join("_stream");
+        fs::write(
+            default_stream.join("events.evt.jsonl"),
+            r#"{"seq":1,"app":"tinode","type":"action.completed","path":"/contacts/alice/send_message.act","request_id":"old-default"}"#,
+        )
+        .expect("write default baseline");
+        fs::write(
+            incident_stream.join("events.evt.jsonl"),
+            r#"{"seq":1,"app":"tinode","type":"action.completed","path":"/contacts/bob/send_message.act","request_id":"old-incident"}"#,
+        )
+        .expect("write incident baseline");
+        write_cursor(&default_stream, 1);
+        write_cursor(&incident_stream, 1);
+
+        let mut session = Session::new();
+        sync_appfs_event_reminders(&mut session, &mount_root).expect("baseline should sync");
+        assert_eq!(session.appfs_event_cursor("app:tinode--default"), Some(1));
+        assert_eq!(
+            session.appfs_event_cursor("app:tinode--incident-reporter"),
+            None
+        );
+
+        fs::write(
+            default_stream.join("events.evt.jsonl"),
+            concat!(
+                r#"{"seq":1,"app":"tinode","type":"action.completed","path":"/contacts/alice/send_message.act","request_id":"old-default"}"#,
+                "\n",
+                r#"{"seq":2,"app":"tinode","type":"action.completed","path":"/contacts/alice/send_message.act","request_id":"new-default","content":{"ok":true,"message":"sent from default"}}"#,
+                "\n"
+            ),
+        )
+        .expect("write default event");
+        fs::write(
+            incident_stream.join("events.evt.jsonl"),
+            concat!(
+                r#"{"seq":1,"app":"tinode","type":"action.completed","path":"/contacts/bob/send_message.act","request_id":"old-incident"}"#,
+                "\n",
+                r#"{"seq":2,"app":"tinode","type":"action.completed","path":"/contacts/bob/send_message.act","request_id":"new-incident","content":{"ok":true,"message":"sent from incident"}}"#,
+                "\n"
+            ),
+        )
+        .expect("write incident event");
+        write_cursor(&default_stream, 2);
+        write_cursor(&incident_stream, 2);
+
+        sync_appfs_event_reminders(&mut session, &mount_root).expect("new event should sync");
+
+        assert_eq!(session.messages.len(), 1);
+        let [ContentBlock::Text { text }] = session.messages[0].blocks.as_slice() else {
+            panic!("expected text reminder");
+        };
+        assert!(text.contains("sent from default"));
+        assert!(text.contains("principal `default`"));
+        assert!(!text.contains("sent from incident"));
+        assert!(!text.contains("incident-reporter"));
+        assert_eq!(session.appfs_event_cursor("app:tinode--default"), Some(2));
+        assert_eq!(
+            session.appfs_event_cursor("app:tinode--incident-reporter"),
+            None
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -49,10 +49,12 @@ mod windows_shell;
 pub mod worker_boot;
 
 pub use appfs::{
-    detect_appfs_environment, resolve_appfs_environment, AppfsAttachSource, AppfsEnvironment,
-    AppfsRegisteredApp, AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities,
-    AppfsRuntimeManifestControlPlane, APPFS_MULTI_AGENT_MODE_SHARED,
-    APPFS_RUNTIME_MANIFEST_REL_PATH,
+    create_appfs_principal, detect_appfs_environment, resolve_appfs_environment, AppfsAttachSource,
+    AppfsEnvironment, AppfsPrincipalCreateOutcome, AppfsPrincipalCreateRequest,
+    AppfsPrincipalCreateStatus, AppfsPrincipalSummary, AppfsRegisteredApp,
+    AppfsRegisteredAppVisibility, AppfsRuntimeManifest, AppfsRuntimeManifestCapabilities,
+    AppfsRuntimeManifestControlPlane, APPFS_DEFAULT_PRINCIPAL_ID, APPFS_MULTI_AGENT_MODE_SHARED,
+    APPFS_PRINCIPAL_ID_ENV, APPFS_RUNTIME_MANIFEST_REL_PATH,
 };
 pub use bash::{
     execute_bash, prepare_background_shell_output, prepare_shell_command_output,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -43,15 +43,16 @@ use init::initialize_repo;
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    check_base_commit, clear_oauth_credentials, detect_appfs_environment,
+    check_base_commit, clear_oauth_credentials, create_appfs_principal, detect_appfs_environment,
     format_stale_base_warning, format_usd, generate_pkce_pair, generate_state,
     load_oauth_credentials, load_system_prompt_with_appfs, parse_oauth_callback_request_target,
     pricing_for_model, resolve_expected_base, resolve_sandbox_status, save_oauth_credentials,
-    set_shell_if_windows, ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader,
-    ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
-    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest,
-    OAuthConfig, OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, ProjectContext,
-    PromptCacheEvent, ResolvedPermissionMode, RuntimeConfig, RuntimeError, RuntimeProviderConfig,
+    set_shell_if_windows, ApiClient, ApiRequest, AppfsPrincipalCreateRequest,
+    AppfsPrincipalCreateStatus, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
+    ContentBlock, ConversationMessage, ConversationRuntime, McpServer, McpServerManager,
+    McpServerSpec, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest, OAuthConfig,
+    OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, ProjectContext, PromptCacheEvent,
+    ResolvedPermissionMode, RuntimeConfig, RuntimeError, RuntimeProviderConfig,
     RuntimeProviderKind, Session, TokenUsage, ToolError, ToolExecutionResult, ToolExecutor,
     UsageTracker,
 };
@@ -94,6 +95,7 @@ const CLI_OPTION_SUGGESTIONS: &[&str] = &[
     "--allowedTools",
     "--allowed-tools",
     "--resume",
+    "--session",
     "--print",
     "--compact",
     "--base-commit",
@@ -248,12 +250,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             allowed_tools,
             permission_mode,
             base_commit,
+            session_path,
             ..
         } => run_repl(
             model,
             allowed_tools,
             permission_mode,
             base_commit.as_deref(),
+            session_path.as_deref(),
         )?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
@@ -336,6 +340,7 @@ enum CliAction {
         output_format: CliOutputFormat,
     },
     Repl {
+        session_path: Option<PathBuf>,
         model: String,
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
@@ -387,6 +392,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
     let mut allowed_tool_values = Vec::new();
     let mut compact = false;
     let mut base_commit: Option<String> = None;
+    let mut session_path: Option<PathBuf> = None;
     let mut rest = Vec::new();
     let mut index = 0;
 
@@ -453,6 +459,9 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 index += 1;
             }
             "-p" => {
+                if session_path.is_some() {
+                    return Err("--session cannot be combined with -p prompt mode".to_string());
+                }
                 // Claw Code compat: -p "prompt" = one-shot prompt
                 let prompt = args[index + 1..].join(" ");
                 if prompt.trim().is_empty() {
@@ -483,6 +492,17 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             flag if rest.is_empty() && flag.starts_with("--resume=") => {
                 rest.push("--resume".to_string());
                 rest.push(flag[9..].to_string());
+                index += 1;
+            }
+            "--session" if rest.is_empty() => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "missing value for --session".to_string())?;
+                session_path = Some(PathBuf::from(value));
+                index += 2;
+            }
+            flag if rest.is_empty() && flag.starts_with("--session=") => {
+                session_path = Some(PathBuf::from(&flag[10..]));
                 index += 1;
             }
             "--allowedTools" | "--allowed-tools" => {
@@ -520,9 +540,14 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
 
     let allowed_tools = normalize_allowed_tools(&allowed_tool_values)?;
 
+    if session_path.is_some() && !rest.is_empty() {
+        return Err("--session can only be used to start an interactive REPL".to_string());
+    }
+
     if rest.is_empty() {
         let permission_mode = permission_mode_override.unwrap_or_else(default_permission_mode);
         return Ok(CliAction::Repl {
+            session_path,
             model,
             allowed_tools,
             permission_mode,
@@ -2608,6 +2633,90 @@ fn format_resume_report(session_path: &str, message_count: usize, turns: u32) ->
     )
 }
 
+fn fork_session_for_principal(
+    source: &Session,
+    parent_principal_id: &str,
+    child_principal_id: &str,
+    task: Option<&str>,
+) -> Session {
+    let mut forked = source.fork(Some(format!("principal-{child_principal_id}")));
+    forked
+        .invoked_skills
+        .retain(|skill| !is_appfs_generated_invoked_skill(skill));
+    forked
+        .appfs_event_cursors
+        .retain(|stream_id, _| !stream_id.starts_with("app:"));
+    let bootstrap = format_principal_fork_bootstrap_message(
+        &source.session_id,
+        parent_principal_id,
+        child_principal_id,
+        task,
+    );
+    forked
+        .push_message(ConversationMessage::user_text(bootstrap))
+        .expect("in-memory principal fork bootstrap should not fail");
+    forked
+}
+
+fn is_appfs_generated_invoked_skill(skill: &runtime::InvokedSkill) -> bool {
+    skill
+        .path
+        .as_deref()
+        .is_some_and(|path| path.starts_with("generated://appfs-"))
+        || skill.skill.starts_with("appfs-")
+        || skill
+            .resolved_name
+            .as_deref()
+            .is_some_and(|name| name.starts_with("appfs-"))
+}
+
+fn format_principal_fork_bootstrap_message(
+    parent_session_id: &str,
+    parent_principal_id: &str,
+    child_principal_id: &str,
+    task: Option<&str>,
+) -> String {
+    let task = task
+        .map(str::trim)
+        .filter(|task| !task.is_empty())
+        .unwrap_or("Continue from the inherited context and ask for clarification if the next implementation step is ambiguous.");
+    format!(
+        "<system-reminder>\n\
+This session was forked from parent session `{parent_session_id}` under AppFS principal `{parent_principal_id}`.\n\
+You are intended to run as AppFS principal `{child_principal_id}`. Verify `/status` if identity-sensitive work depends on private AppFS apps.\n\
+Your delegated task: {task}\n\
+The parent principal remains responsible for overall coordination; focus on the delegated implementation/details.\n\
+Reload AppFS generated skills as needed. Parent AppFS generated skill cache and app event cursors were intentionally cleared for this principal fork.\n\
+</system-reminder>"
+    )
+}
+
+fn format_principal_fork_launch_command(principal_id: &str, session_path: &Path) -> String {
+    if cfg!(windows) {
+        format!(
+            "$env:{}={}; claw --session {}",
+            runtime::APPFS_PRINCIPAL_ID_ENV,
+            quote_powershell(principal_id),
+            quote_powershell(&session_path.display().to_string())
+        )
+    } else {
+        format!(
+            "{}={} claw --session {}",
+            runtime::APPFS_PRINCIPAL_ID_ENV,
+            quote_posix_shell(principal_id),
+            quote_posix_shell(&session_path.display().to_string())
+        )
+    }
+}
+
+fn quote_powershell(value: &str) -> String {
+    format!("\"{}\"", value.replace('`', "``").replace('"', "`\""))
+}
+
+fn quote_posix_shell(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn render_resume_usage() -> String {
     format!(
         "Resume
@@ -3134,6 +3243,7 @@ where
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
         | SlashCommand::Session { .. }
+        | SlashCommand::Principal { .. }
         | SlashCommand::Plugins { .. }
         | SlashCommand::Login
         | SlashCommand::Logout
@@ -3194,10 +3304,21 @@ fn run_repl(
     allowed_tools: Option<AllowedToolSet>,
     permission_mode: PermissionMode,
     base_commit: Option<&str>,
+    session_path: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     run_stale_base_preflight(base_commit);
     let resolved_model = resolve_repl_model(model);
-    let mut cli = LiveCli::new(resolved_model, true, allowed_tools, permission_mode)?;
+    let mut cli = if let Some(session_path) = session_path {
+        LiveCli::new_from_session(
+            resolved_model,
+            true,
+            allowed_tools,
+            permission_mode,
+            session_path,
+        )?
+    } else {
+        LiveCli::new(resolved_model, true, allowed_tools, permission_mode)?
+    };
     let mut editor =
         input::LineEditor::new("> ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
@@ -3220,10 +3341,14 @@ fn run_repl(
                         if cli.handle_repl_command(command)? {
                             cli.persist_session()?;
                         }
+                        editor.push_history(input);
+                        continue;
                     }
                     Ok(None) => {}
                     Err(error) => {
                         eprintln!("{error}");
+                        editor.push_history(input);
+                        continue;
                     }
                 }
                 editor.push_history(input);
@@ -3779,6 +3904,44 @@ impl LiveCli {
         Ok(cli)
     }
 
+    fn new_from_session(
+        model: String,
+        enable_tools: bool,
+        allowed_tools: Option<AllowedToolSet>,
+        permission_mode: PermissionMode,
+        session_reference: &Path,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let system_prompt = build_system_prompt()?;
+        let handle = resolve_session_path_or_reference(session_reference)?;
+        let session_state = Session::load_from_path(&handle.path)?;
+        let session = SessionHandle {
+            id: session_state.session_id.clone(),
+            path: handle.path,
+        };
+        let runtime = build_runtime(
+            session_state,
+            &session.id,
+            model.clone(),
+            system_prompt.clone(),
+            enable_tools,
+            true,
+            allowed_tools.clone(),
+            permission_mode,
+            None,
+        )?;
+        let cli = Self {
+            model,
+            allowed_tools,
+            permission_mode,
+            system_prompt,
+            runtime,
+            session,
+            prompt_history: Vec::new(),
+        };
+        cli.persist_session()?;
+        Ok(cli)
+    }
+
     fn startup_banner(&self) -> String {
         let cwd = env::current_dir().map_or_else(
             |_| "<unknown>".to_string(),
@@ -4063,6 +4226,15 @@ impl LiveCli {
             SlashCommand::Session { action, target } => {
                 self.handle_session_command(action.as_deref(), target.as_deref())?
             }
+            SlashCommand::Principal {
+                action,
+                target,
+                description,
+            } => self.handle_principal_command(
+                action.as_deref(),
+                target.as_deref(),
+                description.as_deref(),
+            )?,
             SlashCommand::Plugins { action, target } => {
                 self.handle_plugins_command(action.as_deref(), target.as_deref())?
             }
@@ -4618,6 +4790,176 @@ impl LiveCli {
         }
     }
 
+    fn handle_principal_command(
+        &mut self,
+        action: Option<&str>,
+        target: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        match action.unwrap_or("list") {
+            "list" => {
+                let cwd = env::current_dir()?;
+                let Some(environment) = detect_appfs_environment(&cwd) else {
+                    println!("AppFS principals\n  Detected          no");
+                    return Ok(false);
+                };
+                let principals = if environment.known_principals.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    environment
+                        .known_principals
+                        .iter()
+                        .map(|principal| {
+                            let name = principal.display_name.as_deref().unwrap_or("<unnamed>");
+                            principal.description.as_ref().map_or_else(
+                                || format!("{} ({name})", principal.principal_id),
+                                |description| {
+                                    format!("{} ({name}) - {description}", principal.principal_id)
+                                },
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                println!(
+                    "AppFS principals\n  Current principal {}\n  Registry          {}\n  Principals        {}",
+                    environment.principal_id,
+                    environment
+                        .control_dir
+                        .as_ref()
+                        .map(|path| path.join("principals.registry.json"))
+                        .map_or_else(|| "<unknown>".to_string(), |path| path.display().to_string()),
+                    principals
+                );
+                Ok(false)
+            }
+            "create" => {
+                let Some(principal_id) = target else {
+                    println!("Usage: /principal create <principal-id> [description]");
+                    return Ok(false);
+                };
+                let cwd = env::current_dir()?;
+                let outcome = create_appfs_principal(
+                    &cwd,
+                    AppfsPrincipalCreateRequest {
+                        principal_id: principal_id.to_string(),
+                        display_name: Some(principal_id.to_string()),
+                        description: description.map(ToOwned::to_owned),
+                        kind: Some("agent".to_string()),
+                    },
+                )
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+                let status = match outcome.status {
+                    AppfsPrincipalCreateStatus::Created => "created",
+                    AppfsPrincipalCreateStatus::Exists => "already exists",
+                    AppfsPrincipalCreateStatus::Submitted => {
+                        "submitted (registry update not visible yet)"
+                    }
+                };
+                let private_apps = if outcome.visible_private_apps.is_empty() {
+                    "<none visible yet>".to_string()
+                } else {
+                    outcome
+                        .visible_private_apps
+                        .iter()
+                        .map(|app| format!("{} [{}]", app.app_id, app.path))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                println!(
+                    "AppFS principal {status}\n  Principal id      {}\n  Action            {}\n  Registry          {}\n  Private apps      {}\n  Manual launch     $env:{}=\"{}\"; claw",
+                    outcome.principal_id,
+                    outcome.action_path.display(),
+                    outcome.registry_path.display(),
+                    private_apps,
+                    runtime::APPFS_PRINCIPAL_ID_ENV,
+                    outcome.principal_id
+                );
+                Ok(false)
+            }
+            "fork" => {
+                let Some(principal_id) = target else {
+                    println!("Usage: /principal fork <principal-id> [task]");
+                    return Ok(false);
+                };
+                let cwd = env::current_dir()?;
+                let Some(environment) = detect_appfs_environment(&cwd) else {
+                    println!("AppFS principal fork\n  Detected          no");
+                    return Ok(false);
+                };
+                if principal_id == environment.principal_id {
+                    println!(
+                        "AppFS principal fork\n  Result           skipped\n  Reason           target principal is already active\n  Use              /session fork [branch-name]"
+                    );
+                    return Ok(false);
+                }
+
+                let outcome = create_appfs_principal(
+                    &cwd,
+                    AppfsPrincipalCreateRequest {
+                        principal_id: principal_id.to_string(),
+                        display_name: Some(principal_id.to_string()),
+                        description: description.map(ToOwned::to_owned),
+                        kind: Some("agent".to_string()),
+                    },
+                )
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+                let principal_status = match outcome.status {
+                    AppfsPrincipalCreateStatus::Created => "created",
+                    AppfsPrincipalCreateStatus::Exists => "already exists",
+                    AppfsPrincipalCreateStatus::Submitted => {
+                        "submitted (registry update not visible yet)"
+                    }
+                };
+                let mut forked = fork_session_for_principal(
+                    self.runtime.session(),
+                    &environment.principal_id,
+                    &outcome.principal_id,
+                    description,
+                );
+                let parent_session_id = self.session.id.clone();
+                let branch_name = forked
+                    .fork
+                    .as_ref()
+                    .and_then(|fork| fork.branch_name.clone())
+                    .unwrap_or_else(|| format!("principal-{}", outcome.principal_id));
+                let handle = create_managed_session_handle(&forked.session_id)?;
+                let message_count = forked.messages.len();
+                forked = forked.with_persistence_path(handle.path.clone());
+                forked.save_to_path(&handle.path)?;
+                let private_apps = if outcome.visible_private_apps.is_empty() {
+                    "<none visible yet>".to_string()
+                } else {
+                    outcome
+                        .visible_private_apps
+                        .iter()
+                        .map(|app| format!("{} [{}]", app.app_id, app.path))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                println!(
+                    "AppFS principal fork\n  Principal         {} ({principal_status})\n  Parent principal  {}\n  Parent session    {}\n  Child session     {}\n  Branch            {}\n  File              {}\n  Messages          {}\n  Private apps      {}\n  Launch            {}",
+                    outcome.principal_id,
+                    environment.principal_id,
+                    parent_session_id,
+                    handle.id,
+                    branch_name,
+                    handle.path.display(),
+                    message_count,
+                    private_apps,
+                    format_principal_fork_launch_command(&outcome.principal_id, &handle.path),
+                );
+                Ok(false)
+            }
+            other => {
+                println!(
+                    "Unknown /principal action '{other}'. Use /principal list, /principal create <principal-id> [description], or /principal fork <principal-id> [task]."
+                );
+                Ok(false)
+            }
+        }
+    }
+
     fn handle_plugins_command(
         &mut self,
         action: Option<&str>,
@@ -4778,6 +5120,19 @@ fn create_managed_session_handle(
     let id = session_id.to_string();
     let path = sessions_dir()?.join(format!("{id}.{PRIMARY_SESSION_EXTENSION}"));
     Ok(SessionHandle { id, path })
+}
+
+fn resolve_session_path_or_reference(
+    reference: &Path,
+) -> Result<SessionHandle, Box<dyn std::error::Error>> {
+    if reference.exists() {
+        let session = Session::load_from_path(reference)?;
+        return Ok(SessionHandle {
+            id: session.session_id,
+            path: reference.to_path_buf(),
+        });
+    }
+    resolve_session_reference(&reference.display().to_string())
 }
 
 fn resolve_session_reference(reference: &str) -> Result<SessionHandle, Box<dyn std::error::Error>> {
@@ -5151,6 +5506,7 @@ fn status_json_value(
                     "mount_root": environment.mount_root,
                     "runtime_session_id": environment.runtime_session_id,
                     "attach_id": environment.attach_id,
+                    "principal_id": environment.principal_id,
                     "attach_role": environment.attach_role,
                     "multi_agent_mode": environment.multi_agent_mode,
                     "manifest_path": environment.manifest_path,
@@ -5164,6 +5520,7 @@ fn status_json_value(
                     "current_app_root": environment.current_app_root,
                     "current_app_events_path": environment.current_app_events_path,
                     "registered_apps": environment.registered_apps,
+                    "known_principals": environment.known_principals,
                     "warnings": environment.warnings,
                 })
             },
@@ -5337,8 +5694,8 @@ fn format_appfs_report(environment: Option<&runtime::AppfsEnvironment>) -> Strin
             .iter()
             .map(|app| {
                 app.active_scope.as_ref().map_or_else(
-                    || app.app_id.clone(),
-                    |scope| format!("{} (scope {scope})", app.app_id),
+                    || format!("{} [{}]", app.app_id, app.path),
+                    |scope| format!("{} [{}] (scope {scope})", app.app_id, app.path),
                 )
             })
             .collect::<Vec<_>>()
@@ -5358,6 +5715,7 @@ fn format_appfs_report(environment: Option<&runtime::AppfsEnvironment>) -> Strin
   Mount root        {}
   Runtime session   {}
   Attach id         {}
+  Principal id      {}
   Attach role       {}
   Multi-agent mode  {}
   Control plane     {}
@@ -5372,6 +5730,7 @@ fn format_appfs_report(environment: Option<&runtime::AppfsEnvironment>) -> Strin
             .as_deref()
             .unwrap_or("<unknown>"),
         environment.attach_id,
+        environment.principal_id,
         environment.attach_role.as_deref().unwrap_or("<none>"),
         environment.multi_agent_mode,
         environment
@@ -8315,7 +8674,7 @@ fn push_output_block(
     match block {
         OutputContentBlock::Text { text } => {
             if !text.is_empty() {
-                let rendered = TerminalRenderer::new().markdown_to_ansi(&text);
+                let rendered = TerminalRenderer::new().markdown_to_ansi_stream_chunk(&text);
                 write!(out, "{rendered}")
                     .and_then(|()| out.flush())
                     .map_err(|error| RuntimeError::new(error.to_string()))?;
@@ -8619,6 +8978,11 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         out,
         "      Inspect or maintain a saved session without entering the REPL"
     )?;
+    writeln!(out, "  claw --session SESSION.jsonl")?;
+    writeln!(
+        out,
+        "      Start the interactive REPL from an existing session file or id"
+    )?;
     writeln!(out, "  claw help")?;
     writeln!(out, "      Alias for --help")?;
     writeln!(out, "  claw version")?;
@@ -8711,6 +9075,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
+        "  Use --session SESSION.jsonl to continue a saved session in a new interactive process"
+    )?;
+    writeln!(
+        out,
         "  Use /session list in the REPL to browse managed sessions"
     )?;
     writeln!(out, "Examples:")?;
@@ -8725,6 +9093,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         "  claw --allowedTools read,glob \"summarize Cargo.toml\""
     )?;
     writeln!(out, "  claw --resume {LATEST_SESSION_REFERENCE}")?;
+    writeln!(out, "  claw --session {LATEST_SESSION_REFERENCE}")?;
     writeln!(
         out,
         "  claw --resume {LATEST_SESSION_REFERENCE} /status /diff /export notes.txt"
@@ -8765,20 +9134,22 @@ mod tests {
         build_runtime_plugin_state_with_loader, build_runtime_with_plugin_state,
         collect_session_prompt_history, create_managed_session_handle,
         delete_merged_local_branches_in, describe_tool_progress, filter_tool_specs,
-        format_bughunter_report, format_commit_preflight_report, format_commit_skipped_report,
-        format_compact_report, format_connected_line, format_cost_report, format_history_timestamp,
-        format_internal_prompt_progress_line, format_issue_report, format_model_report,
-        format_model_switch_report, format_permissions_report, format_permissions_switch_report,
-        format_pr_report, format_resume_report, format_status_report, format_tool_call_start,
-        format_tool_result, format_ultraplan_report, format_unknown_slash_command,
-        format_unknown_slash_command_message, format_user_visible_api_error, git_ref_exists_in,
-        merge_prompt_with_stdin, normalize_permission_mode, parse_args, parse_export_args,
-        parse_git_status_branch, parse_git_status_metadata_for, parse_git_workspace_summary,
-        parse_git_worktrees, parse_history_count, parse_hook_args, parse_recent_commits,
-        permission_policy, print_help_to, push_output_block, render_config_report,
-        render_diff_report, render_diff_report_for, render_hook_list_report_for,
-        render_memory_report, render_merged_runtime_config_json, render_prompt_history_report,
-        render_repl_help, render_resume_usage, render_session_markdown, resolve_model_alias,
+        fork_session_for_principal, format_bughunter_report, format_commit_preflight_report,
+        format_commit_skipped_report, format_compact_report, format_connected_line,
+        format_cost_report, format_history_timestamp, format_internal_prompt_progress_line,
+        format_issue_report, format_model_report, format_model_switch_report,
+        format_permissions_report, format_permissions_switch_report, format_pr_report,
+        format_principal_fork_launch_command, format_resume_report, format_status_report,
+        format_tool_call_start, format_tool_result, format_ultraplan_report,
+        format_unknown_slash_command, format_unknown_slash_command_message,
+        format_user_visible_api_error, git_ref_exists_in, merge_prompt_with_stdin,
+        normalize_permission_mode, parse_args, parse_export_args, parse_git_status_branch,
+        parse_git_status_metadata_for, parse_git_workspace_summary, parse_git_worktrees,
+        parse_history_count, parse_hook_args, parse_recent_commits, permission_policy,
+        print_help_to, push_output_block, render_config_report, render_diff_report,
+        render_diff_report_for, render_hook_list_report_for, render_memory_report,
+        render_merged_runtime_config_json, render_prompt_history_report, render_repl_help,
+        render_resume_usage, render_session_markdown, resolve_model_alias,
         resolve_model_alias_with_config, resolve_repl_model, resolve_session_reference,
         response_to_events, resume_supported_slash_commands, run_resume_command,
         run_resume_command_with_compactor, short_tool_id,
@@ -8795,8 +9166,9 @@ mod tests {
     };
     use runtime::{
         bash_shell_path, load_oauth_credentials, save_oauth_credentials, set_shell_if_windows,
-        AssistantEvent, ConfigLoader, ContentBlock, ConversationMessage, MessageRole, OAuthConfig,
-        PermissionMode, PermissionPromptDecision, PermissionRequest, Session, ToolExecutor,
+        AssistantEvent, ConfigLoader, ContentBlock, ConversationMessage, InvokedSkill, MessageRole,
+        OAuthConfig, PermissionMode, PermissionPromptDecision, PermissionRequest, Session,
+        ToolExecutor,
     };
     use serde_json::json;
     use std::collections::BTreeSet;
@@ -9191,6 +9563,7 @@ mod tests {
         assert_eq!(
             parse_args(&[]).expect("args should parse"),
             CliAction::Repl {
+                session_path: None,
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: None,
                 permission_mode: PermissionMode::DangerFullAccess,
@@ -9645,6 +10018,7 @@ mod tests {
         assert_eq!(
             parse_args(&args).expect("args should parse"),
             CliAction::Repl {
+                session_path: None,
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: None,
                 permission_mode: PermissionMode::ReadOnly,
@@ -9652,6 +10026,113 @@ mod tests {
                 reasoning_effort: None,
             }
         );
+    }
+
+    #[test]
+    fn parses_session_flag_for_interactive_repl() {
+        let _guard = env_lock();
+        std::env::remove_var("RUSTY_CLAUDE_PERMISSION_MODE");
+        let args = vec!["--session".to_string(), "session-child.jsonl".to_string()];
+        assert_eq!(
+            parse_args(&args).expect("args should parse"),
+            CliAction::Repl {
+                session_path: Some(PathBuf::from("session-child.jsonl")),
+                model: DEFAULT_MODEL.to_string(),
+                allowed_tools: None,
+                permission_mode: PermissionMode::DangerFullAccess,
+                base_commit: None,
+                reasoning_effort: None,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_session_flag_with_prompt_mode() {
+        let error = parse_args(&[
+            "--session".to_string(),
+            "session-child.jsonl".to_string(),
+            "-p".to_string(),
+            "hello".to_string(),
+        ])
+        .expect_err("session flag should be interactive-only");
+        assert!(error.contains("--session"));
+    }
+
+    #[test]
+    fn principal_fork_session_inherits_context_but_clears_appfs_runtime_state() {
+        let mut session = Session::new();
+        let parent_session_id = session.session_id.clone();
+        session
+            .push_message(ConversationMessage::user_text("讨论过的需求上下文"))
+            .expect("push source message");
+        session.invoked_skills.push(InvokedSkill {
+            skill: "appfs-aiim".to_string(),
+            resolved_name: Some("appfs-aiim".to_string()),
+            path: Some("generated://appfs-aiim".to_string()),
+            description: Some("AIIM".to_string()),
+            args: None,
+            prompt: "Base directory for this skill: C:\\mnt\\private\\default\\aiim".to_string(),
+        });
+        session.invoked_skills.push(InvokedSkill {
+            skill: "remember".to_string(),
+            resolved_name: Some("remember".to_string()),
+            path: Some("C:\\skills\\remember\\SKILL.md".to_string()),
+            description: Some("Memory skill".to_string()),
+            args: None,
+            prompt: "remember prompt".to_string(),
+        });
+        session
+            .appfs_event_cursors
+            .insert("app:tinode--default".to_string(), 7);
+        session
+            .appfs_event_cursors
+            .insert("platform".to_string(), 3);
+
+        let forked = fork_session_for_principal(
+            &session,
+            "default",
+            "code-implementer",
+            Some("负责实现代码"),
+        );
+
+        assert_ne!(forked.session_id, parent_session_id);
+        assert_eq!(
+            forked
+                .fork
+                .as_ref()
+                .map(|fork| fork.parent_session_id.as_str()),
+            Some(parent_session_id.as_str())
+        );
+        assert_eq!(
+            forked
+                .fork
+                .as_ref()
+                .and_then(|fork| fork.branch_name.as_deref()),
+            Some("principal-code-implementer")
+        );
+        assert!(forked
+            .messages
+            .iter()
+            .any(|message| matches!(&message.blocks[..], [ContentBlock::Text { text }] if text.contains("负责实现代码") && text.contains("code-implementer"))));
+        assert_eq!(forked.invoked_skills.len(), 1);
+        assert_eq!(forked.invoked_skills[0].skill, "remember");
+        assert_eq!(forked.appfs_event_cursors.get("platform"), Some(&3));
+        assert!(!forked
+            .appfs_event_cursors
+            .contains_key("app:tinode--default"));
+    }
+
+    #[test]
+    fn principal_fork_launch_command_sets_principal_and_session() {
+        let command = format_principal_fork_launch_command(
+            "code-implementer",
+            Path::new("C:\\tmp\\session-child.jsonl"),
+        );
+
+        assert!(command.contains("APPFS_PRINCIPAL_ID"));
+        assert!(command.contains("code-implementer"));
+        assert!(command.contains("--session"));
+        assert!(command.contains("session-child.jsonl"));
     }
 
     #[test]
@@ -9665,6 +10146,7 @@ mod tests {
         assert_eq!(
             parsed,
             CliAction::Repl {
+                session_path: None,
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: None,
                 permission_mode: PermissionMode::DangerFullAccess,
@@ -9716,6 +10198,7 @@ mod tests {
         assert_eq!(
             parse_args(&args).expect("args should parse"),
             CliAction::Repl {
+                session_path: None,
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: Some(
                     ["glob_search", "read_file", "write_file"]
@@ -10897,6 +11380,7 @@ mod tests {
                     mount_root: PathBuf::from("/mnt/appfs"),
                     runtime_session_id: Some("rt-shared-01".to_string()),
                     attach_id: "agent-planner".to_string(),
+                    principal_id: "default".to_string(),
                     attach_role: Some("planner".to_string()),
                     multi_agent_mode: runtime::APPFS_MULTI_AGENT_MODE_SHARED.to_string(),
                     manifest_path: Some(PathBuf::from("/mnt/appfs/.well-known/appfs/runtime.json")),
@@ -10917,14 +11401,32 @@ mod tests {
                     )),
                     registered_apps: vec![
                         runtime::AppfsRegisteredApp {
+                            instance_id: "aiim".to_string(),
                             app_id: "aiim".to_string(),
+                            visibility: runtime::AppfsRegisteredAppVisibility::Public,
+                            parent_app_id: None,
+                            principal_id: None,
+                            profile_id: None,
+                            path: "aiim".to_string(),
                             active_scope: Some("chat-long".to_string()),
                         },
                         runtime::AppfsRegisteredApp {
+                            instance_id: "notion".to_string(),
                             app_id: "notion".to_string(),
+                            visibility: runtime::AppfsRegisteredAppVisibility::Public,
+                            parent_app_id: None,
+                            principal_id: None,
+                            profile_id: None,
+                            path: "notion".to_string(),
                             active_scope: None,
                         },
                     ],
+                    known_principals: vec![runtime::AppfsPrincipalSummary {
+                        principal_id: "default".to_string(),
+                        display_name: Some("Default agent".to_string()),
+                        description: Some("The default project agent.".to_string()),
+                        kind: Some("agent".to_string()),
+                    }],
                     warnings: Vec::new(),
                 }),
             },
@@ -10952,6 +11454,7 @@ mod tests {
         assert!(status.contains("Attach source     manifest"));
         assert!(status.contains("Runtime session   rt-shared-01"));
         assert!(status.contains("Attach id         agent-planner"));
+        assert!(status.contains("Principal id      default"));
         assert!(status.contains("Attach role       planner"));
         assert!(status.contains("Multi-agent mode  shared_mount_distinct_attach"));
         assert!(status.contains("Suggested flow   /status → /diff → /commit"));
@@ -10994,6 +11497,7 @@ mod tests {
                     mount_root: PathBuf::from("/mnt/appfs"),
                     runtime_session_id: Some("rt-shared-09".to_string()),
                     attach_id: "agent-reviewer".to_string(),
+                    principal_id: "incident-reporter".to_string(),
                     attach_role: Some("reviewer".to_string()),
                     multi_agent_mode: runtime::APPFS_MULTI_AGENT_MODE_SHARED.to_string(),
                     manifest_path: Some(PathBuf::from("/mnt/appfs/.well-known/appfs/runtime.json")),
@@ -11013,8 +11517,20 @@ mod tests {
                         "/mnt/appfs/aiim/_stream/events.evt.jsonl",
                     )),
                     registered_apps: vec![runtime::AppfsRegisteredApp {
+                        instance_id: "aiim".to_string(),
                         app_id: "aiim".to_string(),
+                        visibility: runtime::AppfsRegisteredAppVisibility::Public,
+                        parent_app_id: None,
+                        principal_id: None,
+                        profile_id: None,
+                        path: "aiim".to_string(),
                         active_scope: Some("chat-long".to_string()),
+                    }],
+                    known_principals: vec![runtime::AppfsPrincipalSummary {
+                        principal_id: "incident-reporter".to_string(),
+                        display_name: Some("Incident reporter".to_string()),
+                        description: None,
+                        kind: Some("agent".to_string()),
                     }],
                     warnings: vec!["env mount root mismatch".to_string()],
                 }),
@@ -11029,6 +11545,7 @@ mod tests {
             json!("rt-shared-09")
         );
         assert_eq!(payload["appfs"]["attach_id"], json!("agent-reviewer"));
+        assert_eq!(payload["appfs"]["principal_id"], json!("incident-reporter"));
         assert_eq!(payload["appfs"]["attach_role"], json!("reviewer"));
         assert_eq!(
             payload["appfs"]["multi_agent_mode"],
@@ -11642,8 +12159,11 @@ UU conflicted.rs",
         assert!(help.contains("claw hook list"));
         assert!(help.contains("claw branch delete"));
         assert!(help.contains("claw --resume [SESSION.jsonl|session-id|latest]"));
+        assert!(help.contains("claw --session SESSION.jsonl"));
         assert!(help.contains("Use `latest` with --resume, /resume, or /session switch"));
+        assert!(help.contains("Use --session SESSION.jsonl"));
         assert!(help.contains("claw --resume latest"));
+        assert!(help.contains("claw --session latest"));
         assert!(help.contains("claw --resume latest /status /diff /export notes.txt"));
     }
 

--- a/rust/crates/rusty-claude-cli/src/render.rs
+++ b/rust/crates/rusty-claude-cli/src/render.rs
@@ -275,6 +275,30 @@ impl TerminalRenderer {
         self.render_markdown(markdown)
     }
 
+    #[must_use]
+    pub fn markdown_to_ansi_stream_chunk(&self, markdown: &str) -> String {
+        let mut rendered = self.markdown_to_ansi(markdown);
+        if rendered.is_empty() {
+            return rendered;
+        }
+
+        // `render_markdown` trims trailing whitespace so normal rendering does
+        // not leave dangling blank lines. Streaming output is different: every
+        // flushed chunk must leave the cursor on the next line, otherwise the
+        // next chunk or the final spinner can overwrite the current line.
+        let desired_newlines = markdown
+            .chars()
+            .rev()
+            .take_while(|ch| *ch == '\n')
+            .count()
+            .clamp(1, 2);
+        let current_newlines = rendered.chars().rev().take_while(|ch| *ch == '\n').count();
+        for _ in current_newlines..desired_newlines {
+            rendered.push('\n');
+        }
+        rendered
+    }
+
     #[allow(clippy::too_many_lines)]
     fn render_event(
         &self,
@@ -588,11 +612,8 @@ impl TerminalRenderer {
     }
 
     pub fn stream_markdown(&self, markdown: &str, out: &mut impl Write) -> io::Result<()> {
-        let rendered_markdown = self.markdown_to_ansi(markdown);
+        let rendered_markdown = self.markdown_to_ansi_stream_chunk(markdown);
         write!(out, "{rendered_markdown}")?;
-        if !rendered_markdown.ends_with('\n') {
-            writeln!(out)?;
-        }
         out.flush()
     }
 }
@@ -609,7 +630,7 @@ impl MarkdownStreamState {
         let split = find_stream_safe_boundary(&self.pending)?;
         let ready = self.pending[..split].to_string();
         self.pending.drain(..split);
-        Some(renderer.markdown_to_ansi(&ready))
+        Some(renderer.markdown_to_ansi_stream_chunk(&ready))
     }
 
     #[must_use]
@@ -619,7 +640,7 @@ impl MarkdownStreamState {
             None
         } else {
             let pending = std::mem::take(&mut self.pending);
-            Some(renderer.markdown_to_ansi(&pending))
+            Some(renderer.markdown_to_ansi_stream_chunk(&pending))
         }
     }
 }
@@ -991,6 +1012,54 @@ mod tests {
             .push(&renderer, "```\n")
             .expect("closed code fence flushes");
         assert!(strip_ansi(&code).contains("fn main()"));
+    }
+
+    #[test]
+    fn streaming_state_keeps_chunk_boundaries_visible() {
+        let renderer = TerminalRenderer::new();
+        let mut state = MarkdownStreamState::default();
+
+        let first = state
+            .push(&renderer, "第一段\n\n")
+            .expect("first paragraph boundary flushes");
+        let second = state
+            .push(&renderer, "第二段\n\n")
+            .expect("second paragraph boundary flushes");
+        let plain_text = strip_ansi(&format!("{first}{second}"));
+
+        assert!(
+            plain_text.contains("第一段\n\n第二段"),
+            "streamed markdown chunks must not collapse paragraph boundaries: {plain_text:?}"
+        );
+    }
+
+    #[test]
+    fn streaming_state_flush_terminates_final_line() {
+        let renderer = TerminalRenderer::new();
+        let mut state = MarkdownStreamState::default();
+
+        assert_eq!(state.push(&renderer, "最后一行没有换行"), None);
+        let rendered = state.flush(&renderer).expect("final pending text flushes");
+        let plain_text = strip_ansi(&rendered);
+
+        assert!(
+            plain_text.ends_with('\n'),
+            "final streamed text must leave the terminal cursor on a fresh line: {plain_text:?}"
+        );
+    }
+
+    #[test]
+    fn streaming_markdown_preserves_list_intro_break() {
+        let renderer = TerminalRenderer::new();
+        let rendered =
+            renderer.markdown_to_ansi_stream_chunk("有 3 条未读消息：\n1. 第一条\n2. 第二条");
+        let plain_text = strip_ansi(&rendered);
+
+        assert!(
+            plain_text.contains("有 3 条未读消息：\n\n1. 第一条"),
+            "list intro newline was not preserved: {plain_text:?}"
+        );
+        assert!(plain_text.ends_with('\n'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- backfill AppFS principal-aware environment detection, private app filtering, generated skill/event handling, and prompt/status context from appfs-platform
- add `/principal create` and `/principal fork` session support for principal-scoped multi-agent workflows
- include the streaming markdown rendering fix so chunk boundaries and final lines render cleanly

## Validation
- `cargo fmt --manifest-path rust\Cargo.toml --all -- --check`
- `cargo test --manifest-path rust\Cargo.toml -p runtime appfs --target-dir C:\tmp\appfs-agent-backfill-target`
- `cargo test --manifest-path rust\Cargo.toml -p rusty-claude-cli principal --target-dir C:\tmp\appfs-agent-backfill-target`
- `cargo test --manifest-path rust\Cargo.toml -p rusty-claude-cli streaming --target-dir C:\tmp\appfs-agent-backfill-target`